### PR TITLE
feat(ui): add bindable component metadata contracts

### DIFF
--- a/.changeset/bindable-component-metadata-contracts.md
+++ b/.changeset/bindable-component-metadata-contracts.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Add bindable component metadata contracts for declaring data-bindable component props and events.

--- a/src/ui.test.ts
+++ b/src/ui.test.ts
@@ -113,6 +113,134 @@ describe('ui component metadata contracts', () => {
     expect(meta.props.columns?.itemSchema?.map((item) => item.key)).toEqual(['id', 'label']);
   });
 
+  it('serializes bindable prop and event metadata on component metadata', () => {
+    const meta: UiComponentMeta = {
+      name: 'Button',
+      category: 'component',
+      directManifestNode: true,
+      allowedChildren: [],
+      bindings: {
+        props: {
+          children: {
+            label: 'Label',
+            description: 'Text content rendered inside the button.',
+            acceptsFallback: true,
+            acceptsTransforms: true,
+            value: {
+              type: 'string',
+              label: 'Button label',
+            },
+          },
+          disabled: {
+            label: 'Disabled',
+            value: {
+              type: 'boolean',
+            },
+          },
+        },
+        events: {
+          press: {
+            label: 'Press',
+            description: 'Runs when the button is pressed.',
+            payload: {
+              eventType: 'button.press',
+              fields: [],
+            },
+          },
+        },
+      },
+      events: {
+        press: {
+          label: 'Press',
+          eventType: 'button.press',
+        },
+      },
+      props: {
+        children: {
+          type: 'string',
+          category: 'Content',
+          label: 'Label',
+        },
+        disabled: {
+          type: 'boolean',
+          category: 'State',
+          label: 'Disabled',
+        },
+      },
+    };
+
+    assertSerializable(meta);
+    expect(meta.bindings?.props?.children?.value.type).toBe('string');
+    expect(meta.bindings?.events?.press?.payload?.eventType).toBe('button.press');
+  });
+
+  it('serializes bindable collection item metadata with nested value fields', () => {
+    const meta: UiComponentMeta = {
+      name: 'List',
+      category: 'pattern',
+      directManifestNode: true,
+      allowedChildren: [],
+      bindings: {
+        props: {
+          items: {
+            label: 'Items',
+            value: {
+              type: 'array',
+              itemType: 'object',
+              fields: [
+                {
+                  path: '$.id',
+                  type: 'string',
+                  label: 'ID',
+                  required: true,
+                },
+                {
+                  path: '$.title',
+                  type: 'string',
+                  label: 'Title',
+                },
+              ],
+            },
+          },
+        },
+        events: {
+          itemPress: {
+            label: 'Item press',
+            payload: {
+              eventType: 'collection.itemPress',
+              fields: [
+                {
+                  path: 'payload.itemId',
+                  type: 'string',
+                  label: 'Item ID',
+                },
+                {
+                  path: 'payload.item',
+                  type: 'record',
+                  label: 'Item',
+                },
+              ],
+            },
+          },
+        },
+      },
+      props: {
+        items: {
+          type: 'array',
+          category: 'Data',
+          label: 'Items',
+        },
+      },
+    };
+
+    assertSerializable(meta);
+    expect(meta.bindings?.props?.items?.value.fields?.map((field) => field.path)).toEqual([
+      '$.id',
+      '$.title',
+    ]);
+    expect(meta.bindings?.events?.itemPress?.payload?.eventType).toBe('collection.itemPress');
+  });
+
   it('serializes a component metadata registry', () => {
     const registry: UiComponentMetaRegistry = {
       Text: {
@@ -120,6 +248,15 @@ describe('ui component metadata contracts', () => {
         category: 'component',
         directManifestNode: true,
         allowedChildren: [],
+        bindings: {
+          props: {
+            children: {
+              value: {
+                type: 'string',
+              },
+            },
+          },
+        },
         props: {
           children: {
             type: 'string',
@@ -139,6 +276,7 @@ describe('ui component metadata contracts', () => {
 
     assertSerializable(registry);
     expect(registry.Screen?.allowedChildren).toEqual(['Text']);
+    expect(registry.Text?.bindings?.props?.children?.value.type).toBe('string');
   });
 
   it('serializes a component package manifest for extension packages', () => {
@@ -151,6 +289,36 @@ describe('ui component metadata contracts', () => {
           category: 'component',
           directManifestNode: true,
           allowedChildren: [],
+          bindings: {
+            props: {
+              fen: {
+                value: {
+                  type: 'string',
+                  label: 'FEN',
+                },
+              },
+            },
+            events: {
+              move: {
+                label: 'Move',
+                payload: {
+                  eventType: 'chess.move',
+                  fields: [
+                    {
+                      path: 'payload.from',
+                      type: 'string',
+                      label: 'From square',
+                    },
+                    {
+                      path: 'payload.to',
+                      type: 'string',
+                      label: 'To square',
+                    },
+                  ],
+                },
+              },
+            },
+          },
           events: {
             move: {
               label: 'Move',
@@ -189,5 +357,6 @@ describe('ui component metadata contracts', () => {
 
     assertSerializable(manifest);
     expect(manifest.components.Chessboard?.events?.move?.eventType).toBe('chess.move');
+    expect(manifest.components.Chessboard?.bindings?.props?.fen?.value.type).toBe('string');
   });
 });

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -85,6 +85,58 @@ export interface UiComponentEventMeta {
   readonly payloadFields?: readonly UiComponentEventPayloadFieldMeta[];
 }
 
+export type UiBindableValueType =
+  | 'array'
+  | 'boolean'
+  | 'date'
+  | 'imageAsset'
+  | 'number'
+  | 'object'
+  | 'record'
+  | 'string'
+  | 'unknown';
+
+export interface UiBindableValueFieldMeta {
+  readonly path: string;
+  readonly type: UiBindableValueType;
+  readonly label?: string;
+  readonly description?: string;
+  readonly required?: boolean;
+}
+
+export interface UiBindableValueMeta {
+  readonly type: UiBindableValueType;
+  readonly label?: string;
+  readonly description?: string;
+  readonly fields?: readonly UiBindableValueFieldMeta[];
+  readonly itemType?: UiBindableValueType;
+}
+
+export interface UiBindablePropMeta {
+  readonly value: UiBindableValueMeta;
+  readonly label?: string;
+  readonly description?: string;
+  readonly required?: boolean;
+  readonly acceptsFallback?: boolean;
+  readonly acceptsTransforms?: boolean;
+}
+
+export interface UiBindableEventPayloadMeta {
+  readonly eventType: UiComponentEventPayloadKind;
+  readonly fields?: readonly UiComponentEventPayloadFieldMeta[];
+}
+
+export interface UiBindableEventMeta {
+  readonly label?: string;
+  readonly description?: string;
+  readonly payload?: UiBindableEventPayloadMeta;
+}
+
+export interface UiComponentBindingMeta {
+  readonly props?: Readonly<Record<string, UiBindablePropMeta>>;
+  readonly events?: Readonly<Record<string, UiBindableEventMeta>>;
+}
+
 export interface UiComponentSlotMeta {
   readonly label?: string;
   readonly allowedChildren?: readonly string[];
@@ -96,6 +148,7 @@ export interface UiComponentMeta {
   readonly description?: string;
   readonly directManifestNode: boolean;
   readonly allowedChildren: readonly string[];
+  readonly bindings?: UiComponentBindingMeta;
   readonly blueprint?: UiComponentBlueprint;
   readonly events?: Readonly<Record<string, UiComponentEventMeta>>;
   readonly i18n?: UiComponentI18nMeta;


### PR DESCRIPTION
## Summary

Implements #49.

Adds bindable metadata contracts to the neutral `UiComponentMeta` model so UI packages can declare which component props and events are data-bindable.

Adds:

- `UiBindableValueType`
- `UiBindableValueFieldMeta`
- `UiBindableValueMeta`
- `UiBindablePropMeta`
- `UiBindableEventPayloadMeta`
- `UiBindableEventMeta`
- `UiComponentBindingMeta`
- optional `bindings` field on `UiComponentMeta`

Also adds serialization tests for:

- bindable Button props/events
- bindable List collection item fields/events
- metadata registries with bindable props
- extension package manifests with bindable props/events

## Scope intentionally excluded

- no actual component instance binding model from #48
- no replacement of `src/bindings.ts`
- no ZORA metadata migration
- no Studio UI changes
- no Runtime changes

## Verification

I could not run local validation from this session because the environment cannot reliably clone/resolve GitHub repositories.

Please run before merge:

```bash
bun install
bun run build
bun run lint:fix
bun run test
```

## Notes

This PR extends the generic component metadata model from #46. It does not define concrete app/component instance bindings; that remains the next step in #48.