### PR TITLE
08 Add provider-neutral data and state binding contracts

### DIFF
--- a/.changeset/data-state-value-sources.md
+++ b/.changeset/data-state-value-sources.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": minor
+---
+
+Add provider-neutral data and state binding contracts for manifest node props and database collection queries.

--- a/.changeset/data-state-value-sources.md
+++ b/.changeset/data-state-value-sources.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": minor
+'@ankhorage/contracts': minor
 ---
 
 Add provider-neutral data and state binding contracts for manifest node props and database collection queries.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
       "types": "./dist/auth.d.ts",
       "default": "./dist/auth.js"
     },
+    "./bindings": {
+      "types": "./dist/bindings.d.ts",
+      "default": "./dist/bindings.js"
+    },
     "./db": {
       "types": "./dist/db.d.ts",
       "default": "./dist/db.js"

--- a/src/bindings.test.ts
+++ b/src/bindings.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'bun:test';
+
+import type {
+  BindingValueSource,
+  DbCollectionQueryBinding,
+  NodePropBinding,
+  UiNode,
+} from './index';
+
+describe('binding contracts', () => {
+  it('serializes a node prop bound to state', () => {
+    const binding: NodePropBinding = {
+      prop: 'value',
+      valueFrom: {
+        source: 'state',
+        path: 'forms.contact.values.firstname',
+      },
+      transform: 'trim',
+    };
+    const node: UiNode = {
+      id: 'firstname-input',
+      type: 'Input',
+      props: {
+        label: 'Firstname',
+      },
+      bindings: [binding],
+    };
+
+    expect(JSON.parse(JSON.stringify(node))).toEqual(node);
+    expect(node.bindings?.[0]?.valueFrom.source).toBe('state');
+  });
+
+  it('serializes a node prop bound to a DB collection query', () => {
+    const query: DbCollectionQueryBinding = {
+      collection: 'posts',
+      schema: 'public',
+      columns: ['id', 'title', 'published'],
+      filters: [{ field: 'published', operator: 'eq', value: true }],
+      sort: [{ field: 'created_at', direction: 'desc' }],
+      page: { limit: 10, offset: 0 },
+      refresh: 'live',
+    };
+    const node: UiNode = {
+      id: 'posts-list',
+      type: 'CollectionList',
+      bindings: [
+        {
+          prop: 'items',
+          valueFrom: {
+            source: 'db.collection',
+            query,
+          },
+        },
+      ],
+    };
+
+    expect(JSON.parse(JSON.stringify(node))).toEqual(node);
+    expect(node.bindings?.[0]?.valueFrom.source).toBe('db.collection');
+  });
+
+  it('supports literal, context, and event value sources', () => {
+    const sources: readonly BindingValueSource[] = [
+      { source: 'literal', value: { fallback: 'Untitled' } },
+      { source: 'context', path: 'auth.user.displayName' },
+      { source: 'event', path: 'payload.values.search' },
+    ];
+
+    expect(JSON.parse(JSON.stringify(sources))).toEqual(sources);
+    expect(sources.map((source) => source.source)).toEqual(['literal', 'context', 'event']);
+  });
+
+  it('supports static, focus, poll, and live refresh intent', () => {
+    const refreshModes = ['static', 'focus', 'poll', 'live'] as const;
+    const bindings = refreshModes.map(
+      (refresh): NodePropBinding => ({
+        prop: `items.${refresh}`,
+        valueFrom: {
+          source: 'db.collection',
+          query: {
+            collection: 'posts',
+            refresh,
+            pollIntervalMs: refresh === 'poll' ? 30_000 : undefined,
+          },
+        },
+      }),
+    );
+
+    expect(JSON.parse(JSON.stringify(bindings))).toEqual(bindings);
+    expect(bindings.map((binding) => binding.valueFrom.source)).toEqual([
+      'db.collection',
+      'db.collection',
+      'db.collection',
+      'db.collection',
+    ]);
+  });
+});

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,0 +1,54 @@
+import type { DbFilter, DbPage, DbSort } from './db';
+
+export type BindingValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly BindingValue[]
+  | {
+      readonly [key: string]: BindingValue;
+    };
+
+export type BindingRefreshMode = 'focus' | 'live' | 'poll' | 'static';
+
+export interface DbCollectionQueryBinding {
+  readonly collection: string;
+  readonly schema?: string;
+  readonly columns?: readonly string[];
+  readonly filters?: readonly DbFilter[];
+  readonly sort?: readonly DbSort[];
+  readonly page?: DbPage;
+  readonly refresh?: BindingRefreshMode;
+  readonly pollIntervalMs?: number;
+}
+
+export type BindingValueSource =
+  | {
+      readonly source: 'context';
+      readonly path: string;
+    }
+  | {
+      readonly source: 'db.collection';
+      readonly query: DbCollectionQueryBinding;
+    }
+  | {
+      readonly source: 'event';
+      readonly path: string;
+    }
+  | {
+      readonly source: 'literal';
+      readonly value: BindingValue;
+    }
+  | {
+      readonly source: 'state';
+      readonly path: string;
+    };
+
+export type BindingValueTransform = 'lowercase' | 'trim' | 'uppercase';
+
+export interface NodePropBinding {
+  readonly prop: string;
+  readonly valueFrom: BindingValueSource;
+  readonly transform?: BindingValueTransform | readonly BindingValueTransform[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './auth';
+export * from './bindings';
 export * from './db';
 export * from './state';
 export * from './storage';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { ColorHarmony } from '@ankhorage/color-theory';
 
 import type { AuthFlowConfig, AuthIdentifierKind, AuthSignUpField } from './auth';
+import type { NodePropBinding } from './bindings';
 
 export interface ThemeModeConfig {
   primaryColor: string;
@@ -330,6 +331,7 @@ export interface UiNode {
   type: string;
   alias?: string;
   props?: Record<string, unknown>;
+  bindings?: readonly NodePropBinding[];
   children?: UiNode[];
   style?: Record<string, number | string>;
   events?: UiNodeEventBindings;


### PR DESCRIPTION
## Summary

- adds provider-neutral binding contracts for manifest node props
- adds `BindingValueSource` for literal, state, context, event, and `db.collection` sources
- adds `DbCollectionQueryBinding` reusing `DbFilter`, `DbSort`, and `DbPage`
- supports refresh intent through `static`, `focus`, `poll`, and `live`
- adds `UiNode.bindings?: readonly NodePropBinding[]`
- exports the contracts from root and the `@ankhorage/contracts/bindings` subpath
- adds tests for:
  - a node prop bound to state
  - a node prop bound to a DB collection query
  - literal/context/event value sources
  - refresh intent modes
- adds a changeset

Closes #35.

## Notes

This remains provider-neutral and state-engine-neutral. It does not import runtime, ZORA, Supabase, Legend State, React Query, Zustand, SWR, or React.

## Verification

Please run locally:

```bash
bun run build
bun run lint:fix
bun run test
bun run knip
```

I could not run local verification from this environment.