### PR TITLE
feat(color-theory): add app theme recommendation contracts

### DIFF
--- a/.changeset/app-theme-recommendations.md
+++ b/.changeset/app-theme-recommendations.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Add app category theme recommendation contracts and a partial category recommendation map for theme tooling.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
+}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ Shared public contracts for Ankhorage packages and standalone provider packages.
 ```ts
 import type { AppManifest } from '@ankhorage/contracts';
 import type { AuthAdapter } from '@ankhorage/contracts/auth';
-import type { AppMood, ColorHarmony, ColorTone } from '@ankhorage/contracts/color-theory';
+import type {
+  AppCategoryThemeRecommendation,
+  AppMood,
+  ColorHarmony,
+  ColorTone,
+} from '@ankhorage/contracts/color-theory';
+import { APP_CATEGORY_THEME_RECOMMENDATIONS } from '@ankhorage/contracts/color-theory';
 import type { DbAdapter } from '@ankhorage/contracts/db';
 ```
 
@@ -33,6 +39,17 @@ import type { DbAdapter } from '@ankhorage/contracts/db';
 `playful`.
 
 `ColorHarmony` describes hue relationships.
+
+Category-aware theme recommendations can suggest an app mood, color tone,
+harmony, and optional primary hue without moving UI color-generation logic into
+Contracts:
+
+```ts
+const financeThemeRecommendation = APP_CATEGORY_THEME_RECOMMENDATIONS.finance_money;
+```
+
+These recommendation contracts are serializable handoff data for tooling. OKLCH,
+chroma, and semantic-token generation stay in UI/theme packages.
 
 Provider packages can implement the shared contracts without importing runtime,
 CLI, ZORA, Expo Router, or app-generation logic.

