### PR TITLE
feat(ui): add component metadata contracts

### DIFF
--- a/.changeset/ui-component-metadata-contracts.md
+++ b/.changeset/ui-component-metadata-contracts.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Add provider-neutral UI component metadata contracts for component registries and extension package manifests.

--- a/package.json
+++ b/package.json
@@ -40,26 +40,15 @@
     "./storage": {
       "types": "./dist/storage.d.ts",
       "default": "./dist/storage.js"
+    },
+    "./ui": {
+      "types": "./dist/ui.d.ts",
+      "default": "./dist/ui.js"
     }
   },
   "description": "Serializable app, action, and theme config contracts for Ankhorage.",
-  "keywords": [
-    "typescript",
-    "contracts",
-    "schema",
-    "manifest",
-    "auth",
-    "storage",
-    "adapter"
-  ],
-  "files": [
-    "dist",
-    "src",
-    "package.json",
-    "README.md",
-    "CHANGELOG.md",
-    "LICENSE"
-  ],
+  "keywords": ["typescript", "contracts", "schema", "manifest", "auth", "storage", "adapter"],
+  "files": ["dist", "src", "package.json", "README.md", "CHANGELOG.md", "LICENSE"],
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,23 @@
     }
   },
   "description": "Serializable app, action, and theme config contracts for Ankhorage.",
