### PR TITLE
feat(auth): add profile provisioning contract

### DIFF
--- a/.changeset/profile-table.md
+++ b/.changeset/profile-table.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": minor
+'@ankhorage/contracts': minor
 ---
 
 Add profile table metadata to auth profile specs.

--- a/.changeset/profile-table.md
+++ b/.changeset/profile-table.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": minor
+---
+
+Add profile table metadata to auth profile specs.

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 Shared public contracts for Ankhorage packages and standalone provider packages.
 
-## 🎯 What you get
+## What you get
 
 - Strongly typed app structures
 - Serializable schemas for app manifests and UI definitions
 - Provider-neutral runtime contracts for auth and database adapters
 - Clear contracts between systems without depending on framework internals
 
-## ✨ Features
+## Features
 
 - Serializable app, action, theme, infra, and auth config contracts
 - UI and navigation definitions
-- Auth adapter contracts using `signIn`, `signUp`, and `signOut` naming
+- Auth adapter contracts using signIn, signUp, and signOut naming
 - Database adapter contracts for provider-neutral CRUD-style access
 - Dedicated subpath exports for focused imports
 
-## 📦 Usage
+## Usage
 
 ```ts
 import type { AppManifest } from '@ankhorage/contracts';
@@ -71,7 +71,28 @@ export function createSupabaseAuthAdapter(): AuthAdapter {
 }
 ```
 
-## 🧠 Why this exists
+## Profile contract
+
+Auth providers own identity records. App-facing profile data should be modeled separately, usually in an app table such as `profiles`.
+
+```ts
+const auth = {
+  scope: 'global',
+  provider: 'supabase',
+  authorization: { kind: 'RBAC', engine: 'native' },
+  profile: {
+    fields: ['email', 'displayName', 'avatarUrl'],
+    table: 'profiles',
+    primaryKey: 'authUserId',
+    createStrategy: 'trigger',
+    updateStrategy: 'api',
+  },
+};
+```
+
+Generated infra can use this metadata to create and maintain app profile rows while leaving identity lifecycle changes to the auth provider.
+
+## Why this exists
 
 Contracts separates shared data and runtime contracts from implementation details.
 Standalone packages such as Supabase, Clerk, database providers, or UI/color

--- a/src/nutrition/index.ts
+++ b/src/nutrition/index.ts
@@ -1,4 +1,4 @@
+export * from './capture';
 export * from './common';
 export * from './products';
-export * from './capture';
 export * from './review';

--- a/src/nutrition/review.ts
+++ b/src/nutrition/review.ts
@@ -1,3 +1,4 @@
+import type { NutritionCaptureSubmission, NutritionCaptureSubmissionStatus } from './capture';
 import type {
   NutritionCaptureSubmissionId,
   NutritionIsoDateTime,
@@ -6,7 +7,6 @@ import type {
   NutritionReviewId,
   NutritionUserId,
 } from './common';
-import type { NutritionCaptureSubmission, NutritionCaptureSubmissionStatus } from './capture';
 import type { NutritionProduct } from './products';
 
 export const NUTRITION_REVIEW_DECISIONS = [

--- a/src/profile-contract.test.ts
+++ b/src/profile-contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  AUTH_PROFILE_CREATE_STRATEGIES,
+  AUTH_PROFILE_PRIMARY_KEY_STRATEGIES,
+  AUTH_PROFILE_UPDATE_STRATEGIES,
+  type AuthSpec,
+} from './index';
+
+describe('profile contract', () => {
+  it('exports profile strategy lists', () => {
+    expect(AUTH_PROFILE_PRIMARY_KEY_STRATEGIES).toEqual(['authUserId']);
+    expect(AUTH_PROFILE_CREATE_STRATEGIES).toEqual(['trigger', 'api', 'app']);
+    expect(AUTH_PROFILE_UPDATE_STRATEGIES).toEqual(['api', 'app']);
+  });
+
+  it('serializes profile settings on an auth spec', () => {
+    const auth: AuthSpec = {
+      scope: 'global',
+      provider: 'supabase',
+      authorization: { kind: 'RBAC', engine: 'native' },
+      profile: {
+        fields: ['email', 'displayName', 'avatarUrl'],
+        table: 'profiles',
+        primaryKey: 'authUserId',
+        createStrategy: 'trigger',
+        updateStrategy: 'api',
+      },
+    };
+
+    expect(JSON.parse(JSON.stringify(auth))).toEqual(auth);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,15 @@ export const AUTH_PROFILE_FIELDS = [
 export type KnownAuthProfileField = (typeof AUTH_PROFILE_FIELDS)[number];
 export type AuthProfileField = KnownAuthProfileField | (string & {});
 
+export const AUTH_PROFILE_PRIMARY_KEY_STRATEGIES = ['authUserId'] as const;
+export type AuthProfilePrimaryKeyStrategy = (typeof AUTH_PROFILE_PRIMARY_KEY_STRATEGIES)[number];
+
+export const AUTH_PROFILE_CREATE_STRATEGIES = ['trigger', 'api', 'app'] as const;
+export type AuthProfileCreateStrategy = (typeof AUTH_PROFILE_CREATE_STRATEGIES)[number];
+
+export const AUTH_PROFILE_UPDATE_STRATEGIES = ['api', 'app'] as const;
+export type AuthProfileUpdateStrategy = (typeof AUTH_PROFILE_UPDATE_STRATEGIES)[number];
+
 export interface IconSpec {
   name: string;
   provider?: string;
@@ -307,6 +316,10 @@ export interface AuthSignUpSpec {
 
 export interface AuthProfileSpec {
   fields: AuthProfileField[];
+  table?: string;
+  primaryKey?: AuthProfilePrimaryKeyStrategy;
+  createStrategy?: AuthProfileCreateStrategy;
+  updateStrategy?: AuthProfileUpdateStrategy;
 }
 
 export interface AuthSpec {


### PR DESCRIPTION
## Summary

Closes #70.

Adds profile provisioning metadata to `AuthProfileSpec` so generated apps can declare their app-facing profile table separately from provider-owned identity records.

## Included

- `AUTH_PROFILE_PRIMARY_KEY_STRATEGIES`
- `AUTH_PROFILE_CREATE_STRATEGIES`
- `AUTH_PROFILE_UPDATE_STRATEGIES`
- `AuthProfilePrimaryKeyStrategy`
- `AuthProfileCreateStrategy`
- `AuthProfileUpdateStrategy`
- optional `table`, `primaryKey`, `createStrategy`, and `updateStrategy` fields on `AuthProfileSpec`
- tests for the new profile contract surface
- README docs
- changeset

## Notes

This is intentionally only the shared contract. Actual Supabase SQL/profile table generation should be implemented in infra/generation code that consumes this metadata.

## Verification

Not run locally in this environment.