--- a/src/color-theory.ts
+++ b/src/color-theory.ts
@@ -1,3 +1,5 @@
+import type { AppCategory } from './types';
+
 export const COLOR_HARMONIES = [
   'monochromatic',
   'analogous',
@@ -50,3 +52,45 @@ export interface ColorThemeRecommendation {
   suggestedHarmony: ColorHarmony;
   suggestedPrimaryHueDegrees?: number;
 }
+
+export interface AppCategoryThemeRecommendation extends ColorThemeRecommendation {
+  appCategory: AppCategory;
+}
+
+export const APP_CATEGORY_THEME_RECOMMENDATIONS = {
+  finance_money: {
+    appCategory: 'finance_money',
+    appMood: 'trustworthy',
+    suggestedColorTone: 'mineral',
+    suggestedHarmony: 'analogous',
+    suggestedPrimaryHueDegrees: 195,
+  },
+  health_fitness: {
+    appCategory: 'health_fitness',
+    appMood: 'calm',
+    suggestedColorTone: 'pastel',
+    suggestedHarmony: 'analogous',
+    suggestedPrimaryHueDegrees: 155,
+  },
+  developer_tools: {
+    appCategory: 'developer_tools',
+    appMood: 'focused',
+    suggestedColorTone: 'obsidian',
+    suggestedHarmony: 'analogous',
+    suggestedPrimaryHueDegrees: 220,
+  },
+  graphics_design: {
+    appCategory: 'graphics_design',
+    appMood: 'creative',
+    suggestedColorTone: 'vaporwave',
+    suggestedHarmony: 'splitComplementary',
+    suggestedPrimaryHueDegrees: 305,
+  },
+  social_community: {
+    appCategory: 'social_community',
+    appMood: 'friendly',
+    suggestedColorTone: 'jewel',
+    suggestedHarmony: 'triadic',
+    suggestedPrimaryHueDegrees: 265,
+  },
+} as const satisfies Partial<Record<AppCategory, AppCategoryThemeRecommendation>>;

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -92,10 +92,6 @@ describe('contracts', () => {
 
   it('keeps app category theme recommendation hues in range', () => {
     for (const recommendation of Object.values(APP_CATEGORY_THEME_RECOMMENDATIONS)) {
-      if (recommendation.suggestedPrimaryHueDegrees === undefined) {
-        continue;
-      }
-
       expect(Number.isFinite(recommendation.suggestedPrimaryHueDegrees)).toBe(true);
       expect(recommendation.suggestedPrimaryHueDegrees).toBeGreaterThanOrEqual(0);
       expect(recommendation.suggestedPrimaryHueDegrees).toBeLessThan(360);

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'bun:test';
 
 import {
   APP_CATEGORIES,
+  APP_CATEGORY_THEME_RECOMMENDATIONS,
+  APP_MOODS,
   type AppCategory,
   AUTH_PROVIDERS,
   AUTH_SIGN_IN_IDENTIFIERS,
@@ -9,6 +11,8 @@ import {
   type AuthAdapter,
   type AuthFlowConfig,
   type AuthSpec,
+  COLOR_HARMONIES,
+  COLOR_TONES,
   type DbAdapter,
   DEPLOYMENT_TARGETS,
   NAVIGATOR_TYPES,
@@ -71,6 +75,31 @@ describe('contracts', () => {
 
     expect(theme.light.primaryColor).toBe('#3366ff');
     expect(theme.dark.colorTone).toBe('neutral');
+  });
+
+  it('exports app category theme recommendations with valid serialized values', () => {
+    const recommendations = Object.values(APP_CATEGORY_THEME_RECOMMENDATIONS);
+
+    expect(recommendations.length).toBeGreaterThan(0);
+
+    for (const recommendation of recommendations) {
+      expect(APP_CATEGORIES).toContain(recommendation.appCategory);
+      expect(APP_MOODS).toContain(recommendation.appMood);
+      expect(COLOR_TONES).toContain(recommendation.suggestedColorTone);
+      expect(COLOR_HARMONIES).toContain(recommendation.suggestedHarmony);
+    }
+  });
+
+  it('keeps app category theme recommendation hues in range', () => {
+    for (const recommendation of Object.values(APP_CATEGORY_THEME_RECOMMENDATIONS)) {
+      if (recommendation.suggestedPrimaryHueDegrees === undefined) {
+        continue;
+      }
+
+      expect(Number.isFinite(recommendation.suggestedPrimaryHueDegrees)).toBe(true);
+      expect(recommendation.suggestedPrimaryHueDegrees).toBeGreaterThanOrEqual(0);
+      expect(recommendation.suggestedPrimaryHueDegrees).toBeLessThan(360);
+    }
   });
 
   it('accepts canonical auth flow config without legacy route fields', () => {

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -176,20 +176,20 @@ describe('contracts', () => {
     const dbAdapter: DbAdapter = {
       async select() {
         await new Promise((resolve) => setTimeout(resolve, 1));
-        return { ok: true, data: [{ id: 'row-1' }] };
+        return { ok: true, data: [] };
       },
       async findById() {
         await new Promise((resolve) => setTimeout(resolve, 1));
-        return { ok: true, data: { id: 'row-1' } };
+        return { ok: true, data: null };
       },
       async insert(input) {
         const values = Array.isArray(input.values) ? input.values : [input.values];
         await new Promise((resolve) => setTimeout(resolve, 1));
         return { ok: true, data: values };
       },
-      async update(input) {
+      async update() {
         await new Promise((resolve) => setTimeout(resolve, 1));
-        return { ok: true, data: [input.values] };
+        return { ok: true, data: [] };
       },
       async delete() {
         await new Promise((resolve) => setTimeout(resolve, 1));


### PR DESCRIPTION
## Summary

Closes #8.

Adds a serializable app-category theme recommendation layer for shared tooling:

- adds `AppCategoryThemeRecommendation`
- adds `APP_CATEGORY_THEME_RECOMMENDATIONS` as a partial, strongly typed category map
- keeps recommendation data limited to `AppCategory`, `AppMood`, `ColorTone`, `ColorHarmony`, and optional primary hue degrees
- documents the new recommendation contracts in the README
- adds tests for valid serialized values and hue ranges
- adds a minor changeset for `@ankhorage/contracts`

## Scope boundaries

This intentionally does not add OKLCH/chroma recipes, semantic tokens, ZORA-specific types, dependencies, legacy `ColorMood`, or any `systemTone`/`colorMood` vocabulary.

## Verification

Not run locally from this environment. GitHub CI should run on the PR.