### PR TITLE
feat(bindings): add component data-binding contracts

### DIFF
--- a/.changeset/component-data-binding-contracts.md
+++ b/.changeset/component-data-binding-contracts.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Replace node-local prop bindings with app-level component data-binding contracts that reference data-source operations.

--- a/src/bindings.test.ts
+++ b/src/bindings.test.ts
@@ -1,96 +1,316 @@
 import { describe, expect, it } from 'bun:test';
 
 import type {
+  AppManifest,
+  BindingInputMap,
   BindingValueSource,
-  DbCollectionQueryBinding,
-  NodePropBinding,
-  UiNode,
+  ComponentDataBinding,
+  ComponentDataBindingRegistry,
+  EventBinding,
+  PropBinding,
 } from './index';
 
-describe('binding contracts', () => {
-  it('serializes a node prop bound to state', () => {
-    const binding: NodePropBinding = {
-      prop: 'value',
-      valueFrom: {
-        source: 'state',
-        path: 'forms.contact.values.firstname',
-      },
-      transform: 'trim',
-    };
-    const node: UiNode = {
-      id: 'firstname-input',
-      type: 'Input',
+function assertSerializable<TValue>(value: TValue): void {
+  expect(JSON.parse(JSON.stringify(value))).toEqual(value);
+}
+
+describe('component data-binding contracts', () => {
+  it('serializes a component prop bound to an operation response path', () => {
+    const binding: ComponentDataBinding = {
+      componentId: 'hero-title',
+      componentType: 'Text',
       props: {
-        label: 'Firstname',
+        children: {
+          source: {
+            kind: 'operation',
+            operation: {
+              dataSourceId: 'cms',
+              endpointId: 'pages',
+              operationId: 'pages.getHome',
+            },
+            path: '$.data.title',
+          },
+          fallback: {
+            value: 'Untitled',
+          },
+          loading: {
+            state: 'loading',
+            fallback: {
+              value: 'Loading…',
+            },
+          },
+          error: {
+            state: 'error',
+            message: 'Could not load title.',
+            fallback: {
+              value: 'Untitled',
+            },
+          },
+          transforms: ['trim'],
+        },
       },
-      bindings: [binding],
     };
 
-    expect(JSON.parse(JSON.stringify(node))).toEqual(node);
-    expect(node.bindings?.[0]?.valueFrom.source).toBe('state');
+    assertSerializable(binding);
+    expect(binding.props?.children?.source.kind).toBe('operation');
   });
 
-  it('serializes a node prop bound to a DB collection query', () => {
-    const query: DbCollectionQueryBinding = {
-      collection: 'posts',
-      schema: 'public',
-      columns: ['id', 'title', 'published'],
-      filters: [{ field: 'published', operator: 'eq', value: true }],
-      sort: [{ field: 'created_at', direction: 'desc' }],
-      page: { limit: 10, offset: 0 },
-      refresh: 'live',
+  it('serializes literal, context, event, state, and operation value sources', () => {
+    const sources: readonly BindingValueSource[] = [
+      { kind: 'literal', value: { fallback: 'Untitled' } },
+      { kind: 'context', path: 'auth.user.displayName' },
+      { kind: 'event', path: 'payload.values.search' },
+      { kind: 'state', path: 'forms.search.query' },
+      {
+        kind: 'operation',
+        operation: {
+          dataSourceId: 'search-api',
+          operationId: 'search.query',
+        },
+        path: '$.results',
+      },
+    ];
+
+    assertSerializable(sources);
+    expect(sources.map((source) => source.kind)).toEqual([
+      'literal',
+      'context',
+      'event',
+      'state',
+      'operation',
+    ]);
+  });
+
+  it('serializes an event binding that executes a data-source operation', () => {
+    const input: BindingInputMap = {
+      email: {
+        kind: 'source',
+        source: {
+          kind: 'event',
+          path: 'payload.values.email',
+        },
+        transforms: ['trim', 'lowercase'],
+      },
+      message: {
+        kind: 'source',
+        source: {
+          kind: 'event',
+          path: 'payload.values.message',
+        },
+      },
+      source: {
+        kind: 'literal',
+        value: 'contact-form',
+      },
+      metadata: {
+        kind: 'object',
+        fields: {
+          userId: {
+            kind: 'source',
+            source: {
+              kind: 'context',
+              path: 'auth.user.id',
+            },
+          },
+        },
+      },
     };
-    const node: UiNode = {
-      id: 'posts-list',
-      type: 'CollectionList',
-      bindings: [
+
+    const binding: EventBinding = {
+      target: {
+        kind: 'operation',
+        operation: {
+          dataSourceId: 'contact-api',
+          endpointId: 'messages',
+          operationId: 'messages.create',
+        },
+      },
+      input,
+      when: {
+        source: {
+          kind: 'event',
+          path: 'payload.values.email',
+        },
+        operator: 'exists',
+      },
+    };
+
+    assertSerializable(binding);
+    expect(binding.target.kind).toBe('operation');
+    expect(binding.input?.email?.kind).toBe('source');
+  });
+
+  it('serializes an event binding that targets a named action', () => {
+    const binding: EventBinding = {
+      target: {
+        kind: 'action',
+        type: 'toast.show',
+      },
+      input: {
+        message: {
+          kind: 'literal',
+          value: 'Saved successfully.',
+        },
+      },
+    };
+
+    assertSerializable(binding);
+    expect(binding.target.kind).toBe('action');
+  });
+
+  it('serializes component data-binding registries', () => {
+    const bindings: ComponentDataBindingRegistry = {
+      'submit-button': {
+        componentId: 'submit-button',
+        componentType: 'Button',
+        props: {
+          children: {
+            source: {
+              kind: 'literal',
+              value: 'Send',
+            },
+          },
+          disabled: {
+            source: {
+              kind: 'state',
+              path: 'forms.contact.isSubmitting',
+            },
+          },
+        },
+        events: {
+          press: [
+            {
+              target: {
+                kind: 'operation',
+                operation: {
+                  dataSourceId: 'contact-api',
+                  operationId: 'messages.create',
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    assertSerializable(bindings);
+    expect(bindings['submit-button']?.events?.press?.[0]?.target.kind).toBe('operation');
+  });
+
+  it('serializes app-level dataSources and dataBindings on the manifest', () => {
+    const propBinding: PropBinding = {
+      source: {
+        kind: 'operation',
+        operation: {
+          dataSourceId: 'cms',
+          endpointId: 'pages',
+          operationId: 'pages.getHome',
+        },
+        path: '$.data.heroTitle',
+      },
+    };
+
+    const manifest: AppManifest = {
+      metadata: {
+        name: 'Demo',
+        slug: 'demo',
+        version: '1.0.0',
+        themeId: 'default',
+      },
+      themes: [
         {
-          prop: 'items',
-          valueFrom: {
-            source: 'db.collection',
-            query,
+          id: 'default',
+          name: 'Default',
+          light: {
+            primaryColor: '#3366ff',
+            harmony: 'analogous',
+          },
+          dark: {
+            primaryColor: '#3366ff',
+            harmony: 'analogous',
           },
         },
       ],
-    };
-
-    expect(JSON.parse(JSON.stringify(node))).toEqual(node);
-    expect(node.bindings?.[0]?.valueFrom.source).toBe('db.collection');
-  });
-
-  it('supports literal, context, and event value sources', () => {
-    const sources: readonly BindingValueSource[] = [
-      { source: 'literal', value: { fallback: 'Untitled' } },
-      { source: 'context', path: 'auth.user.displayName' },
-      { source: 'event', path: 'payload.values.search' },
-    ];
-
-    expect(JSON.parse(JSON.stringify(sources))).toEqual(sources);
-    expect(sources.map((source) => source.source)).toEqual(['literal', 'context', 'event']);
-  });
-
-  it('supports static, focus, poll, and live refresh intent', () => {
-    const refreshModes = ['static', 'focus', 'poll', 'live'] as const;
-    const bindings = refreshModes.map(
-      (refresh): NodePropBinding => ({
-        prop: `items.${refresh}`,
-        valueFrom: {
-          source: 'db.collection',
-          query: {
-            collection: 'posts',
-            refresh,
-            pollIntervalMs: refresh === 'poll' ? 30_000 : undefined,
+      activeThemeId: 'default',
+      infra: {
+        plugins: [],
+      },
+      navigator: {
+        type: 'stack',
+        routes: [
+          {
+            name: 'home',
+            screenId: 'home',
+          },
+        ],
+      },
+      screens: {
+        home: {
+          id: 'home',
+          name: 'Home',
+          root: {
+            id: 'screen-root',
+            type: 'Screen',
+            children: [
+              {
+                id: 'hero-title',
+                type: 'Text',
+              },
+            ],
           },
         },
-      }),
-    );
+      },
+      dataSources: {
+        cms: {
+          id: 'cms',
+          kind: 'rest',
+          baseUrl: 'https://cms.example.com',
+          endpoints: {
+            pages: {
+              id: 'pages',
+              kind: 'http',
+              path: '/pages/home',
+              operations: {
+                'pages.getHome': {
+                  id: 'pages.getHome',
+                  endpointId: 'pages',
+                  protocol: 'http',
+                  intent: 'read',
+                  method: 'GET',
+                  path: '/pages/home',
+                },
+              },
+            },
+          },
+        },
+      },
+      dataBindings: {
+        'hero-title': {
+          componentId: 'hero-title',
+          componentType: 'Text',
+          props: {
+            children: propBinding,
+          },
+        },
+      },
+      settings: {
+        localization: {
+          defaultLocale: 'en',
+          locales: ['en'],
+        },
+        authFlow: {
+          signInRoute: '/sign-in',
+          signUpRoute: '/sign-up',
+          signOutRoute: '/sign-out',
+          forgotPasswordRoute: '/forgot-password',
+          postSignInRoute: '/',
+          unauthorizedRoute: '/sign-in',
+        },
+      },
+    };
 
-    expect(JSON.parse(JSON.stringify(bindings))).toEqual(bindings);
-    expect(bindings.map((binding) => binding.valueFrom.source)).toEqual([
-      'db.collection',
-      'db.collection',
-      'db.collection',
-      'db.collection',
-    ]);
+    assertSerializable(manifest);
+    expect(manifest.dataBindings?.['hero-title']?.props?.children?.source.kind).toBe('operation');
+    expect(manifest.dataSources?.cms?.kind).toBe('rest');
   });
 });

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,4 +1,7 @@
-import type { DbFilter, DbPage, DbSort } from './db';
+import type { DataSourceId, EndpointId, OperationId } from './data';
+
+export type ComponentInstanceId = string;
+export type ComponentTypeId = string;
 
 export type BindingValue =
   | string
@@ -10,45 +13,116 @@ export type BindingValue =
       readonly [key: string]: BindingValue;
     };
 
-export type BindingRefreshMode = 'focus' | 'live' | 'poll' | 'static';
+export type BindingDataPath = string;
 
-export interface DbCollectionQueryBinding {
-  readonly collection: string;
-  readonly schema?: string;
-  readonly columns?: readonly string[];
-  readonly filters?: readonly DbFilter[];
-  readonly sort?: readonly DbSort[];
-  readonly page?: DbPage;
-  readonly refresh?: BindingRefreshMode;
-  readonly pollIntervalMs?: number;
+export type BindingValueTransform = 'lowercase' | 'trim' | 'uppercase';
+
+export interface BindingOperationRef {
+  readonly dataSourceId: DataSourceId;
+  readonly operationId: OperationId;
+  readonly endpointId?: EndpointId;
 }
 
 export type BindingValueSource =
   | {
-      readonly source: 'context';
-      readonly path: string;
+      readonly kind: 'context';
+      readonly path: BindingDataPath;
     }
   | {
-      readonly source: 'db.collection';
-      readonly query: DbCollectionQueryBinding;
+      readonly kind: 'event';
+      readonly path: BindingDataPath;
     }
   | {
-      readonly source: 'event';
-      readonly path: string;
-    }
-  | {
-      readonly source: 'literal';
+      readonly kind: 'literal';
       readonly value: BindingValue;
     }
   | {
-      readonly source: 'state';
-      readonly path: string;
+      readonly kind: 'operation';
+      readonly operation: BindingOperationRef;
+      readonly path?: BindingDataPath;
+    }
+  | {
+      readonly kind: 'state';
+      readonly path: BindingDataPath;
     };
 
-export type BindingValueTransform = 'lowercase' | 'trim' | 'uppercase';
-
-export interface NodePropBinding {
-  readonly prop: string;
-  readonly valueFrom: BindingValueSource;
-  readonly transform?: BindingValueTransform | readonly BindingValueTransform[];
+export interface BindingValueExpression {
+  readonly source: BindingValueSource;
+  readonly transforms?: readonly BindingValueTransform[];
 }
+
+export interface BindingFallback {
+  readonly value?: BindingValue;
+  readonly source?: BindingValueSource;
+}
+
+export type BindingLifecycleState = 'empty' | 'error' | 'loading';
+
+export interface BindingLifecycleBehavior {
+  readonly state: BindingLifecycleState;
+  readonly fallback?: BindingFallback;
+  readonly message?: string;
+}
+
+export interface PropBinding {
+  readonly source: BindingValueSource;
+  readonly fallback?: BindingFallback;
+  readonly loading?: BindingLifecycleBehavior;
+  readonly error?: BindingLifecycleBehavior;
+  readonly empty?: BindingLifecycleBehavior;
+  readonly transforms?: readonly BindingValueTransform[];
+}
+
+export type BindingInputValue =
+  | {
+      readonly kind: 'array';
+      readonly items: readonly BindingInputValue[];
+    }
+  | {
+      readonly kind: 'literal';
+      readonly value: BindingValue;
+    }
+  | {
+      readonly kind: 'object';
+      readonly fields: Readonly<Record<string, BindingInputValue>>;
+    }
+  | {
+      readonly kind: 'source';
+      readonly source: BindingValueSource;
+      readonly transforms?: readonly BindingValueTransform[];
+    };
+
+export type BindingInputMap = Readonly<Record<string, BindingInputValue>>;
+
+export type BindingConditionOperator = 'eq' | 'exists' | 'neq' | 'notExists';
+
+export interface BindingCondition {
+  readonly source: BindingValueSource;
+  readonly operator: BindingConditionOperator;
+  readonly value?: BindingValue;
+}
+
+export type EventBindingTarget =
+  | {
+      readonly kind: 'action';
+      readonly type: string;
+    }
+  | {
+      readonly kind: 'operation';
+      readonly operation: BindingOperationRef;
+    };
+
+export interface EventBinding {
+  readonly target: EventBindingTarget;
+  readonly input?: BindingInputMap;
+  readonly when?: BindingCondition;
+}
+
+export interface ComponentDataBinding {
+  readonly componentId: ComponentInstanceId;
+  readonly componentType?: ComponentTypeId;
+  readonly props?: Readonly<Record<string, PropBinding>>;
+  readonly events?: Readonly<Record<string, readonly EventBinding[]>>;
+}
+
+export type ComponentDataBindingRegistry = Readonly<Record<ComponentInstanceId, ComponentDataBinding>>;

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -125,4 +125,6 @@ export interface ComponentDataBinding {
   readonly events?: Readonly<Record<string, readonly EventBinding[]>>;
 }
 
-export type ComponentDataBindingRegistry = Readonly<Record<ComponentInstanceId, ComponentDataBinding>>;
+export type ComponentDataBindingRegistry = Readonly<
+  Record<ComponentInstanceId, ComponentDataBinding>
+>;

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -5,8 +5,6 @@ import { COLOR_HARMONIES } from '@ankhorage/color-theory';
 import { describe, expect, it } from 'bun:test';
 
 import {
-  type ActionBinding,
-  type ActionValueSource,
   APP_CATEGORIES,
   type AppCategory,
   AUTH_PROVIDERS,
@@ -21,22 +19,16 @@ import {
   type DbAdapter,
   type DbAdminAdapter,
   type DbChangeEvent,
-  type DbPersistActionBinding,
-  type DbPersistCommand,
   type DbRealtimeAdapter,
   DEPLOYMENT_TARGETS,
-  type EmailSendActionBinding,
   type FormSubmitEventDto,
   type ImageAssetSource,
-  type KnownActionBinding,
-  type KnownCommandDto,
   NAVIGATOR_TYPES,
   type StoragePublicUrlResult,
   type StorageResult,
   type StorageUploadResult,
   type ThemeConfig,
   type ThemeModeConfig,
-  type UiNode,
 } from './index';
 
 async function collectTypeScriptFiles(directory: string): Promise<string[]> {
@@ -236,55 +228,6 @@ describe('contracts', () => {
     expect(JSON.parse(JSON.stringify(source))).toEqual(source);
   });
 
-  it('serializes node event bindings for submit actions', () => {
-    const node: UiNode = {
-      id: 'contact-form',
-      type: 'Form',
-      props: {
-        title: 'Contact us',
-      },
-      events: {
-        submit: [
-          {
-            type: 'email.send',
-            payload: {
-              to: 'info@example.com',
-              subject: 'New contact message',
-              bodyFrom: 'payload.values.message',
-            },
-          },
-          {
-            type: 'db.persist',
-            payload: {
-              collection: 'contact_messages',
-              mode: 'columns',
-            },
-          },
-        ],
-      },
-    };
-
-    expect(JSON.parse(JSON.stringify(node))).toEqual(node);
-    expect(node.events?.submit?.map((action) => action.type)).toEqual(['email.send', 'db.persist']);
-  });
-
-  it('accepts conditional node event bindings', () => {
-    const binding: ActionBinding = {
-      type: 'db.persist',
-      payload: {
-        collection: 'contact_messages',
-      },
-      when: {
-        source: 'event',
-        path: 'payload.values.email',
-        operator: 'exists',
-      },
-    };
-
-    expect(binding.when?.operator).toBe('exists');
-    expect(binding.payload?.collection).toBe('contact_messages');
-  });
-
   it('serializes normalized form submit event DTOs', () => {
     const event: FormSubmitEventDto = {
       type: 'form.submit',
@@ -342,121 +285,6 @@ describe('contracts', () => {
 
     expect(event.payload.mediaId).toBe('video-1');
     expect(knownEventType).toBe('form.submit');
-  });
-
-  it('serializes provider-neutral value sources for action payloads', () => {
-    const sources: readonly ActionValueSource[] = [
-      { source: 'event', path: 'payload.values.email' },
-      { source: 'literal', value: 'website-contact-form' },
-      { source: 'context', path: 'auth.user.id' },
-      { source: 'state', path: 'forms.contact.isSubmitting' },
-    ];
-
-    expect(JSON.parse(JSON.stringify(sources))).toEqual(sources);
-    expect(sources.map((source) => source.source)).toEqual([
-      'event',
-      'literal',
-      'context',
-      'state',
-    ]);
-  });
-
-  it('serializes a typed db.persist action binding', () => {
-    const binding: DbPersistActionBinding = {
-      type: 'db.persist',
-      payload: {
-        collection: 'contact_messages',
-        mode: 'columns',
-        values: [
-          {
-            field: 'firstname',
-            valueFrom: { source: 'event', path: 'payload.values.firstname' },
-            transform: 'trim',
-          },
-          {
-            field: 'message',
-            valueFrom: { source: 'event', path: 'payload.values.message' },
-          },
-          {
-            field: 'source',
-            valueFrom: { source: 'literal', value: 'website-contact-form' },
-          },
-        ],
-      },
-    };
-
-    expect(JSON.parse(JSON.stringify(binding))).toEqual(binding);
-    expect(binding.payload.values.map((value) => value.field)).toEqual([
-      'firstname',
-      'message',
-      'source',
-    ]);
-  });
-
-  it('serializes a typed email.send action binding', () => {
-    const binding: EmailSendActionBinding = {
-      type: 'email.send',
-      payload: {
-        to: 'info@example.com',
-        subject: 'New contact message',
-        bodyFrom: { source: 'event', path: 'payload.values.message' },
-      },
-    };
-
-    expect(JSON.parse(JSON.stringify(binding))).toEqual(binding);
-    expect(binding.payload.bodyFrom?.source).toBe('event');
-  });
-
-  it('accepts typed action bindings in node event bindings', () => {
-    const persist: DbPersistActionBinding = {
-      type: 'db.persist',
-      payload: {
-        collection: 'contact_messages',
-        values: [
-          {
-            field: 'message',
-            valueFrom: { source: 'event', path: 'payload.values.message' },
-          },
-        ],
-      },
-    };
-    const email: EmailSendActionBinding = {
-      type: 'email.send',
-      payload: {
-        to: 'info@example.com',
-        bodyFrom: { source: 'event', path: 'payload.values.message' },
-      },
-    };
-    const node: UiNode = {
-      id: 'contact-form',
-      type: 'Form',
-      events: {
-        submit: [persist, email],
-      },
-    };
-    const known: KnownActionBinding = persist;
-
-    expect(node.events?.submit?.map((action) => action.type)).toEqual(['db.persist', 'email.send']);
-    expect(known.type).toBe('db.persist');
-  });
-
-  it('serializes a normalized db.persist command DTO', () => {
-    const command: DbPersistCommand = {
-      type: 'db.persist.command',
-      payload: {
-        operation: 'insert',
-        collection: 'contact_messages',
-        mode: 'columns',
-        values: {
-          firstname: 'Fabio',
-          message: 'This is my contact message',
-        },
-      },
-    };
-    const knownCommand: KnownCommandDto = command;
-
-    expect(JSON.parse(JSON.stringify(command))).toEqual(command);
-    expect(knownCommand.type).toBe('db.persist.command');
   });
 
   it('accepts a provider-neutral CRUD database adapter', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 import type { ColorHarmony } from '@ankhorage/color-theory';
 
 import type { AuthFlowConfig, AuthIdentifierKind, AuthSignUpField } from './auth';
-import type { NodePropBinding } from './bindings';
+import type { ComponentDataBindingRegistry } from './bindings';
+import type { DataSourceRegistry } from './data';
 
 export interface ThemeModeConfig {
   primaryColor: string;
@@ -88,121 +89,6 @@ export type ManifestValue =
   | null
   | readonly ManifestValue[]
   | { readonly [key: string]: ManifestValue };
-
-export type ActionValue = ManifestValue;
-
-export type ActionBindingPayload = Record<string, ActionValue>;
-
-export type ActionConditionSource = 'context' | 'event' | 'state';
-
-export type ActionConditionOperator = 'eq' | 'exists' | 'neq' | 'notExists';
-
-export interface ActionCondition {
-  readonly source: ActionConditionSource;
-  readonly path: string;
-  readonly operator: ActionConditionOperator;
-  readonly value?: ActionValue;
-}
-
-export type ActionValueSource =
-  | {
-      readonly source: 'context';
-      readonly path: string;
-    }
-  | {
-      readonly source: 'event';
-      readonly path: string;
-    }
-  | {
-      readonly source: 'literal';
-      readonly value: ActionValue;
-    }
-  | {
-      readonly source: 'state';
-      readonly path: string;
-    };
-
-export type ActionValueTransform = 'lowercase' | 'trim' | 'uppercase';
-
-export interface ActionValueBinding {
-  readonly valueFrom: ActionValueSource;
-  readonly transform?: ActionValueTransform | readonly ActionValueTransform[];
-}
-
-export interface ActionBinding<
-  TType extends string = string,
-  TPayload extends object = ActionBindingPayload,
-> {
-  readonly type: TType;
-  readonly payload?: TPayload;
-  readonly when?: ActionCondition;
-}
-
-export type DbPersistMode = 'columns' | 'json';
-
-export interface DbPersistFieldBinding {
-  readonly field: string;
-  readonly valueFrom: ActionValueSource;
-  readonly transform?: ActionValueTransform | readonly ActionValueTransform[];
-}
-
-export interface DbPersistActionPayload {
-  readonly collection: string;
-  readonly kind?: string;
-  readonly mode?: DbPersistMode;
-  readonly jsonField?: string;
-  readonly values: readonly DbPersistFieldBinding[];
-}
-
-export interface DbPersistActionBinding extends ActionBinding<
-  'db.persist',
-  DbPersistActionPayload
-> {
-  readonly payload: DbPersistActionPayload;
-}
-
-export interface EmailSendActionPayload {
-  readonly to: string;
-  readonly subject?: string;
-  readonly body?: string;
-  readonly bodyFrom?: ActionValueSource;
-}
-
-export interface EmailSendActionBinding extends ActionBinding<
-  'email.send',
-  EmailSendActionPayload
-> {
-  readonly payload: EmailSendActionPayload;
-}
-
-export type KnownActionBinding = DbPersistActionBinding | EmailSendActionBinding;
-
-export type UiNodeEventBindings = Record<string, readonly ActionBinding<string, object>[]>;
-
-export interface CommandDto<
-  TType extends string = string,
-  TPayload extends object = Record<string, ActionValue>,
-> {
-  readonly type: TType;
-  readonly payload: TPayload;
-}
-
-export type DbPersistOperation = 'insert';
-
-export type DbPersistCommandValues = Record<string, ActionValue>;
-
-export interface DbPersistCommandPayload {
-  readonly operation: DbPersistOperation;
-  readonly collection: string;
-  readonly kind?: string;
-  readonly mode?: DbPersistMode;
-  readonly jsonField?: string;
-  readonly values: DbPersistCommandValues;
-}
-
-export type DbPersistCommand = CommandDto<'db.persist.command', DbPersistCommandPayload>;
-
-export type KnownCommandDto = DbPersistCommand;
 
 export type ComponentEventPayloadValue = ManifestValue;
 
@@ -331,10 +217,8 @@ export interface UiNode {
   type: string;
   alias?: string;
   props?: Record<string, unknown>;
-  bindings?: readonly NodePropBinding[];
   children?: UiNode[];
   style?: Record<string, number | string>;
-  events?: UiNodeEventBindings;
 }
 
 export interface ScreenSpec {
@@ -437,6 +321,8 @@ export interface AppManifest {
   infra: InfraManifest;
   navigator: NavigatorSpec;
   screens: Record<string, ScreenSpec>;
+  dataSources?: DataSourceRegistry;
+  dataBindings?: ComponentDataBindingRegistry;
   settings: {
     apiBaseUrl?: string;
     localization: {


### PR DESCRIPTION
## Summary

Implements #48.

Replaces the old node-local prop binding model with app-level component data-binding contracts.

Adds/reworks:

- `ComponentInstanceId`
- `ComponentTypeId`
- `BindingOperationRef`
- `BindingValueSource`
- `BindingValueExpression`
- `BindingFallback`
- `BindingLifecycleBehavior`
- `PropBinding`
- `BindingInputValue`
- `BindingInputMap`
- `BindingCondition`
- `EventBindingTarget`
- `EventBinding`
- `ComponentDataBinding`
- `ComponentDataBindingRegistry`
- `AppManifest.dataSources`
- `AppManifest.dataBindings`

Removes from the public model:

- `NodePropBinding`
- `DbCollectionQueryBinding`
- special `source: 'db.collection'` binding source
- node-local `UiNode.bindings`
- node-local `UiNode.events`
- old action-binding contract layer from `types.ts`

## Scope intentionally excluded

- no Runtime resolver implementation
- no Studio UI migration
- no ZORA metadata migration
- no `@ankhorage/data-sources` implementation

Those are follow-up repo-local tasks.

## Verification

I could not run local validation from this session because the environment cannot reliably clone/resolve GitHub repositories.

Please run before merge:

```bash
bun install
bun run build
bun run lint:fix
bun run test
```

## Notes

DB-backed reads are now represented through data-source operation references instead of the old direct `db.collection` binding source. Runtime lifecycle/cache state remains outside the serializable binding contracts.