### PR TITLE
feat(auth): add OAuth2 auth contracts

### DIFF
--- a/.changeset/clean-apples-approve.md
+++ b/.changeset/clean-apples-approve.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": minor
+'@ankhorage/contracts': minor
 ---
 
 Add provider-neutral OAuth2 auth contracts and manifest auth config support.

--- a/.changeset/clean-apples-approve.md
+++ b/.changeset/clean-apples-approve.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": minor
+---
+
+Add provider-neutral OAuth2 auth contracts and manifest auth config support.

--- a/src/auth-oauth.test.ts
+++ b/src/auth-oauth.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  AUTH_OAUTH_PROVIDER_IDS,
+  type AuthAdapter,
+  type AuthOAuthConfig,
+  type AuthSpec,
+} from './index';
+
+describe('OAuth auth contracts', () => {
+  it('accepts provider-neutral OAuth provider config on auth specs', () => {
+    const oauth: AuthOAuthConfig = {
+      enabled: true,
+      callbackRoute: '/auth/callback',
+      providers: [
+        {
+          id: 'google',
+          label: 'Google',
+          enabled: true,
+          scopes: ['openid', 'email', 'profile'],
+          icon: {
+            provider: 'FontAwesome',
+            name: 'google',
+          },
+        },
+        {
+          id: 'custom-sso',
+          label: 'Custom SSO',
+          enabled: false,
+          redirectTo: '/auth/custom/callback',
+          queryParams: {
+            prompt: 'select_account',
+          },
+        },
+      ],
+    };
+
+    const auth: AuthSpec = {
+      scope: 'global',
+      provider: 'supabase',
+      authorization: { kind: 'RBAC', engine: 'native' },
+      oauth,
+    };
+
+    expect(AUTH_OAUTH_PROVIDER_IDS.includes('google')).toBe(true);
+    expect(auth.oauth?.providers[0]?.icon?.name).toBe('google');
+    expect(auth.oauth?.providers[1]?.id).toBe('custom-sso');
+    expect(auth.oauth?.providers[1]?.enabled).toBe(false);
+  });
+
+  it('accepts optional OAuth adapter capabilities and redirect flow methods', async () => {
+    const adapter: AuthAdapter = {
+      capabilities: {
+        signInIdentifiers: ['email'],
+        supportsSignUp: true,
+        supportsPasswordReset: true,
+        supportsOtp: true,
+        supportsSessionRefresh: true,
+        supportsOAuth: true,
+        oauthProviders: ['google', 'custom-sso'],
+      },
+      signIn() {
+        return Promise.resolve({
+          ok: false,
+          error: { code: 'unsupported', message: 'Password sign-in is not implemented.' },
+        });
+      },
+      signUp() {
+        return Promise.resolve({
+          ok: false,
+          error: { code: 'unsupported', message: 'Sign-up is not implemented.' },
+        });
+      },
+      signOut() {
+        return Promise.resolve({ ok: true });
+      },
+      getSession() {
+        return Promise.resolve({ ok: true, data: null });
+      },
+      signInWithOAuth(input) {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            provider: input.provider,
+            url: `https://auth.example.com/oauth/${input.provider}`,
+          },
+        });
+      },
+    };
+
+    const result = await adapter.signInWithOAuth?.({
+      provider: 'google',
+      redirectTo: '/auth/callback',
+      scopes: ['openid', 'email', 'profile'],
+    });
+
+    expect(adapter.capabilities?.supportsOAuth).toBe(true);
+    expect(adapter.capabilities?.oauthProviders).toEqual(['google', 'custom-sso']);
+    expect(result?.ok).toBe(true);
+    expect(result?.ok === true ? result.data?.provider : undefined).toBe('google');
+    expect(result?.ok === true ? result.data?.url : undefined).toContain('/oauth/google');
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,5 @@
+import type { IconSpec } from './types';
+
 export const AUTH_IDENTIFIER_KINDS = ['email', 'phone', 'username'] as const;
 export type AuthIdentifierKind = (typeof AUTH_IDENTIFIER_KINDS)[number];
 
@@ -10,6 +12,30 @@ export const AUTH_SIGN_UP_FIELDS = [
 ] as const;
 export type KnownAuthSignUpField = (typeof AUTH_SIGN_UP_FIELDS)[number];
 export type AuthSignUpField = KnownAuthSignUpField | (string & {});
+
+export const AUTH_OAUTH_PROVIDER_IDS = [
+  'apple',
+  'azure',
+  'bitbucket',
+  'discord',
+  'facebook',
+  'figma',
+  'github',
+  'gitlab',
+  'google',
+  'kakao',
+  'keycloak',
+  'linkedin',
+  'notion',
+  'slack',
+  'spotify',
+  'twitch',
+  'twitter',
+  'workos',
+  'zoom',
+] as const;
+export type KnownAuthOAuthProviderId = (typeof AUTH_OAUTH_PROVIDER_IDS)[number];
+export type AuthOAuthProviderId = KnownAuthOAuthProviderId | (string & {});
 
 export interface AuthIdentifier {
   kind: AuthIdentifierKind;
@@ -35,11 +61,28 @@ export interface AuthSignUpConfig {
   optionalFields?: AuthSignUpField[];
 }
 
+export interface AuthOAuthProviderConfig {
+  id: AuthOAuthProviderId;
+  label?: string;
+  enabled?: boolean;
+  scopes?: string[];
+  redirectTo?: string;
+  queryParams?: Record<string, string>;
+  icon?: IconSpec;
+}
+
+export interface AuthOAuthConfig {
+  enabled: boolean;
+  callbackRoute: string;
+  providers: AuthOAuthProviderConfig[];
+}
+
 export interface AuthProviderConfig {
   provider: string;
   flow: AuthFlowConfig;
   signIn: AuthSignInConfig;
   signUp?: AuthSignUpConfig;
+  oauth?: AuthOAuthConfig;
   passwordReset?: {
     enabled: boolean;
   };
@@ -114,12 +157,32 @@ export interface VerifyOtpInput {
   metadata?: Record<string, unknown>;
 }
 
+export interface SignInWithOAuthInput {
+  provider: AuthOAuthProviderId;
+  redirectTo?: string;
+  scopes?: string[];
+  queryParams?: Record<string, string>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuthOAuthRedirect {
+  provider: AuthOAuthProviderId;
+  url: string;
+}
+
+export interface CompleteOAuthSignInInput {
+  url: string;
+  redirectTo?: string;
+}
+
 export interface AuthAdapterCapabilities {
   signInIdentifiers: AuthIdentifierKind[];
   supportsSignUp: boolean;
   supportsPasswordReset: boolean;
   supportsOtp: boolean;
   supportsSessionRefresh: boolean;
+  supportsOAuth?: boolean;
+  oauthProviders?: AuthOAuthProviderId[];
 }
 
 export interface AuthAdapter {
@@ -134,4 +197,7 @@ export interface AuthAdapter {
 
   requestPasswordReset?(input: PasswordResetInput): Promise<AuthResult>;
   verifyOtp?(input: VerifyOtpInput): Promise<AuthResult<AuthSession>>;
+
+  signInWithOAuth?(input: SignInWithOAuthInput): Promise<AuthResult<AuthOAuthRedirect>>;
+  completeOAuthSignIn?(input: CompleteOAuthSignInInput): Promise<AuthResult<AuthSession>>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,6 @@
 import type { ColorHarmony } from '@ankhorage/color-theory';
 
-import type {
-  AuthFlowConfig,
-  AuthIdentifierKind,
-  AuthOAuthConfig,
-  AuthSignUpField,
-} from './auth';
+import type { AuthFlowConfig, AuthIdentifierKind, AuthOAuthConfig, AuthSignUpField } from './auth';
 import type { ComponentDataBindingRegistry } from './bindings';
 import type { DataSourceRegistry } from './data';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,11 @@
 import type { ColorHarmony } from '@ankhorage/color-theory';
 
-import type { AuthFlowConfig, AuthIdentifierKind, AuthSignUpField } from './auth';
+import type {
+  AuthFlowConfig,
+  AuthIdentifierKind,
+  AuthOAuthConfig,
+  AuthSignUpField,
+} from './auth';
 import type { ComponentDataBindingRegistry } from './bindings';
 import type { DataSourceRegistry } from './data';
 
@@ -288,6 +293,7 @@ export interface AuthSpec {
   flow?: AuthFlowConfig;
   signIn?: AuthSignInSpec;
   signUp?: AuthSignUpSpec;
+  oauth?: AuthOAuthConfig;
   profile?: AuthProfileSpec;
 }
 


### PR DESCRIPTION
## Summary

- add provider-neutral OAuth2 provider IDs/config types
- add optional OAuth2 adapter capabilities and redirect-flow methods
- expose `oauth` config on manifest `AuthSpec`
- add focused OAuth contract tests
- add a minor changeset for `@ankhorage/contracts`

Closes #58.

## Verification

Not run locally; changes were made through GitHub connector. CI should run the package checks on this PR.

Expected package checks:

- `bun run build`
- `bun run lint:fix`
- `bun run test`