### PR TITLE
Add shared runtime callback contracts

### DIFF
--- a/.changeset/runtime-callback-contracts.md
+++ b/.changeset/runtime-callback-contracts.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": patch
+---
+
+Add shared runtime callback contracts for node prop resolvers and callback maps.

--- a/.changeset/runtime-callback-contracts.md
+++ b/.changeset/runtime-callback-contracts.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": patch
+'@ankhorage/contracts': patch
 ---
 
 Add shared runtime callback contracts for node prop resolvers and callback maps.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
       "types": "./dist/nutrition/index.d.ts",
       "default": "./dist/nutrition/index.js"
     },
+    "./runtime": {
+      "types": "./dist/runtimeCallbacks.d.ts",
+      "default": "./dist/runtimeCallbacks.js"
+    },
     "./state": {
       "types": "./dist/state.d.ts",
       "default": "./dist/state.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './data';
 export * from './db';
 export * from './nutrition';
 export * from './requirements';
+export * from './runtimeCallbacks';
 export * from './state';
 export * from './storage';
 export * from './types';

--- a/src/runtimeCallbacks.ts
+++ b/src/runtimeCallbacks.ts
@@ -1,0 +1,19 @@
+import type { UiNode } from './types';
+
+export interface RuntimeResolveNodePropsArgs {
+  readonly node: UiNode;
+  readonly props: Record<string, unknown>;
+}
+
+export type RuntimeNodePropsResolver = (
+  args: RuntimeResolveNodePropsArgs,
+) => Record<string, unknown>;
+
+export interface RuntimeCallbackArgs {
+  readonly payload: unknown;
+  readonly node?: UiNode;
+  readonly resolvedPayload?: object;
+}
+
+export type RuntimeCallback = (args: RuntimeCallbackArgs) => Promise<void> | void;
+export type RuntimeCallbackMap = Readonly<Record<string, RuntimeCallback>>;


### PR DESCRIPTION
## Summary

- Add shared package-neutral runtime callback contracts for node prop resolvers and callback maps.
- Export them from the root contracts entrypoint.
- Add an `@ankhorage/contracts/runtime` subpath for packages that want the focused boundary.
- Add a patch changeset.

## Notes

This is the upstream first step for the shared typing audit in ankhorage/ankhorage4#452. After release, `@ankhorage/runtime` and `@ankhorage/studio` can consume/re-export these contracts instead of keeping parallel structural callback types.

## Validation

Not run here. Expected CI: build, typecheck, lint, tests, knip, changeset status.

Refs ankhorage/ankhorage4#452
Refs ankhorage/ankhorage4#432