### PR TITLE
[codex] Add repeatable manifest node contract

### DIFF
--- a/.changeset/great-ants-invent.md
+++ b/.changeset/great-ants-invent.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': patch
+---
+
+Add a generic `UiNode.repeat` manifest primitive for repeated child rendering from binding sources.

--- a/src/bindings.test.ts
+++ b/src/bindings.test.ts
@@ -280,6 +280,114 @@ describe('component data-binding contracts', () => {
     expect(bindings.scanner?.events?.barcodeScanned?.[2]?.target.type).toBe('navigate');
   });
 
+  it('serializes repeated container nodes with generic item-context bindings', () => {
+    const productsListOperation = {
+      dataSourceId: 'catalog-api',
+      endpointId: 'products',
+      operationId: 'products.list',
+    } as const;
+
+    const root: AppManifest['screens'][string]['root'] = {
+      id: 'products-grid',
+      type: 'Grid',
+      repeat: {
+        source: {
+          kind: 'operation',
+          operation: productsListOperation,
+        },
+        itemAlias: 'item',
+        keyPath: 'id',
+      },
+      children: [
+        {
+          id: 'product-card-template',
+          type: 'ProductCard',
+        },
+      ],
+    };
+
+    const bindings: ComponentDataBindingRegistry = {
+      'product-card-template': {
+        componentId: 'product-card-template',
+        componentType: 'ProductCard',
+        props: {
+          title: {
+            source: {
+              kind: 'context',
+              path: 'item.name',
+            },
+          },
+          brand: {
+            source: {
+              kind: 'context',
+              path: 'item.brand',
+            },
+          },
+          description: {
+            source: {
+              kind: 'context',
+              path: 'item.barcode',
+            },
+          },
+        },
+        events: {
+          press: [
+            {
+              target: {
+                kind: 'action',
+                type: 'navigate',
+              },
+              input: {
+                route: {
+                  kind: 'literal',
+                  value: '/products/[id]',
+                },
+                params: {
+                  kind: 'object',
+                  fields: {
+                    id: {
+                      kind: 'source',
+                      source: {
+                        kind: 'context',
+                        path: 'item.id',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    assertSerializable({ root, bindings });
+    expect(root.repeat).toEqual({
+      source: {
+        kind: 'operation',
+        operation: productsListOperation,
+      },
+      itemAlias: 'item',
+      keyPath: 'id',
+    });
+    expect(bindings['product-card-template']?.props?.title?.source).toEqual({
+      kind: 'context',
+      path: 'item.name',
+    });
+    expect(bindings['product-card-template']?.events?.press?.[0]?.input?.params).toEqual({
+      kind: 'object',
+      fields: {
+        id: {
+          kind: 'source',
+          source: {
+            kind: 'context',
+            path: 'item.id',
+          },
+        },
+      },
+    });
+  });
+
   it('serializes component data-binding registries', () => {
     const bindings: ComponentDataBindingRegistry = {
       'submit-button': {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { ColorHarmony } from '@ankhorage/color-theory';
 
 import type { AuthFlowConfig, AuthIdentifierKind, AuthOAuthConfig, AuthSignUpField } from './auth';
-import type { ComponentDataBindingRegistry } from './bindings';
+import type { BindingValueSource, ComponentDataBindingRegistry } from './bindings';
 import type { AppDataManifest, DataSourceRegistry } from './data';
 import type { ScreenRequirements } from './requirements';
 
@@ -229,6 +229,12 @@ export interface IconSpec {
   color?: string;
 }
 
+export interface UiNodeRepeatSpec {
+  source: BindingValueSource;
+  itemAlias?: string;
+  keyPath?: string;
+}
+
 export interface UiNode {
   id: string;
   type: string;
@@ -236,6 +242,7 @@ export interface UiNode {
   props?: Record<string, unknown>;
   children?: UiNode[];
   style?: Record<string, number | string>;
+  repeat?: UiNodeRepeatSpec;
 }
 
 export interface ScreenSpec {


### PR DESCRIPTION
## What changed
- added a generic `UiNodeRepeatSpec` contract with `source`, `itemAlias`, and `keyPath`
- extended `UiNode` with optional `repeat` support
- added a serialization test covering a repeated container, item-context prop bindings, and generic navigate event bindings
- added a patch changeset for `@ankhorage/contracts`

## Why
Issue 06 needs a manifest-level primitive for repeated child rendering so starter templates can bind live collections without introducing product- or scanner-specific contract types.

## Impact
- contracts can now describe repeated direct-child rendering from existing binding sources
- repeated item context can stay generic via `context.<itemAlias>.*`
- existing `dataBindings.events` semantics remain unchanged

## Validation
- `bun test src/bindings.test.ts src/contracts.test.ts`
- `bun run lint:fix`