### PR TITLE
feat(storage): add storage and image asset contracts

### DIFF
--- a/.changeset/fresh-impalas-leave.md
+++ b/.changeset/fresh-impalas-leave.md
@@ -1,0 +1,9 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Add provider-neutral storage and image asset contracts.
+
+This introduces serializable storage asset references, a `StorageAdapter` contract for upload, remove, and public URL workflows, and manifest-safe `ImageAssetSource` variants for storage-backed and URL-backed images.
+
+The storage upload boundary uses `Uint8Array` only, avoids DOM-specific `File`/`Blob` types, and keeps storage identity provider-neutral through `storageId`, `bucket`, and `path`.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Shared public contracts for Ankhorage packages and standalone provider packages.
 import type { AppManifest } from '@ankhorage/contracts';
 import type { AuthAdapter } from '@ankhorage/contracts/auth';
 import type { DbAdapter } from '@ankhorage/contracts/db';
+import type { StorageAdapter } from '@ankhorage/contracts/storage';
 ```
 
 Contracts keeps theme configuration serializable. Color validation, harmony,

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@ankhorage/contracts",
       "dependencies": {
-        "@ankhorage/color-theory": "^0.0.3",
+        "@ankhorage/color-theory": "^0.0.4",
       },
       "devDependencies": {
         "@ankhorage/devtools": "^1.0.0",
@@ -17,7 +17,7 @@
     },
   },
   "packages": {
-    "@ankhorage/color-theory": ["@ankhorage/color-theory@0.0.3", "", { "dependencies": { "culori": "^4.0.2" } }, "sha512-obKcFrEbnhbsrYEOSCDnH4wSEobB+wTIxaUEXDOlq69Oirwzk7Z2Rsu0drmROCnY14ITpCWvE9BEdeCezzLVOg=="],
+    "@ankhorage/color-theory": ["@ankhorage/color-theory@0.0.4", "", { "dependencies": { "culori": "^4.0.2" } }, "sha512-24/RKqJxQAqWFbqqcWfKzqCCzUcKVAQ+MHWkwVfwrFbxHrhKXV7YV2//svACDbpCYizvvT6OAqOPxbEA3SFmuw=="],
 
     "@ankhorage/devtools": ["@ankhorage/devtools@1.0.1", "", { "dependencies": { "@eslint/js": "^10.0.1", "eslint": "^10.2.0", "eslint-config-prettier": "^10.1.8", "eslint-plugin-import": "^2.32.0", "eslint-plugin-prettier": "^5.5.5", "eslint-plugin-simple-import-sort": "^12.1.1", "eslint-plugin-unused-imports": "^4.4.1", "prettier": "^3.8.1", "typescript-eslint": "^8.24.0" } }, "sha512-Qpr+TL7biJnUwIYvZtuvG/oXq43+UyBoM+Q61pVDCmTA13Uu/a/A669U9fqJprFAicJfBDWBi/NJ7WvVH+ud/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "main": "./dist/index.js",
   "dependencies": {
-    "@ankhorage/color-theory": "^0.0.3"
+    "@ankhorage/color-theory": "^0.0.4"
   },
   "devDependencies": {
     "@ankhorage/devtools": "^1.0.0",
@@ -24,6 +24,10 @@
     "./db": {
       "types": "./dist/db.d.ts",
       "default": "./dist/db.js"
+    },
+    "./storage": {
+      "types": "./dist/storage.d.ts",
+      "default": "./dist/storage.js"
     }
   },
   "description": "Serializable app, action, and theme config contracts for Ankhorage.",

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -13,7 +13,11 @@ import {
   type AuthFlowConfig,
   type AuthSpec,
   DEPLOYMENT_TARGETS,
+  type ImageAssetSource,
   NAVIGATOR_TYPES,
+  type StoragePublicUrlResult,
+  type StorageResult,
+  type StorageUploadResult,
   type ThemeConfig,
   type ThemeModeConfig,
 } from './index';
@@ -163,5 +167,55 @@ describe('contracts', () => {
     expect(AUTH_SIGN_UP_POLICIES).toEqual(['autoSignIn', 'requireVerification']);
     expect(auth.flow?.signInRoute).toBe('/sign-in');
     expect(auth.signUp?.signUpPolicy).toBe('requireVerification');
+  });
+
+  it('requires data for successful non-void storage results', () => {
+    const uploaded: StorageResult<StorageUploadResult> = {
+      ok: true,
+      data: {
+        asset: {
+          storageId: 'default',
+          bucket: 'app-assets',
+          path: 'images/logo.png',
+        },
+      },
+    };
+
+    expect(uploaded.ok).toBe(true);
+    expect(uploaded.data.asset.bucket).toBe('app-assets');
+    expect(uploaded.data.asset.path).toBe('images/logo.png');
+  });
+
+  it('accepts a public URL result for storage assets', () => {
+    const resolved: StorageResult<StoragePublicUrlResult> = {
+      ok: true,
+      data: {
+        publicUrl: 'https://cdn.example.com/app-assets/images/logo.png',
+      },
+    };
+
+    expect(resolved.ok).toBe(true);
+    expect(resolved.data.publicUrl).toContain('https://');
+  });
+
+  it('serializes image asset sources without provider-specific runtime values', () => {
+    const source: ImageAssetSource = {
+      kind: 'storage',
+      storageId: 'default',
+      bucket: 'app-assets',
+      path: 'images/logo.png',
+      publicUrl: 'https://cdn.example.com/app-assets/images/logo.png',
+      alt: 'Logo',
+      width: 1200,
+      height: 630,
+      contentType: 'image/png',
+      metadata: {
+        fileName: 'logo.png',
+        sizeBytes: 123456,
+        createdAt: '2026-05-10T00:00:00.000Z',
+      },
+    };
+
+    expect(JSON.parse(JSON.stringify(source))).toEqual(source);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './db';
+export * from './storage';
 export * from './types';

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,91 @@
+export interface StorageAdapterError {
+  code: string;
+  message: string;
+  cause?: unknown;
+}
+
+export type StorageOkResult<TData> = [TData] extends [void]
+  ? { ok: true; data?: undefined }
+  : { ok: true; data: TData };
+
+export type StorageResult<TData = void> =
+  | StorageOkResult<TData>
+  | {
+      ok: false;
+      error: StorageAdapterError;
+    };
+
+export interface StorageAssetReference {
+  storageId?: string;
+  bucket: string;
+  path: string;
+  publicUrl?: string;
+}
+
+export interface StorageUploadInput {
+  storageId?: string;
+  bucket: string;
+  path: string;
+  body: Uint8Array;
+  contentType?: string;
+  cacheControl?: string;
+  upsert?: boolean;
+}
+
+export interface StorageUploadResult {
+  asset: StorageAssetReference;
+}
+
+export interface StorageRemoveInput {
+  storageId?: string;
+  bucket: string;
+  path: string;
+}
+
+export interface StoragePublicUrlInput {
+  storageId?: string;
+  bucket: string;
+  path: string;
+}
+
+export interface StoragePublicUrlResult {
+  publicUrl: string;
+}
+
+export interface ImageMetadata {
+  fileName?: string;
+  sizeBytes?: number;
+  createdAt?: string;
+}
+
+export interface StorageImageAssetSource {
+  kind: 'storage';
+  storageId?: string;
+  bucket: string;
+  path: string;
+  publicUrl?: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+  contentType?: string;
+  metadata?: ImageMetadata;
+}
+
+export interface UrlImageAssetSource {
+  kind: 'url';
+  url: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+  contentType?: string;
+  metadata?: ImageMetadata;
+}
+
+export type ImageAssetSource = StorageImageAssetSource | UrlImageAssetSource;
+
+export interface StorageAdapter {
+  upload(input: StorageUploadInput): Promise<StorageResult<StorageUploadResult>>;
+  remove(input: StorageRemoveInput): Promise<StorageResult>;
+  publicUrl(input: StoragePublicUrlInput): Promise<StorageResult<StoragePublicUrlResult>>;
+  getImageMetadata?(input: StorageAssetReference): Promise<StorageResult<ImageMetadata>>;
+}


### PR DESCRIPTION
## Summary

- Adds provider-neutral storage contracts for upload, remove, and public URL workflows.
- Adds manifest-safe image asset source types for storage-backed and URL-backed images.
- Exports the new storage module from the package entrypoint and `@ankhorage/contracts/storage` subpath.
- Documents the storage import path in the README.
- Adds contract tests for storage result shapes, public URL results, and JSON-safe image asset serialization.

## Boundary decisions

- Upload bodies use `Uint8Array` only; callers normalize platform-specific inputs before crossing the adapter boundary.
- No DOM-specific `File`/`Blob` types are added to contracts.
- No `dataUrl` image asset variant is persisted in manifests.
- `publicUrl` is public-only in v1; signed/expiring URL semantics are intentionally left for a future contract.
- Storage identity is `storageId? + bucket + path`; `publicUrl` is optional cache/convenience only.

## Verification

- CI: passing
- Expected local verification: `bun run build`, `bun run lint:fix`, `bun run test`
