### PR TITLE
02 Add normalized component event DTO contracts

### DIFF
--- a/.changeset/component-event-dtos.md
+++ b/.changeset/component-event-dtos.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": minor
+'@ankhorage/contracts': minor
 ---
 
 Add normalized component event DTO contracts for stable component-emitted event envelopes, including form submit, button press, and collection item press events.

--- a/.changeset/component-event-dtos.md
+++ b/.changeset/component-event-dtos.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": minor
+---
+
+Add normalized component event DTO contracts for stable component-emitted event envelopes, including form submit, button press, and collection item press events.

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -13,11 +13,16 @@ import {
   AUTH_SIGN_UP_POLICIES,
   type AuthFlowConfig,
   type AuthSpec,
+  type ButtonPressEventDto,
+  type CollectionItemPressEventDto,
+  type ComponentEventDto,
+  type ComponentEventDtoKind,
   type DbAdapter,
   type DbAdminAdapter,
   type DbChangeEvent,
   type DbRealtimeAdapter,
   DEPLOYMENT_TARGETS,
+  type FormSubmitEventDto,
   type ImageAssetSource,
   NAVIGATOR_TYPES,
   type StoragePublicUrlResult,
@@ -272,6 +277,65 @@ describe('contracts', () => {
 
     expect(binding.when?.operator).toBe('exists');
     expect(binding.payload?.collection).toBe('contact_messages');
+  });
+
+  it('serializes normalized form submit event DTOs', () => {
+    const event: FormSubmitEventDto = {
+      type: 'form.submit',
+      sourceNodeId: 'contact-form',
+      payload: {
+        values: {
+          firstname: 'Fabio',
+          message: 'This is my contact message',
+          newsletter: true,
+        },
+      },
+    };
+
+    expect(JSON.parse(JSON.stringify(event))).toEqual(event);
+    expect(event.payload.values.message).toBe('This is my contact message');
+  });
+
+  it('serializes normalized button press event DTOs', () => {
+    const event: ButtonPressEventDto = {
+      type: 'button.press',
+      sourceNodeId: 'submit-button',
+      payload: {},
+    };
+
+    expect(JSON.parse(JSON.stringify(event))).toEqual(event);
+    expect(event.type).toBe('button.press');
+  });
+
+  it('serializes normalized collection item press event DTOs', () => {
+    const event: CollectionItemPressEventDto = {
+      type: 'collection.itemPress',
+      sourceNodeId: 'posts-list',
+      payload: {
+        itemId: 'post-1',
+        item: {
+          id: 'post-1',
+          title: 'Hello',
+        },
+      },
+    };
+
+    expect(JSON.parse(JSON.stringify(event))).toEqual(event);
+    expect(event.payload.item.title).toBe('Hello');
+  });
+
+  it('accepts custom component event DTOs through the same envelope', () => {
+    const event: ComponentEventDto<'media.play', { readonly mediaId: string }> = {
+      type: 'media.play',
+      sourceNodeId: 'hero-video',
+      payload: {
+        mediaId: 'video-1',
+      },
+    };
+    const knownEventType: ComponentEventDtoKind = 'form.submit';
+
+    expect(event.payload.mediaId).toBe('video-1');
+    expect(knownEventType).toBe('form.submit');
   });
 
   it('accepts a provider-neutral CRUD database adapter', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,10 +113,7 @@ export type ComponentEventPayloadValue = ManifestValue;
 
 export interface ComponentEventDto<
   TType extends string = string,
-  TPayload extends Record<string, ComponentEventPayloadValue> = Record<
-    string,
-    ComponentEventPayloadValue
-  >,
+  TPayload extends object = Record<string, ComponentEventPayloadValue>,
 > {
   readonly type: TType;
   readonly sourceNodeId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,51 @@ export interface ActionBinding {
 
 export type UiNodeEventBindings = Record<string, readonly ActionBinding[]>;
 
+export type ComponentEventPayloadValue = ManifestValue;
+
+export interface ComponentEventDto<
+  TType extends string = string,
+  TPayload extends Record<string, ComponentEventPayloadValue> = Record<
+    string,
+    ComponentEventPayloadValue
+  >,
+> {
+  readonly type: TType;
+  readonly sourceNodeId: string;
+  readonly payload: TPayload;
+}
+
+export type FormSubmitValues = Record<string, ComponentEventPayloadValue>;
+
+export type FormSubmitEventDto = ComponentEventDto<
+  'form.submit',
+  {
+    readonly values: FormSubmitValues;
+  }
+>;
+
+export type ButtonPressEventDto = ComponentEventDto<'button.press', Record<string, never>>;
+
+export interface CollectionItemPressPayload {
+  readonly itemId: string | number;
+  readonly item: Record<string, ComponentEventPayloadValue>;
+}
+
+export type CollectionItemPressEventDto = ComponentEventDto<
+  'collection.itemPress',
+  CollectionItemPressPayload
+>;
+
+export type ComponentEventDtoKind =
+  | ButtonPressEventDto['type']
+  | CollectionItemPressEventDto['type']
+  | FormSubmitEventDto['type'];
+
+export type KnownComponentEventDto =
+  | ButtonPressEventDto
+  | CollectionItemPressEventDto
+  | FormSubmitEventDto;
+
 export const NAVIGATOR_TYPES = ['stack', 'tabs', 'drawer'] as const;
 export type NavigatorType = (typeof NAVIGATOR_TYPES)[number];
 


### PR DESCRIPTION
## Summary

- adds a stable `ComponentEventDto` envelope with `type`, `sourceNodeId`, and `payload`
- adds serializable event payload value support based on the existing manifest value model
- adds first known event DTOs for:
  - `form.submit`
  - `button.press`
  - `collection.itemPress`
- adds tests for known and custom component event DTOs
- adds a changeset

Closes #32.

## Notes

This keeps event DTOs descriptive only: they describe what happened, not what action should execute. Action/command execution remains scoped to issue #33.

## Verification

Please run locally:

```bash
bun run build
bun run lint:fix
bun run test
```

I could not run local verification from this environment.