### PR TITLE
Update metadata examples

### DIFF
--- a/.changeset/cli-provider-examples.md
+++ b/.changeset/cli-provider-examples.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': patch
+---
+
+Update CLI provider metadata examples.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ provider module path:
 {
   "ankh": {
     "category": "infra",
-    "provider": "./dist/ankh.provider.js",
+    "provider": "./dist/cli/index.js",
     "capabilities": ["infra.up", "infra.status"]
   }
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -11,7 +11,7 @@ describe('cli contracts', () => {
   it('accepts provider package metadata and provider manifests', () => {
     const packageMetadata = {
       category: 'infra',
-      provider: './dist/ankh.provider.js',
+      provider: './dist/cli/index.js',
       capabilities: ['infra.up', 'infra.status'],
     } as const satisfies AnkhPackageMetadata;
 


### PR DESCRIPTION
Updates CLI contract examples to use `./dist/cli/index.js`.

Progress toward ankhorage/ankh#22.