### PR TITLE
01 Add manifest event binding contracts to UiNode

### DIFF
--- a/.changeset/manifest-event-bindings.md
+++ b/.changeset/manifest-event-bindings.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": minor
+---
+
+Add manifest node event bindings so `UiNode` can declare provider-neutral event-to-action mappings such as `submit` actions for email and database persistence.

--- a/.changeset/manifest-event-bindings.md
+++ b/.changeset/manifest-event-bindings.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": minor
+'@ankhorage/contracts': minor
 ---
 
 Add manifest node event bindings so `UiNode` can declare provider-neutral event-to-action mappings such as `submit` actions for email and database persistence.

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -5,8 +5,8 @@ import { COLOR_HARMONIES } from '@ankhorage/color-theory';
 import { describe, expect, it } from 'bun:test';
 
 import {
-  APP_CATEGORIES,
   type ActionBinding,
+  APP_CATEGORIES,
   type AppCategory,
   AUTH_PROVIDERS,
   AUTH_SIGN_IN_IDENTIFIERS,
@@ -254,10 +254,7 @@ describe('contracts', () => {
     };
 
     expect(JSON.parse(JSON.stringify(node))).toEqual(node);
-    expect(node.events?.submit?.map((action) => action.type)).toEqual([
-      'email.send',
-      'db.persist',
-    ]);
+    expect(node.events?.submit?.map((action) => action.type)).toEqual(['email.send', 'db.persist']);
   });
 
   it('accepts conditional node event bindings', () => {

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'bun:test';
 
 import {
   APP_CATEGORIES,
+  type ActionBinding,
   type AppCategory,
   AUTH_PROVIDERS,
   AUTH_SIGN_IN_IDENTIFIERS,
@@ -24,6 +25,7 @@ import {
   type StorageUploadResult,
   type ThemeConfig,
   type ThemeModeConfig,
+  type UiNode,
 } from './index';
 
 async function collectTypeScriptFiles(directory: string): Promise<string[]> {
@@ -221,6 +223,58 @@ describe('contracts', () => {
     };
 
     expect(JSON.parse(JSON.stringify(source))).toEqual(source);
+  });
+
+  it('serializes node event bindings for submit actions', () => {
+    const node: UiNode = {
+      id: 'contact-form',
+      type: 'Form',
+      props: {
+        title: 'Contact us',
+      },
+      events: {
+        submit: [
+          {
+            type: 'email.send',
+            payload: {
+              to: 'info@example.com',
+              subject: 'New contact message',
+              bodyFrom: 'payload.values.message',
+            },
+          },
+          {
+            type: 'db.persist',
+            payload: {
+              collection: 'contact_messages',
+              mode: 'columns',
+            },
+          },
+        ],
+      },
+    };
+
+    expect(JSON.parse(JSON.stringify(node))).toEqual(node);
+    expect(node.events?.submit?.map((action) => action.type)).toEqual([
+      'email.send',
+      'db.persist',
+    ]);
+  });
+
+  it('accepts conditional node event bindings', () => {
+    const binding: ActionBinding = {
+      type: 'db.persist',
+      payload: {
+        collection: 'contact_messages',
+      },
+      when: {
+        source: 'event',
+        path: 'payload.values.email',
+        operator: 'exists',
+      },
+    };
+
+    expect(binding.when?.operator).toBe('exists');
+    expect(binding.payload?.collection).toBe('contact_messages');
   });
 
   it('accepts a provider-neutral CRUD database adapter', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,35 @@ export type Action =
   | SetLanguageAction
   | ToggleDarkModeAction;
 
+export type ManifestValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly ManifestValue[]
+  | { readonly [key: string]: ManifestValue };
+
+export type ActionBindingPayload = Record<string, ManifestValue>;
+
+export type ActionConditionSource = 'context' | 'event' | 'state';
+
+export type ActionConditionOperator = 'eq' | 'exists' | 'neq' | 'notExists';
+
+export interface ActionCondition {
+  readonly source: ActionConditionSource;
+  readonly path: string;
+  readonly operator: ActionConditionOperator;
+  readonly value?: ManifestValue;
+}
+
+export interface ActionBinding {
+  readonly type: string;
+  readonly payload?: ActionBindingPayload;
+  readonly when?: ActionCondition;
+}
+
+export type UiNodeEventBindings = Record<string, readonly ActionBinding[]>;
+
 export const NAVIGATOR_TYPES = ['stack', 'tabs', 'drawer'] as const;
 export type NavigatorType = (typeof NAVIGATOR_TYPES)[number];
 
@@ -167,6 +196,7 @@ export interface UiNode {
   props?: Record<string, unknown>;
   children?: UiNode[];
   style?: Record<string, number | string>;
+  events?: UiNodeEventBindings;
 }
 
 export interface ScreenSpec {


### PR DESCRIPTION
## Summary

- adds serializable manifest event binding types
- adds `UiNode.events` for node-local event-to-action mappings
- keeps bindings provider-neutral and generic for issue 01 scope
- adds tests for `submit -> email.send` and `submit -> db.persist` event bindings
- adds a changeset

Closes #31.

## Notes

This intentionally does not add the richer typed action/command model yet; that remains scoped to issue #33.

## Verification

Please run locally:

```bash
bun run build
bun run lint:fix
bun run test
```

I could not run local verification from this environment.