### PR TITLE
[codex] Add CLI discovery contracts

### DIFF
--- a/.changeset/ankh-cli-contracts.md
+++ b/.changeset/ankh-cli-contracts.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Add `@ankhorage/contracts/cli` metadata contracts for Ankh package discovery.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Shared public contracts for Ankhorage packages and standalone provider packages.
 ```ts
 import type { AppManifest } from '@ankhorage/contracts';
 import type { AuthAdapter } from '@ankhorage/contracts/auth';
+import type { AnkhCommandProviderManifest, AnkhPackageMetadata } from '@ankhorage/contracts/cli';
 import type { DbAdapter } from '@ankhorage/contracts/db';
 import type { StorageAdapter } from '@ankhorage/contracts/storage';
 ```
@@ -70,6 +71,53 @@ export function createSupabaseAuthAdapter(): AuthAdapter {
   };
 }
 ```
+
+## CLI discovery contracts
+
+`@ankhorage/contracts/cli` contains metadata-only discovery contracts for Ankh
+packages and command providers.
+
+```ts
+import type {
+  AnkhCommandProviderManifest,
+  AnkhPackageMetadata,
+} from '@ankhorage/contracts/cli';
+```
+
+Provider packages expose `package.json.ankh` metadata using a package-relative
+provider module path:
+
+```json
+{
+  "ankh": {
+    "category": "infra",
+    "provider": "./dist/ankh.provider.js",
+    "capabilities": ["infra.up", "infra.status"]
+  }
+}
+```
+
+Metadata-only packages use `null` for `provider`:
+
+```json
+{
+  "ankh": {
+    "category": "contracts",
+    "provider": null,
+    "capabilities": ["contracts.cli"]
+  }
+}
+```
+
+Command descriptor paths are relative to the provider category:
+
+- `category: "infra"` with `path: ["up"]` maps to `ankh infra up`
+- `category: "dev"` with `path: ["android", "scan"]` maps to `ankh dev android scan`
+
+This subpath contains contracts only. It must not depend on `commander`,
+`@ankhorage/ankh`, provider implementations, or runtime CLI execution logic.
+Concrete `package.json.ankh` adoption for this package is deferred to
+`contracts#84`.
 
 ## Profile contract
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,7 @@ export function createSupabaseAuthAdapter(): AuthAdapter {
 packages and command providers.
 
 ```ts
-import type {
-  AnkhCommandProviderManifest,
-  AnkhPackageMetadata,
-} from '@ankhorage/contracts/cli';
+import type { AnkhCommandProviderManifest, AnkhPackageMetadata } from '@ankhorage/contracts/cli';
 ```
 
 Provider packages expose `package.json.ankh` metadata using a package-relative

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
       "types": "./dist/bindings.d.ts",
       "default": "./dist/bindings.js"
     },