-  "keywords": ["typescript", "contracts", "schema", "manifest", "auth", "storage", "adapter"],
-  "files": ["dist", "src", "package.json", "README.md", "CHANGELOG.md", "LICENSE"],
+  "keywords": [
+    "typescript",
+    "contracts",
+    "schema",
+    "manifest",
+    "auth",
+    "storage",
+    "adapter"
+  ],
+  "files": [
+    "dist",
+    "src",
+    "package.json",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from './db';
 export * from './state';
 export * from './storage';
 export * from './types';
+export * from './ui';

--- a/src/ui.test.ts
+++ b/src/ui.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import type {
-  UiComponentMeta,
-  UiComponentMetaRegistry,
-  UiComponentPackageManifest,
-} from './index';
+import type { UiComponentMeta, UiComponentMetaRegistry, UiComponentPackageManifest } from './index';
 
 function assertSerializable<TValue>(value: TValue): void {
   expect(JSON.parse(JSON.stringify(value))).toEqual(value);

--- a/src/ui.test.ts
+++ b/src/ui.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'bun:test';
+
+import type {
+  UiComponentMeta,
+  UiComponentMetaRegistry,
+  UiComponentPackageManifest,
+} from './index';
+
+function assertSerializable<TValue>(value: TValue): void {
+  expect(JSON.parse(JSON.stringify(value))).toEqual(value);
+}
+
+describe('ui component metadata contracts', () => {
+  it('serializes component metadata with props, events, slots, i18n, and blueprint defaults', () => {
+    const meta: UiComponentMeta = {
+      name: 'Button',
+      category: 'component',
+      description: 'Action component used to trigger an interaction.',
+      directManifestNode: true,
+      allowedChildren: [],
+      blueprint: {
+        label: 'Button',
+        icon: {
+          name: 'cursor-default-click',
+          provider: 'material-community',
+        },
+        defaultProps: {
+          children: 'Continue',
+          disabled: false,
+          size: 'm',
+        },
+      },
+      events: {
+        press: {
+          label: 'Press',
+          eventType: 'button.press',
+          description: 'Emitted when the button is pressed.',
+          payloadFields: [],
+        },
+      },
+      i18n: {
+        fields: [
+          {
+            keyProp: 'i18nKey',
+            defaultTextProp: 'children',
+          },
+        ],
+      },
+      slots: {
+        icon: {
+          label: 'Icon',
+          allowedChildren: ['Icon'],
+        },
+      },
+      props: {
+        children: {
+          type: 'string',
+          category: 'Content',
+          label: 'Label',
+          default: 'Continue',
+        },
+        disabled: {
+          type: 'boolean',
+          category: 'State',
+          label: 'Disabled',
+          default: false,
+        },
+        size: {
+          type: 'enum',
+          category: 'Style',
+          label: 'Size',
+          enum: ['s', 'm', 'l'],
+          default: 'm',
+        },
+      },
+    };
+
+    assertSerializable(meta);
+    expect(meta.events?.press?.eventType).toBe('button.press');
+    expect(meta.props.size?.enum).toEqual(['s', 'm', 'l']);
+  });
+
+  it('serializes component metadata with array item schemas', () => {
+    const meta: UiComponentMeta = {
+      name: 'DataTable',
+      category: 'component',
+      directManifestNode: true,
+      allowedChildren: [],
+      props: {
+        columns: {
+          type: 'array',
+          category: 'Data',
+          label: 'Columns',
+          itemSchema: [
+            {
+              key: 'id',
+              schema: {
+                type: 'string',
+                category: 'Data',
+                label: 'Column id',
+              },
+            },
+            {
+              key: 'label',
+              schema: {
+                type: 'string',
+                category: 'Data',
+                label: 'Column label',
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    assertSerializable(meta);
+    expect(meta.props.columns?.itemSchema?.map((item) => item.key)).toEqual(['id', 'label']);
+  });
+
+  it('serializes a component metadata registry', () => {
+    const registry: UiComponentMetaRegistry = {
+      Text: {
+        name: 'Text',
+        category: 'component',
+        directManifestNode: true,
+        allowedChildren: [],
+        props: {
+          children: {
+            type: 'string',
+            category: 'Content',
+            label: 'Text',
+          },
+        },
+      },
+      Screen: {
+        name: 'Screen',
+        category: 'layout',
+        directManifestNode: true,
+        allowedChildren: ['Text'],
+        props: {},
+      },
+    };
+
+    assertSerializable(registry);
+    expect(registry.Screen?.allowedChildren).toEqual(['Text']);
+  });
+
+  it('serializes a component package manifest for extension packages', () => {
+    const manifest: UiComponentPackageManifest = {
+      packageName: '@ankhorage/zora-chessboard',
+      displayName: 'ZORA Chessboard',
+      components: {
+        Chessboard: {
+          name: 'Chessboard',
+          category: 'component',
+          directManifestNode: true,
+          allowedChildren: [],
+          events: {
+            move: {
+              label: 'Move',
+              eventType: 'chess.move',
+              payloadFields: [
+                {
+                  path: 'payload.from',
+                  type: 'string',
+                  label: 'From square',
+                },
+                {
+                  path: 'payload.to',
+                  type: 'string',
+                  label: 'To square',
+                },
+              ],
+            },
+          },
+          props: {
+            fen: {
+              type: 'string',
+              category: 'Chess',
+              label: 'FEN',
+            },
+            orientation: {
+              type: 'enum',
+              category: 'Chess',
+              label: 'Orientation',
+              enum: ['white', 'black'],
+              default: 'white',
+            },
+          },
+        },
+      },
+    };
+
+    assertSerializable(manifest);
+    expect(manifest.components.Chessboard?.events?.move?.eventType).toBe('chess.move');
+  });
+});

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,0 +1,113 @@
+import type { ComponentEventDtoKind } from './types';
+
+export type UiComponentCategory = 'component' | 'foundation' | 'layout' | 'pattern';
+
+export type UiComponentPropType =
+  | 'action'
+  | 'array'
+  | 'boolean'
+  | 'color'
+  | 'enum'
+  | 'imageAsset'
+  | 'number'
+  | 'radius'
+  | 'shadow'
+  | 'spacing'
+  | 'string'
+  | 'typographySize'
+  | 'typographyWeight';
+
+export type UiComponentPropValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly UiComponentPropValue[]
+  | {
+      readonly [key: string]: UiComponentPropValue;
+    };
+
+export interface UiComponentPropArrayItemSchema {
+  readonly key: string;
+  readonly schema: UiComponentPropSchema;
+}
+
+export interface UiComponentPropSchema {
+  readonly type: UiComponentPropType;
+  readonly category: string;
+  readonly label?: string;
+  readonly enum?: readonly (number | string)[];
+  readonly default?: UiComponentPropValue;
+  readonly itemSchema?: readonly UiComponentPropArrayItemSchema[];
+}
+
+export interface UiComponentBlueprintIcon {
+  readonly name: string;
+  readonly provider?: string;
+}
+
+export interface UiComponentBlueprint {
+  readonly label: string;
+  readonly icon?: UiComponentBlueprintIcon;
+  readonly defaultProps?: Readonly<Record<string, UiComponentPropValue>>;
+}
+
+export interface UiComponentI18nFieldMeta {
+  readonly keyProp: string;
+  readonly defaultTextProp: string;
+}
+
+export interface UiComponentI18nMeta {
+  readonly fields: readonly UiComponentI18nFieldMeta[];
+}
+
+export type UiComponentEventPayloadKind = ComponentEventDtoKind | (string & {});
+
+export type UiComponentEventPayloadFieldType =
+  | 'boolean'
+  | 'number'
+  | 'object'
+  | 'record'
+  | 'string'
+  | 'unknown';
+
+export interface UiComponentEventPayloadFieldMeta {
+  readonly path: string;
+  readonly type: UiComponentEventPayloadFieldType;
+  readonly label?: string;
+  readonly description?: string;
+}
+
+export interface UiComponentEventMeta {
+  readonly label: string;
+  readonly eventType: UiComponentEventPayloadKind;
+  readonly description?: string;
+  readonly payloadFields?: readonly UiComponentEventPayloadFieldMeta[];
+}
+
+export interface UiComponentSlotMeta {
+  readonly label?: string;
+  readonly allowedChildren?: readonly string[];
+}
+
+export interface UiComponentMeta {
+  readonly name: string;
+  readonly category: UiComponentCategory;
+  readonly description?: string;
+  readonly directManifestNode: boolean;
+  readonly allowedChildren: readonly string[];
+  readonly blueprint?: UiComponentBlueprint;
+  readonly events?: Readonly<Record<string, UiComponentEventMeta>>;
+  readonly i18n?: UiComponentI18nMeta;
+  readonly slots?: Readonly<Record<string, UiComponentSlotMeta>>;
+  readonly note?: string;
+  readonly props: Readonly<Record<string, UiComponentPropSchema>>;
+}
+
+export type UiComponentMetaRegistry = Readonly<Record<string, UiComponentMeta>>;
+
+export interface UiComponentPackageManifest {
+  readonly packageName: string;
+  readonly displayName?: string;
+  readonly components: UiComponentMetaRegistry;
+}


### PR DESCRIPTION
## Summary

Implements #46.

Adds provider-neutral UI component metadata contracts for:

- component categories
- component prop schemas and prop values
- array item prop schemas
- blueprints and default props
- i18n metadata
- event metadata and event payload field metadata
- slot metadata
- component metadata registries
- package-level component manifests for extension packages

Also adds:

- root `src/index.ts` export
- `./ui` package subpath export
- serialization tests for component metadata, registries, and extension package manifests
- minor changeset

## Scope intentionally excluded

- no ZORA migration in this PR
- no ZORA compatibility aliases in this PR
- no bindable metadata extension work from #49
- no Studio UI changes
- no Runtime changes

## Verification

I could not run local validation from this session because the environment cannot reliably clone/resolve GitHub repositories.

Please run before merge:

```bash
bun install
bun run build
bun run lint:fix
bun run test
```

## Notes

The new metadata contracts are type-only and independent from React, React Native, ZORA, Surface, Studio, and Runtime implementations.