### PR TITLE
03 Add provider-neutral action and command contracts

### DIFF
--- a/.changeset/action-command-contracts.md
+++ b/.changeset/action-command-contracts.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": minor
+'@ankhorage/contracts': minor
 ---
 
 Add provider-neutral action value sources, typed action bindings, and normalized command DTO contracts for event-driven runtime action resolution.

--- a/.changeset/action-command-contracts.md
+++ b/.changeset/action-command-contracts.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": minor
+---
+
+Add provider-neutral action value sources, typed action bindings, and normalized command DTO contracts for event-driven runtime action resolution.

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -6,8 +6,8 @@ import { describe, expect, it } from 'bun:test';
 
 import {
   type ActionBinding,
-  APP_CATEGORIES,
   type ActionValueSource,
+  APP_CATEGORIES,
   type AppCategory,
   AUTH_PROVIDERS,
   AUTH_SIGN_IN_IDENTIFIERS,

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   type ActionBinding,
   APP_CATEGORIES,
+  type ActionValueSource,
   type AppCategory,
   AUTH_PROVIDERS,
   AUTH_SIGN_IN_IDENTIFIERS,
@@ -20,10 +21,15 @@ import {
   type DbAdapter,
   type DbAdminAdapter,
   type DbChangeEvent,
+  type DbPersistActionBinding,
+  type DbPersistCommand,
   type DbRealtimeAdapter,
   DEPLOYMENT_TARGETS,
+  type EmailSendActionBinding,
   type FormSubmitEventDto,
   type ImageAssetSource,
+  type KnownActionBinding,
+  type KnownCommandDto,
   NAVIGATOR_TYPES,
   type StoragePublicUrlResult,
   type StorageResult,
@@ -336,6 +342,121 @@ describe('contracts', () => {
 
     expect(event.payload.mediaId).toBe('video-1');
     expect(knownEventType).toBe('form.submit');
+  });
+
+  it('serializes provider-neutral value sources for action payloads', () => {
+    const sources: readonly ActionValueSource[] = [
+      { source: 'event', path: 'payload.values.email' },
+      { source: 'literal', value: 'website-contact-form' },
+      { source: 'context', path: 'auth.user.id' },
+      { source: 'state', path: 'forms.contact.isSubmitting' },
+    ];
+
+    expect(JSON.parse(JSON.stringify(sources))).toEqual(sources);
+    expect(sources.map((source) => source.source)).toEqual([
+      'event',
+      'literal',
+      'context',
+      'state',
+    ]);
+  });
+
+  it('serializes a typed db.persist action binding', () => {
+    const binding: DbPersistActionBinding = {
+      type: 'db.persist',
+      payload: {
+        collection: 'contact_messages',
+        mode: 'columns',
+        values: [
+          {
+            field: 'firstname',
+            valueFrom: { source: 'event', path: 'payload.values.firstname' },
+            transform: 'trim',
+          },
+          {
+            field: 'message',
+            valueFrom: { source: 'event', path: 'payload.values.message' },
+          },
+          {
+            field: 'source',
+            valueFrom: { source: 'literal', value: 'website-contact-form' },
+          },
+        ],
+      },
+    };
+
+    expect(JSON.parse(JSON.stringify(binding))).toEqual(binding);
+    expect(binding.payload.values.map((value) => value.field)).toEqual([
+      'firstname',
+      'message',
+      'source',
+    ]);
+  });
+
+  it('serializes a typed email.send action binding', () => {
+    const binding: EmailSendActionBinding = {
+      type: 'email.send',
+      payload: {
+        to: 'info@example.com',
+        subject: 'New contact message',
+        bodyFrom: { source: 'event', path: 'payload.values.message' },
+      },
+    };
+
+    expect(JSON.parse(JSON.stringify(binding))).toEqual(binding);
+    expect(binding.payload.bodyFrom?.source).toBe('event');
+  });
+
+  it('accepts typed action bindings in node event bindings', () => {
+    const persist: DbPersistActionBinding = {
+      type: 'db.persist',
+      payload: {
+        collection: 'contact_messages',
+        values: [
+          {
+            field: 'message',
+            valueFrom: { source: 'event', path: 'payload.values.message' },
+          },
+        ],
+      },
+    };
+    const email: EmailSendActionBinding = {
+      type: 'email.send',
+      payload: {
+        to: 'info@example.com',
+        bodyFrom: { source: 'event', path: 'payload.values.message' },
+      },
+    };
+    const node: UiNode = {
+      id: 'contact-form',
+      type: 'Form',
+      events: {
+        submit: [persist, email],
+      },
+    };
+    const known: KnownActionBinding = persist;
+
+    expect(node.events?.submit?.map((action) => action.type)).toEqual(['db.persist', 'email.send']);
+    expect(known.type).toBe('db.persist');
+  });
+
+  it('serializes a normalized db.persist command DTO', () => {
+    const command: DbPersistCommand = {
+      type: 'db.persist.command',
+      payload: {
+        operation: 'insert',
+        collection: 'contact_messages',
+        mode: 'columns',
+        values: {
+          firstname: 'Fabio',
+          message: 'This is my contact message',
+        },
+      },
+    };
+    const knownCommand: KnownCommandDto = command;
+
+    expect(JSON.parse(JSON.stringify(command))).toEqual(command);
+    expect(knownCommand.type).toBe('db.persist.command');
   });
 
   it('accepts a provider-neutral CRUD database adapter', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,8 +153,10 @@ export interface DbPersistActionPayload {
   readonly values: readonly DbPersistFieldBinding[];
 }
 
-export interface DbPersistActionBinding
-  extends ActionBinding<'db.persist', DbPersistActionPayload> {
+export interface DbPersistActionBinding extends ActionBinding<
+  'db.persist',
+  DbPersistActionPayload
+> {
   readonly payload: DbPersistActionPayload;
 }
 
@@ -165,7 +167,10 @@ export interface EmailSendActionPayload {
   readonly bodyFrom?: ActionValueSource;
 }
 
-export interface EmailSendActionBinding extends ActionBinding<'email.send', EmailSendActionPayload> {
+export interface EmailSendActionBinding extends ActionBinding<
+  'email.send',
+  EmailSendActionPayload
+> {
   readonly payload: EmailSendActionPayload;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,7 +88,9 @@ export type ManifestValue =
   | readonly ManifestValue[]
   | { readonly [key: string]: ManifestValue };
 
-export type ActionBindingPayload = Record<string, ManifestValue>;
+export type ActionValue = ManifestValue;
+
+export type ActionBindingPayload = Record<string, ActionValue>;
 
 export type ActionConditionSource = 'context' | 'event' | 'state';
 
@@ -98,16 +100,103 @@ export interface ActionCondition {
   readonly source: ActionConditionSource;
   readonly path: string;
   readonly operator: ActionConditionOperator;
-  readonly value?: ManifestValue;
+  readonly value?: ActionValue;
 }
 
-export interface ActionBinding {
-  readonly type: string;
-  readonly payload?: ActionBindingPayload;
+export type ActionValueSource =
+  | {
+      readonly source: 'context';
+      readonly path: string;
+    }
+  | {
+      readonly source: 'event';
+      readonly path: string;
+    }
+  | {
+      readonly source: 'literal';
+      readonly value: ActionValue;
+    }
+  | {
+      readonly source: 'state';
+      readonly path: string;
+    };
+
+export type ActionValueTransform = 'lowercase' | 'trim' | 'uppercase';
+
+export interface ActionValueBinding {
+  readonly valueFrom: ActionValueSource;
+  readonly transform?: ActionValueTransform | readonly ActionValueTransform[];
+}
+
+export interface ActionBinding<
+  TType extends string = string,
+  TPayload extends object = ActionBindingPayload,
+> {
+  readonly type: TType;
+  readonly payload?: TPayload;
   readonly when?: ActionCondition;
 }
 
-export type UiNodeEventBindings = Record<string, readonly ActionBinding[]>;
+export type DbPersistMode = 'columns' | 'json';
+
+export interface DbPersistFieldBinding {
+  readonly field: string;
+  readonly valueFrom: ActionValueSource;
+  readonly transform?: ActionValueTransform | readonly ActionValueTransform[];
+}
+
+export interface DbPersistActionPayload {
+  readonly collection: string;
+  readonly kind?: string;
+  readonly mode?: DbPersistMode;
+  readonly jsonField?: string;
+  readonly values: readonly DbPersistFieldBinding[];
+}
+
+export interface DbPersistActionBinding
+  extends ActionBinding<'db.persist', DbPersistActionPayload> {
+  readonly payload: DbPersistActionPayload;
+}
+
+export interface EmailSendActionPayload {
+  readonly to: string;
+  readonly subject?: string;
+  readonly body?: string;
+  readonly bodyFrom?: ActionValueSource;
+}
+
+export interface EmailSendActionBinding extends ActionBinding<'email.send', EmailSendActionPayload> {
+  readonly payload: EmailSendActionPayload;
+}
+
+export type KnownActionBinding = DbPersistActionBinding | EmailSendActionBinding;
+
+export type UiNodeEventBindings = Record<string, readonly ActionBinding<string, object>[]>;
+
+export interface CommandDto<
+  TType extends string = string,
+  TPayload extends object = Record<string, ActionValue>,
+> {
+  readonly type: TType;
+  readonly payload: TPayload;
+}
+
+export type DbPersistOperation = 'insert';
+
+export type DbPersistCommandValues = Record<string, ActionValue>;
+
+export interface DbPersistCommandPayload {
+  readonly operation: DbPersistOperation;
+  readonly collection: string;
+  readonly kind?: string;
+  readonly mode?: DbPersistMode;
+  readonly jsonField?: string;
+  readonly values: DbPersistCommandValues;
+}
+
+export type DbPersistCommand = CommandDto<'db.persist.command', DbPersistCommandPayload>;
+
+export type KnownCommandDto = DbPersistCommand;
 
 export type ComponentEventPayloadValue = ManifestValue;
 


### PR DESCRIPTION
## Summary

- adds provider-neutral action value contracts:
  - `ActionValue`
  - `ActionValueSource`
  - `ActionValueBinding`
  - `ActionValueTransform`
- makes `ActionBinding` generic so typed action payloads can extend the node event-binding model
- adds typed action bindings for:
  - `db.persist`
  - `email.send`
- adds normalized command DTO contracts, including `DbPersistCommand`
- adds tests for value sources, typed action bindings, node event bindings, and normalized command DTOs
- adds a changeset

Closes #33.

## Notes

This PR only defines provider-neutral contracts. It does not add runtime execution, DB adapter calls, Supabase behavior, SMTP behavior, Studio UI, or ZORA metadata.

## Verification

Please run locally:

```bash
bun run build
bun run lint:fix
bun run test
```

I could not run local verification from this environment.