+    "./cli": {
+      "types": "./dist/cli.d.ts",
+      "default": "./dist/cli.js"
+    },
     "./data": {
       "types": "./dist/data/index.d.ts",
       "default": "./dist/data/index.js"

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'bun:test';
+
+import type {
+  AnkhCapabilityId,
+  AnkhCommandDescriptor,
+  AnkhCommandProviderManifest,
+  AnkhPackageMetadata,
+} from './index';
+
+describe('cli contracts', () => {
+  it('accepts provider package metadata and provider manifests', () => {
+    const packageMetadata = {
+      category: 'infra',
+      provider: './dist/ankh.provider.js',
+      capabilities: ['infra.up', 'infra.status'],
+    } as const satisfies AnkhPackageMetadata;
+
+    const upCommand = {
+      path: ['up'],
+      summary: 'Bring project infrastructure up',
+      capability: 'infra.up',
+      aliases: ['start'],
+      examples: ['ankh infra up shop'],
+    } as const satisfies AnkhCommandDescriptor;
+
+    const manifest = {
+      id: '@ankhorage/infra',
+      category: 'infra',
+      version: '1.0.0',
+      capabilities: ['infra.up', 'infra.status'],
+      commands: [upCommand],
+    } as const satisfies AnkhCommandProviderManifest;
+
+    expect(JSON.parse(JSON.stringify(packageMetadata))).toEqual(packageMetadata);
+    expect(JSON.parse(JSON.stringify(manifest))).toEqual(manifest);
+    expect(manifest.id).toBe('@ankhorage/infra');
+    expect(manifest.category).toBe('infra');
+    expect(manifest.commands[0].path).toEqual(['up']);
+  });
+
+  it('accepts metadata-only packages without a provider module', () => {
+    const packageMetadata = {
+      category: 'contracts',
+      provider: null,
+      capabilities: ['contracts.cli'],
+    } as const satisfies AnkhPackageMetadata;
+
+    expect(JSON.parse(JSON.stringify(packageMetadata))).toEqual(packageMetadata);
+    expect(packageMetadata.provider).toBeNull();
+  });
+
+  it('keeps command paths relative to the provider category', () => {
+    const androidScanCommand = {
+      path: ['android', 'scan'],
+      summary: 'Scan an Android target',
+      capability: 'dev.android.scan',
+      examples: ['ankh dev android scan'],
+    } as const satisfies AnkhCommandDescriptor;
+
+    const manifest = {
+      id: '@ankhorage/dev',
+      category: 'dev',
+      version: '1.0.0',
+      capabilities: ['dev.android.scan'],
+      commands: [androidScanCommand],
+    } as const satisfies AnkhCommandProviderManifest;
+
+    expect(manifest.category).toBe('dev');
+    expect(manifest.commands[0].path).toEqual(['android', 'scan']);
+    expect(manifest.commands[0].path[0]).not.toBe(manifest.category);
+  });
+
+  it('accepts dot-separated capability ids for discovery metadata', () => {
+    const capabilities = [
+      'infra.up',
+      'templates.list',
+      'board.web.import',
+      'contracts.cli',
+    ] as const satisfies readonly AnkhCapabilityId[];
+
+    expect(capabilities).toEqual([
+      'infra.up',
+      'templates.list',
+      'board.web.import',
+      'contracts.cli',
+    ]);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,27 @@
+export type AnkhCommandCategory = string;
+
+export type AnkhProviderReference = `./${string}`;
+
+export type AnkhCapabilityId = `${string}.${string}`;
+
+export interface AnkhCommandDescriptor {
+  readonly path: readonly [string, ...string[]];
+  readonly summary: string;
+  readonly capability: AnkhCapabilityId;
+  readonly aliases?: readonly string[];
+  readonly examples?: readonly string[];
+}
+
+export interface AnkhCommandProviderManifest {
+  readonly id: string;
+  readonly category: AnkhCommandCategory;
+  readonly version: string;
+  readonly capabilities: readonly AnkhCapabilityId[];
+  readonly commands: readonly AnkhCommandDescriptor[];
+}
+
+export interface AnkhPackageMetadata {
+  readonly category: AnkhCommandCategory;
+  readonly provider: AnkhProviderReference | null;
+  readonly capabilities: readonly AnkhCapabilityId[];
+}

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -56,6 +56,17 @@ async function collectTypeScriptFiles(directory: string): Promise<string[]> {
 }
 
 describe('contracts', () => {
+  it('exports the cli subpath for Ankh discovery contracts', async () => {
+    const packageJson = JSON.parse(await readFile(join(process.cwd(), 'package.json'), 'utf8')) as {
+      exports?: Record<string, { default?: string; types?: string }>;
+    };
+
+    expect(packageJson.exports?.['./cli']).toEqual({
+      types: './dist/cli.d.ts',
+      default: './dist/cli.js',
+    });
+  });
+
   it('exports stable platform constants', () => {
     expect(NAVIGATOR_TYPES).toEqual(['stack', 'tabs', 'drawer']);
     expect(APP_CATEGORIES).toEqual([
@@ -213,7 +224,7 @@ describe('contracts', () => {
 
   it('ThemeModeConfig.harmony accepts all ColorHarmony values', () => {
     for (const harmony of COLOR_HARMONIES) {
-      const config: ThemeModeConfig = { primaryColor: '#ff0000', harmony };
+      const config = { primaryColor: '#ff0000', harmony } satisfies ThemeModeConfig;
       expect(config.harmony).toBe(harmony);
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './auth';
 export * from './bindings';
+export * from './cli';
 export * from './data';
 export * from './db';
 export * from './nutrition';


### PR DESCRIPTION
## Summary
Add the new `@ankhorage/contracts/cli` metadata-only discovery surface for Ankh command providers.

## What changed
- add `src/cli.ts` with `AnkhCommandCategory`, `AnkhProviderReference`, `AnkhCapabilityId`, `AnkhCommandDescriptor`, `AnkhCommandProviderManifest`, and `AnkhPackageMetadata`
- export the new surface from `src/index.ts` and `package.json` via `./cli`
- add `src/cli.test.ts` fixtures using `satisfies` to prove the exported contracts
- extend `src/contracts.test.ts` to verify the `./cli` export entry
- document the new subpath and `package.json.ankh` examples in `README.md`
- add the requested minor changeset

## Scope notes
- metadata only
- no execution context or command result contracts
- no handlers or provider loader
- no `commander`
- no actual `package.json.ankh` adoption yet

## Validation
- `bun run build`
- `bun run lint:fix`
- `bun run test`
