### PR TITLE
feat: add inferred screen requirement contracts

### DIFF
--- a/.changeset/inferred-screen-requirements.md
+++ b/.changeset/inferred-screen-requirements.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": minor
+---
+
+Add manifest contracts for inferred screen permissions and capabilities.

--- a/.changeset/inferred-screen-requirements.md
+++ b/.changeset/inferred-screen-requirements.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": minor
+'@ankhorage/contracts': minor
 ---
 
 Add manifest contracts for inferred screen permissions and capabilities.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './bindings';
 export * from './data';
 export * from './db';
 export * from './nutrition';
+export * from './requirements';
 export * from './state';
 export * from './storage';
 export * from './types';

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -1,0 +1,10 @@
+export interface ScreenRequirements {
+  readonly permissions?: readonly string[];
+  readonly capabilities?: readonly string[];
+}
+
+declare module './types' {
+  interface ScreenSpec {
+    readonly requires?: ScreenRequirements;
+  }
+}

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -1,10 +1,5 @@
-export interface ScreenRequirements {
-  readonly permissions?: readonly string[];
-  readonly capabilities?: readonly string[];
-}
+export const ANKHORAGE_PERMISSION_NAMES = ['camera','microphone','mediaLibrary','mediaLibraryWrite','locationForeground','locationBackground','notifications','clipboard'] as const;
+export type AnkhoragePermissionName = (typeof ANKHORAGE_PERMISSION_NAMES)[number];
 
-declare module './types' {
-  interface ScreenSpec {
-    readonly requires?: ScreenRequirements;
-  }
-}
+export const ANKHORAGE_CAPABILITY_NAMES = ['barcodeScanner','cameraPreview','mediaPicker','filePicker','location','notifications','clipboard'] as const;
+export type Ankh

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -1,6 +1,44 @@
+export const ANKHORAGE_PERMISSION_NAMES = [
+  'camera',
+  'microphone',
+  'mediaLibrary',
+  'mediaLibraryWrite',
+  'locationForeground',
+  'locationBackground',
+  'notifications',
+  'clipboard',
+] as const;
+
+export type AnkhoragePermissionName = (typeof ANKHORAGE_PERMISSION_NAMES)[number];
+
+export const ANKHORAGE_CAPABILITY_NAMES = [
+  'barcodeScanner',
+  'cameraPreview',
+  'mediaPicker',
+  'filePicker',
+  'location',
+  'notifications',
+  'clipboard',
+] as const;
+
+export type AnkhorageCapabilityName = (typeof ANKHORAGE_CAPABILITY_NAMES)[number];
+
+export interface ScreenPermissionRequirement {
+  readonly permission: AnkhoragePermissionName;
+}
+
+export interface ScreenCapabilityRequirement {
+  readonly capability: AnkhorageCapabilityName;
+}
+
 export interface ScreenRequirements {
-  readonly permissions?: readonly string[];
-  readonly capabilities?: readonly string[];
+  readonly permissions?: readonly ScreenPermissionRequirement[];
+  readonly capabilities?: readonly ScreenCapabilityRequirement[];
+}
+
+export interface ComponentRequirements {
+  readonly permissions?: readonly ScreenPermissionRequirement[];
+  readonly capabilities?: readonly ScreenCapabilityRequirement[];
 }
 
 declare module './types' {

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -40,9 +40,3 @@ export interface ComponentRequirements {
   readonly permissions?: readonly ScreenPermissionRequirement[];
   readonly capabilities?: readonly ScreenCapabilityRequirement[];
 }
-
-declare module './types' {
-  interface ScreenSpec {
-    readonly requires?: ScreenRequirements;
-  }
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { ColorHarmony } from '@ankhorage/color-theory';
 import type { AuthFlowConfig, AuthIdentifierKind, AuthOAuthConfig, AuthSignUpField } from './auth';
 import type { ComponentDataBindingRegistry } from './bindings';
 import type { AppDataManifest, DataSourceRegistry } from './data';
+import type { ScreenRequirements } from './requirements';
 
 export interface ThemeModeConfig {
   primaryColor: string;
@@ -243,6 +244,7 @@ export interface ScreenSpec {
   title?: string;
   description?: string;
   root: UiNode;
+  requires?: ScreenRequirements;
 }
 
 export interface NavigatorSpec {


### PR DESCRIPTION
## Summary

- add known permission and capability name contracts
- add `ScreenRequirements` and `ComponentRequirements` for inferred screen requirements
- export the new requirement contracts from the package root
- add a changeset for `@ankhorage/contracts`

Closes #73

## Notes

This is intentionally minimal for v1: no template overrides, no ZORA-specific metadata, no runtime adapter logic. Follow-up issues will use these contracts to let ZORA metadata declare requirements and let ankhorage4 infer screen requirements automatically.

## Verification

Not run in this environment.

Recommended before merge:
- `bun run build`
- `bun run lint`
- `bun run typecheck`