### PR TITLE
[codex] Add package metadata convention docs

### DIFF
--- a/.changeset/contracts-package-metadata.md
+++ b/.changeset/contracts-package-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': patch
+---
+
+Add published ankh package metadata and document capability naming conventions.

--- a/README.md
+++ b/README.md
@@ -127,13 +127,18 @@ Command descriptor paths are relative to the provider category:
 This subpath contains contracts only. It must not depend on `commander`,
 `@ankhorage/ankh`, provider implementations, or runtime CLI execution logic.
 
-Capability naming is a package metadata policy. The preferred format is
-`<category>.<resource>.<action>`.
+Capability names are dot-separated package metadata identifiers.
+
+Preferred forms:
+
+- `<category>.<action>` for simple capabilities
+- `<category>.<resource>.<action>` for nested or domain-specific capabilities
 
 Valid examples:
 
 - `infra.up`
 - `templates.create`
+- `contracts.cli`
 - `board.web.import`
 - `doctor.repo.validate`
 - `dev.android.rebuild`

--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ Metadata-only packages use `null` for `provider`:
 }
 ```
 
+`@ankhorage/contracts` now publishes this metadata shape directly from its own
+`package.json`:
+
+```json
+{
+  "ankh": {
+    "category": "contracts",
+    "provider": null,
+    "capabilities": ["contracts.cli"]
+  }
+}
+```
+
 Command descriptor paths are relative to the provider category:
 
 - `category: "infra"` with `path: ["up"]` maps to `ankh infra up`
@@ -113,8 +126,31 @@ Command descriptor paths are relative to the provider category:
 
 This subpath contains contracts only. It must not depend on `commander`,
 `@ankhorage/ankh`, provider implementations, or runtime CLI execution logic.
-Concrete `package.json.ankh` adoption for this package is deferred to
-`contracts#84`.
+
+Capability naming is a package metadata policy. The preferred format is
+`<category>.<resource>.<action>`.
+
+Valid examples:
+
+- `infra.up`
+- `templates.create`
+- `board.web.import`
+- `doctor.repo.validate`
+- `dev.android.rebuild`
+- `expoRuntime.plan`
+
+Invalid examples:
+
+- `infra`
+- `infra-up`
+- `.status`
+- `infra.`
+- `infra..up`
+
+`AnkhCapabilityId` remains intentionally broad at the TypeScript level so
+packages can publish stable serializable metadata without embedding policy
+validation logic here. Stricter validation belongs later in
+`@ankhorage/doctor`.
 
 ## Profile contract
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "ankh": {
     "category": "contracts",
     "provider": null,
-    "capabilities": ["contracts.cli"]
+    "capabilities": [
+      "contracts.cli"
+    ]
   },
   "dependencies": {
     "@ankhorage/color-theory": "^0.0.7"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "@ankhorage/contracts",
   "version": "1.19.0",
   "main": "./dist/index.js",
+  "ankh": {
+    "category": "contracts",
+    "provider": null,
+    "capabilities": ["contracts.cli"]
+  },
   "dependencies": {
     "@ankhorage/color-theory": "^0.0.7"
   },

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -5,6 +5,7 @@ import { COLOR_HARMONIES } from '@ankhorage/color-theory';
 import { describe, expect, it } from 'bun:test';
 
 import {
+  type AnkhPackageMetadata,
   APP_CATEGORIES,
   type AppCategory,
   type AppManifest,
@@ -57,7 +58,14 @@ async function collectTypeScriptFiles(directory: string): Promise<string[]> {
 
 describe('contracts', () => {
   it('exports the cli subpath for Ankh discovery contracts', async () => {
+    const expectedAnkhMetadata = {
+      category: 'contracts',
+      provider: null,
+      capabilities: ['contracts.cli'],
+    } as const satisfies AnkhPackageMetadata;
+
     const packageJson = JSON.parse(await readFile(join(process.cwd(), 'package.json'), 'utf8')) as {
+      ankh?: unknown;
       exports?: Record<string, { default?: string; types?: string }>;
     };
 
@@ -65,6 +73,8 @@ describe('contracts', () => {
       types: './dist/cli.d.ts',
       default: './dist/cli.js',
     });
+    expect(packageJson.ankh).toEqual(expectedAnkhMetadata);
+    expect(JSON.parse(JSON.stringify(expectedAnkhMetadata))).toEqual(expectedAnkhMetadata);
   });
 
   it('exports stable platform constants', () => {


### PR DESCRIPTION
## Summary
- add published `package.json.ankh` metadata for `@ankhorage/contracts`
- document the package metadata convention and capability naming policy
- lock the published metadata shape with tests and add a patch changeset

## Validation
- `bun run build`
- `bun run lint:fix`
- `bun run test`