### PR TITLE
07 Add provider-neutral state adapter contracts

### DIFF
--- a/.changeset/state-adapter-contracts.md
+++ b/.changeset/state-adapter-contracts.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": minor
+---
+
+Add provider-neutral state adapter contracts for path-based reads, writes, subscriptions, and optional removal support.

--- a/.changeset/state-adapter-contracts.md
+++ b/.changeset/state-adapter-contracts.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": minor
+'@ankhorage/contracts': minor
 ---
 
 Add provider-neutral state adapter contracts for path-based reads, writes, subscriptions, and optional removal support.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
       "types": "./dist/db.d.ts",
       "default": "./dist/db.js"
     },
+    "./state": {
+      "types": "./dist/state.d.ts",
+      "default": "./dist/state.js"
+    },
     "./storage": {
       "types": "./dist/storage.d.ts",
       "default": "./dist/storage.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './auth';
 export * from './db';
+export * from './state';
 export * from './storage';
 export * from './types';

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -151,7 +151,7 @@ describe('StateAdapter', () => {
     expect(snapshots).toEqual([1, 2]);
   });
 
-  it('stops notifying after unsubscribe', () => {
+  it('stops notifying after unsubscribe', async () => {
     const adapter = createFakeStateAdapter();
     const snapshots: StateValue[] = [];
     const subscriptionResult = adapter.subscribe('counter.value', ({ value }) => {
@@ -165,7 +165,7 @@ describe('StateAdapter', () => {
     }
 
     adapter.set('counter.value', 1);
-    subscriptionResult.data.unsubscribe();
+    await subscriptionResult.data.unsubscribe();
     adapter.set('counter.value', 2);
 
     expect(snapshots).toEqual([1]);

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'bun:test';
+
+import type {
+  StateAdapter,
+  StateListener,
+  StatePath,
+  StateResult,
+  StateSubscription,
+  StateValue,
+} from './state';
+
+function pathToKey(path: StatePath): string {
+  return Array.isArray(path) ? path.join('.') : path;
+}
+
+function isStateValue(value: unknown): value is StateValue {
+  if (value === null) {
+    return true;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every(isStateValue);
+  }
+
+  if (typeof value !== 'object') {
+    return false;
+  }
+
+  return Object.values(value).every(isStateValue);
+}
+
+function createError(code: string, message: string): StateResult {
+  return {
+    ok: false,
+    error: { code, message },
+  };
+}
+
+function createFakeStateAdapter(): StateAdapter {
+  const values = new Map<string, StateValue>();
+  const listeners = new Map<string, Set<StateListener>>();
+
+  const emit = (path: StatePath, value: StateValue | undefined) => {
+    const key = pathToKey(path);
+    const pathListeners = listeners.get(key);
+
+    if (!pathListeners) {
+      return;
+    }
+
+    for (const listener of pathListeners) {
+      listener({ path, value });
+    }
+  };
+
+  return {
+    capabilities: {
+      subscriptions: true,
+      computed: false,
+      persistence: false,
+    },
+    get(path) {
+      return { ok: true, data: values.get(pathToKey(path)) };
+    },
+    set(path, value) {
+      if (!isStateValue(value)) {
+        return createError('invalid_value', 'State value must be serializable.');
+      }
+
+      values.set(pathToKey(path), value);
+      emit(path, value);
+      return { ok: true };
+    },
+    subscribe(path, listener) {
+      const key = pathToKey(path);
+      const pathListeners = listeners.get(key) ?? new Set<StateListener>();
+      pathListeners.add(listener);
+      listeners.set(key, pathListeners);
+
+      const subscription: StateSubscription = {
+        unsubscribe() {
+          pathListeners.delete(listener);
+          if (pathListeners.size === 0) {
+            listeners.delete(key);
+          }
+        },
+      };
+
+      return { ok: true, data: subscription };
+    },
+    delete(path) {
+      values.delete(pathToKey(path));
+      emit(path, undefined);
+      return { ok: true };
+    },
+  };
+}
+
+describe('StateAdapter', () => {
+  it('supports path-based set and get', () => {
+    const adapter = createFakeStateAdapter();
+
+    const setResult = adapter.set(['forms', 'contact', 'values'], {
+      firstname: 'Fabio',
+      newsletter: true,
+    });
+    const getResult = adapter.get(['forms', 'contact', 'values']);
+
+    expect(setResult).toEqual({ ok: true });
+    expect(getResult).toEqual({
+      ok: true,
+      data: {
+        firstname: 'Fabio',
+        newsletter: true,
+      },
+    });
+  });
+
+  it('supports string paths and serializable nested values', () => {
+    const adapter = createFakeStateAdapter();
+    const value: StateValue = {
+      selectedIds: ['post-1', 'post-2'],
+      filters: {
+        search: 'hello',
+        onlyPublished: true,
+      },
+    };
+
+    adapter.set('collections.posts', value);
+
+    expect(adapter.get('collections.posts')).toEqual({ ok: true, data: value });
+  });
+
+  it('notifies subscribers when a value changes', () => {
+    const adapter = createFakeStateAdapter();
+    const snapshots: StateValue[] = [];
+    const subscriptionResult = adapter.subscribe('counter.value', ({ value }) => {
+      if (value !== undefined) {
+        snapshots.push(value);
+      }
+    });
+
+    adapter.set('counter.value', 1);
+    adapter.set('counter.value', 2);
+
+    expect(subscriptionResult.ok).toBe(true);
+    expect(snapshots).toEqual([1, 2]);
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const adapter = createFakeStateAdapter();
+    const snapshots: StateValue[] = [];
+    const subscriptionResult = adapter.subscribe('counter.value', ({ value }) => {
+      if (value !== undefined) {
+        snapshots.push(value);
+      }
+    });
+
+    if (!subscriptionResult.ok) {
+      throw new Error('Expected subscription to succeed.');
+    }
+
+    adapter.set('counter.value', 1);
+    subscriptionResult.data.unsubscribe();
+    adapter.set('counter.value', 2);
+
+    expect(snapshots).toEqual([1]);
+  });
+
+  it('supports deleting values when the adapter implements delete', () => {
+    const adapter = createFakeStateAdapter();
+    const snapshots: (StateValue | undefined)[] = [];
+    adapter.subscribe('session.user', ({ value }) => {
+      snapshots.push(value);
+    });
+
+    adapter.set('session.user', { id: 'user-1' });
+    const deleteResult = adapter.delete?.('session.user');
+
+    expect(deleteResult).toEqual({ ok: true });
+    expect(adapter.get('session.user')).toEqual({ ok: true, data: undefined });
+    expect(snapshots).toEqual([{ id: 'user-1' }, undefined]);
+  });
+});

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,63 @@
+export type StatePrimitive = string | number | boolean | null;
+
+export type StateValue =
+  | StatePrimitive
+  | readonly StateValue[]
+  | {
+      readonly [key: string]: StateValue;
+    };
+
+export type StatePath = string | readonly string[];
+
+export interface StateAdapterCapabilities {
+  readonly subscriptions: boolean;
+  readonly computed: boolean;
+  readonly persistence: boolean;
+}
+
+export interface StateAdapterError {
+  readonly code: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}
+
+export type StateSuccess<TValue = void> = [TValue] extends [void]
+  ? {
+      readonly ok: true;
+    }
+  : {
+      readonly ok: true;
+      readonly data: TValue;
+    };
+
+export type StateResult<TValue = void> =
+  | StateSuccess<TValue>
+  | {
+      readonly ok: false;
+      readonly error: StateAdapterError;
+    };
+
+export interface StateSnapshot<TValue extends StateValue = StateValue> {
+  readonly path: StatePath;
+  readonly value: TValue | undefined;
+}
+
+export type StateListener<TValue extends StateValue = StateValue> = (
+  snapshot: StateSnapshot<TValue>,
+) => void;
+
+export interface StateSubscription {
+  unsubscribe(): Promise<void> | void;
+}
+
+export interface StateAdapter {
+  readonly capabilities: StateAdapterCapabilities;
+
+  get<TValue extends StateValue = StateValue>(path: StatePath): StateResult<TValue | undefined>;
+  set<TValue extends StateValue = StateValue>(path: StatePath, value: TValue): StateResult;
+  subscribe<TValue extends StateValue = StateValue>(
+    path: StatePath,
+    listener: StateListener<TValue>,
+  ): StateResult<StateSubscription>;
+  delete?(path: StatePath): StateResult;
+}


### PR DESCRIPTION
## Summary

- adds `src/state.ts` with provider-neutral state contracts
- defines serializable `StateValue`, path-based `StatePath`, `StateResult`, `StateAdapter`, `StateListener`, and `StateSubscription`
- supports path-based `get`, `set`, `subscribe`, and optional removal through `delete`
- adds `StateAdapterCapabilities` for subscriptions, computed state, and persistence
- exports the contracts from the root package and the new `@ankhorage/contracts/state` subpath
- adds fake-adapter tests for get/set/subscribe/unsubscribe/delete behavior
- adds a changeset

Closes #34.

## Notes

This is intentionally provider-neutral. It does not import Legend State, SWR, Zustand, React Query, React, or ZORA.

## Verification

Please run locally:

```bash
bun run build
bun run lint:fix
bun run test
bun run knip
```

I could not run local verification from this environment.