### PR TITLE
[adm 8] Replace primary navigation visibility contract

### DIFF
--- a/.changeset/adm8-primary-navigation.md
+++ b/.changeset/adm8-primary-navigation.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': major
+---
+
+Replace the tab-specific route visibility field with `showInPrimaryNavigation`. Omitted routes remain visible by default, while `false` hides a route from Tabs and Drawer primary navigation without removing its navigability.

--- a/paradox/exports.json
+++ b/paradox/exports.json
@@ -627,7 +627,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 375,
+      "line": 382,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -741,7 +741,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 367,
+      "line": 374,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1912,7 +1912,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 332,
+      "line": 339,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2197,7 +2197,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 322,
+      "line": 329,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2292,7 +2292,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 326,
+      "line": 333,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2332,7 +2332,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 340,
+      "line": 347,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2555,7 +2555,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 317,
+      "line": 324,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3542,7 +3542,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 302,
+      "line": 309,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -5883,7 +5883,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 297,
+      "line": 304,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6923,7 +6923,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 356,
+      "line": 363,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7335,7 +7335,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 351,
+      "line": 358,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9475,13 +9475,6 @@
         "description": null
       },
       {
-        "name": "hideInTabBar",
-        "kind": "property",
-        "type": "boolean | undefined",
-        "required": false,
-        "description": null
-      },
-      {
         "name": "icon",
         "kind": "property",
         "type": "IconSpec | undefined",
@@ -9520,6 +9513,13 @@
         "name": "screenId",
         "kind": "property",
         "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "showInPrimaryNavigation",
+        "kind": "property",
+        "type": "boolean | undefined",
         "required": false,
         "description": null
       }
@@ -10640,7 +10640,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 283,
+      "line": 290,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10680,7 +10680,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 289,
+      "line": 296,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10727,7 +10727,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 281,
+      "line": 288,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10745,7 +10745,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 293,
+      "line": 300,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -11164,7 +11164,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 312,
+      "line": 319,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -11669,7 +11669,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 307,
+      "line": 314,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],

--- a/paradox/exports.md
+++ b/paradox/exports.md
@@ -196,7 +196,7 @@ Source: `src/types.ts:168:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:375:1`
+Source: `src/types.ts:382:1`
 
 ### Members
 
@@ -219,7 +219,7 @@ Source: `src/types.ts:375:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:367:1`
+Source: `src/types.ts:374:1`
 
 ### Members
 
@@ -591,7 +591,7 @@ Source: `src/types.ts:221:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:332:1`
+Source: `src/types.ts:339:1`
 
 ### Members
 
@@ -682,7 +682,7 @@ Source: `src/types.ts:205:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:322:1`
+Source: `src/types.ts:329:1`
 
 ### Members
 
@@ -719,7 +719,7 @@ Source: `src/types.ts:208:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:326:1`
+Source: `src/types.ts:333:1`
 
 ### Members
 
@@ -733,7 +733,7 @@ Source: `src/types.ts:326:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:340:1`
+Source: `src/types.ts:347:1`
 
 ### Members
 
@@ -794,7 +794,7 @@ Source: `src/types.ts:192:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:317:1`
+Source: `src/types.ts:324:1`
 
 ### Members
 
@@ -1127,7 +1127,7 @@ Source: `src/types.ts:176:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:302:1`
+Source: `src/types.ts:309:1`
 
 ### Members
 
@@ -1843,7 +1843,7 @@ Source: `src/types.ts:170:14`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:297:1`
+Source: `src/types.ts:304:1`
 
 ### Members
 
@@ -2140,7 +2140,7 @@ Source: `src/storage.ts:55:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:356:1`
+Source: `src/types.ts:363:1`
 
 ### Members
 
@@ -2272,7 +2272,7 @@ Source: `src/types.ts:141:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:351:1`
+Source: `src/types.ts:358:1`
 
 ### Members
 
@@ -2893,16 +2893,16 @@ Source: `src/types.ts:270:1`
 
 ### Members
 
-| Name         | Kind     | Type                         | Required | Description |
-| ------------ | -------- | ---------------------------- | -------- | ----------- |
-| guards       | property | `string[] \| undefined`      | no       |             |
-| hideInTabBar | property | `boolean \| undefined`       | no       |             |
-| icon         | property | `IconSpec \| undefined`      | no       |             |
-| label        | property | `string \| undefined`        | no       |             |
-| name         | property | `string`                     | yes      |             |
-| navigator    | property | `NavigatorSpec \| undefined` | no       |             |
-| path         | property | `string \| undefined`        | no       |             |
-| screenId     | property | `string \| undefined`        | no       |             |
+| Name                    | Kind     | Type                         | Required | Description |
+| ----------------------- | -------- | ---------------------------- | -------- | ----------- |
+| guards                  | property | `string[] \| undefined`      | no       |             |
+| icon                    | property | `IconSpec \| undefined`      | no       |             |
+| label                   | property | `string \| undefined`        | no       |             |
+| name                    | property | `string`                     | yes      |             |
+| navigator               | property | `NavigatorSpec \| undefined` | no       |             |
+| path                    | property | `string \| undefined`        | no       |             |
+| screenId                | property | `string \| undefined`        | no       |             |
+| showInPrimaryNavigation | property | `boolean \| undefined`       | no       |             |
 
 ## RuntimeCallback
 
@@ -3283,7 +3283,7 @@ Source: `src/auth.ts:150:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:283:1`
+Source: `src/types.ts:290:1`
 
 ### Members
 
@@ -3297,7 +3297,7 @@ Source: `src/types.ts:283:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:289:1`
+Source: `src/types.ts:296:1`
 
 ### Members
 
@@ -3312,13 +3312,13 @@ Source: `src/types.ts:289:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:281:1`
+Source: `src/types.ts:288:1`
 
 ## SplashScreenSpec
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:293:1`
+Source: `src/types.ts:300:1`
 
 ### Members
 
@@ -3454,7 +3454,7 @@ Source: `src/state.ts:40:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:312:1`
+Source: `src/types.ts:319:1`
 
 ### Members
 
@@ -3620,7 +3620,7 @@ Source: `src/storage.ts:11:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:307:1`
+Source: `src/types.ts:314:1`
 
 ### Members
 

--- a/paradox/index.html
+++ b/paradox/index.html
@@ -11614,7 +11614,7 @@
                 data-search="AppManifest type src/types.ts  AppCategory AppSettings ComponentDataBinding DataSourceConfig GeneratedApiDefinition InfraManifest NavigatorSpec ScreenSpec SplashScreenSpec ThemeConfig"
               >
                 <h4>AppManifest</h4>
-                <p class="muted">type • <code>src/types.ts:375:1</code></p>
+                <p class="muted">type • <code>src/types.ts:382:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -11760,7 +11760,7 @@
                 data-search="AppSettings type src/types.ts "
               >
                 <h4>AppSettings</h4>
-                <p class="muted">type • <code>src/types.ts:367:1</code></p>
+                <p class="muted">type • <code>src/types.ts:374:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11920,7 +11920,7 @@
                 data-search="AuthProfileSpec type src/types.ts  AuthProfileField"
               >
                 <h4>AuthProfileSpec</h4>
-                <p class="muted">type • <code>src/types.ts:332:1</code></p>
+                <p class="muted">type • <code>src/types.ts:339:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -12033,7 +12033,7 @@
                 data-search="AuthSignInSpec type src/types.ts "
               >
                 <h4>AuthSignInSpec</h4>
-                <p class="muted">type • <code>src/types.ts:322:1</code></p>
+                <p class="muted">type • <code>src/types.ts:329:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12080,7 +12080,7 @@
                 data-search="AuthSignUpSpec type src/types.ts  AuthSignUpField"
               >
                 <h4>AuthSignUpSpec</h4>
-                <p class="muted">type • <code>src/types.ts:326:1</code></p>
+                <p class="muted">type • <code>src/types.ts:333:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -12136,7 +12136,7 @@
                 data-search="AuthSpec type src/types.ts  AuthFlowConfig AuthOAuthConfig AuthProfileSpec AuthProvider AuthSignInSpec AuthSignUpSpec AuthzSpec"
               >
                 <h4>AuthSpec</h4>
-                <p class="muted">type • <code>src/types.ts:340:1</code></p>
+                <p class="muted">type • <code>src/types.ts:347:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -12274,7 +12274,7 @@
                 data-search="AuthzSpec type src/types.ts "
               >
                 <h4>AuthzSpec</h4>
-                <p class="muted">type • <code>src/types.ts:317:1</code></p>
+                <p class="muted">type • <code>src/types.ts:324:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12519,7 +12519,7 @@
                 data-search="DatabaseSpec type src/types.ts  DatabaseProvider"
               >
                 <h4>DatabaseSpec</h4>
-                <p class="muted">type • <code>src/types.ts:302:1</code></p>
+                <p class="muted">type • <code>src/types.ts:309:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -12585,7 +12585,7 @@
                 data-search="DeploymentSpec type src/types.ts  DeploymentTarget"
               >
                 <h4>DeploymentSpec</h4>
-                <p class="muted">type • <code>src/types.ts:297:1</code></p>
+                <p class="muted">type • <code>src/types.ts:304:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -12750,7 +12750,7 @@
                 data-search="InfraManifest type src/types.ts  AuthSpec DatabaseSpec DeploymentSpec InfraSecretStoreSpec NetworkingSpec StateSpec StorageSpec"
               >
                 <h4>InfraManifest</h4>
-                <p class="muted">type • <code>src/types.ts:356:1</code></p>
+                <p class="muted">type • <code>src/types.ts:363:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13051,7 +13051,7 @@
                 data-search="NetworkingSpec type src/types.ts "
               >
                 <h4>NetworkingSpec</h4>
-                <p class="muted">type • <code>src/types.ts:351:1</code></p>
+                <p class="muted">type • <code>src/types.ts:358:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13120,13 +13120,6 @@
                       <td></td>
                     </tr>
                     <tr>
-                      <td><code>hideInTabBar</code></td>
-                      <td>property</td>
-                      <td><code>boolean | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
                       <td><code>icon</code></td>
                       <td>property</td>
                       <td><code>IconSpec | undefined</code></td>
@@ -13165,6 +13158,13 @@
                       <td><code>screenId</code></td>
                       <td>property</td>
                       <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>showInPrimaryNavigation</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
                       <td>no</td>
                       <td></td>
                     </tr>
@@ -13342,7 +13342,7 @@
                 data-search="SplashScreenAssetSpec type src/types.ts  SplashScreenResizeMode"
               >
                 <h4>SplashScreenAssetSpec</h4>
-                <p class="muted">type • <code>src/types.ts:283:1</code></p>
+                <p class="muted">type • <code>src/types.ts:290:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13393,7 +13393,7 @@
                 data-search="SplashScreenModeSpec type src/types.ts  SplashScreenResizeMode"
               >
                 <h4>SplashScreenModeSpec</h4>
-                <p class="muted">type • <code>src/types.ts:289:1</code></p>
+                <p class="muted">type • <code>src/types.ts:296:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13451,7 +13451,7 @@
                 data-search="SplashScreenResizeMode unknown src/types.ts "
               >
                 <h4>SplashScreenResizeMode</h4>
-                <p class="muted">unknown • <code>src/types.ts:281:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:288:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13462,7 +13462,7 @@
                 data-search="SplashScreenSpec type src/types.ts  SplashScreenModeSpec SplashScreenResizeMode"
               >
                 <h4>SplashScreenSpec</h4>
-                <p class="muted">type • <code>src/types.ts:293:1</code></p>
+                <p class="muted">type • <code>src/types.ts:300:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13572,7 +13572,7 @@
                 data-search="StateSpec type src/types.ts  StateProvider"
               >
                 <h4>StateSpec</h4>
-                <p class="muted">type • <code>src/types.ts:312:1</code></p>
+                <p class="muted">type • <code>src/types.ts:319:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13643,7 +13643,7 @@
                 data-search="StorageSpec type src/types.ts "
               >
                 <h4>StorageSpec</h4>
-                <p class="muted">type • <code>src/types.ts:307:1</code></p>
+                <p class="muted">type • <code>src/types.ts:314:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>

--- a/paradox/paradox.json
+++ b/paradox/paradox.json
@@ -1769,7 +1769,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 375,
+        "line": 382,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1883,7 +1883,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 367,
+        "line": 374,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3054,7 +3054,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 332,
+        "line": 339,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3339,7 +3339,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 322,
+        "line": 329,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3434,7 +3434,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 326,
+        "line": 333,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3474,7 +3474,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 340,
+        "line": 347,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3697,7 +3697,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 317,
+        "line": 324,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4684,7 +4684,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 302,
+        "line": 309,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -7025,7 +7025,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 297,
+        "line": 304,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8065,7 +8065,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 356,
+        "line": 363,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8477,7 +8477,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 351,
+        "line": 358,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10617,13 +10617,6 @@
           "description": null
         },
         {
-          "name": "hideInTabBar",
-          "kind": "property",
-          "type": "boolean | undefined",
-          "required": false,
-          "description": null
-        },
-        {
           "name": "icon",
           "kind": "property",
           "type": "IconSpec | undefined",
@@ -10662,6 +10655,13 @@
           "name": "screenId",
           "kind": "property",
           "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "showInPrimaryNavigation",
+          "kind": "property",
+          "type": "boolean | undefined",
           "required": false,
           "description": null
         }
@@ -11782,7 +11782,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 283,
+        "line": 290,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11822,7 +11822,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 289,
+        "line": 296,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11869,7 +11869,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 281,
+        "line": 288,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11887,7 +11887,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 293,
+        "line": 300,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -12306,7 +12306,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 312,
+        "line": 319,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -12811,7 +12811,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 307,
+        "line": 314,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -26,6 +26,7 @@ import {
   type FormSubmitEventDto,
   type ImageAssetSource,
   NAVIGATOR_TYPES,
+  type RouteDefinition,
   type SplashScreenSpec,
   STATE_PERSISTENCE_MODES,
   STATE_PROVIDERS,
@@ -113,6 +114,27 @@ describe('contracts', () => {
   it('exports the app category union for template packages', () => {
     const category: AppCategory = 'developer_tools';
     expect(category).toBe('developer_tools');
+  });
+
+  it('serializes canonical primary-navigation visibility on routes', () => {
+    const visibleRoute: RouteDefinition = {
+      name: 'home',
+      path: '/',
+      screenId: 'home-screen',
+    };
+    const hiddenRoute: RouteDefinition = {
+      name: 'settings',
+      path: '/settings',
+      screenId: 'settings-screen',
+      showInPrimaryNavigation: false,
+    };
+
+    expect(JSON.parse(JSON.stringify({ visibleRoute, hiddenRoute }))).toEqual({
+      visibleRoute,
+      hiddenRoute,
+    });
+    expect(visibleRoute.showInPrimaryNavigation).toBeUndefined();
+    expect(hiddenRoute.showInPrimaryNavigation).toBe(false);
   });
 
   it('accepts the current serialized theme config shape', () => {
@@ -253,7 +275,7 @@ describe('contracts', () => {
     expect(names.includes('color-theory.ts')).toBe(false);
   });
 
-  it('removes all old tone/mood/recommendation symbols from src recursively', async () => {
+  it('removes obsolete contract symbols from src recursively', async () => {
     const banned = [
       'Color' + 'Tone',
       'color' + 'Tone',
@@ -263,6 +285,7 @@ describe('contracts', () => {
       'APP_' + 'MOODS',
       'suggested' + 'Color' + 'Tone',
       'APP_CATEGORY_' + 'THEME_RECOMMENDATIONS',
+      'hide' + 'InTabBar',
     ];
 
     const srcFiles = await collectTypeScriptFiles(join(process.cwd(), 'src'));

--- a/src/types.ts
+++ b/src/types.ts
@@ -272,7 +272,14 @@ export interface RouteDefinition {
   path?: string;
   label?: string;
   icon?: IconSpec;
-  hideInTabBar?: boolean;
+  /**
+   * Whether this route appears in Tabs and Drawer primary navigation.
+   *
+   * Omitted routes are visible by default. Setting this to `false` hides the
+   * route from primary navigation without making it unnavigable. Stack
+   * navigators preserve the value but do not present primary navigation.
+   */
+  showInPrimaryNavigation?: boolean;
   guards?: string[];
   screenId?: string;
   navigator?: NavigatorSpec;


### PR DESCRIPTION
## What changed

- replace `RouteDefinition.hideInTabBar` with the canonical `showInPrimaryNavigation?: boolean`
- document omitted-as-visible and `false`-as-hidden semantics for Tabs and Drawer while preserving routability
- add serialization/type-surface coverage and a source guard preventing the obsolete field from returning
- regenerate Paradox API documentation
- add a major changeset for `@ankhorage/contracts`

## Why

Studio issue [ankhorage/studio#123](https://github.com/ankhorage/studio/issues/123) requires one generic primary-navigation visibility contract. The previous tab-specific name was already being interpreted for Drawer navigation, so it no longer represented canonical behavior.

This is the Phase 1 owner correction and intentionally contains no alias, fallback, dual-read/dual-write behavior, or downstream Studio/Templates workaround.

## Impact

This is a breaking contract change. Consumers must use `showInPrimaryNavigation` after the Contracts major release. Omission means visible by default; `false` omits the route from Tabs/Drawer primary navigation while the route remains navigable. Stack preserves the canonical value without presenting primary navigation.

## Validation

- `bun run build`
- `bun run lint:fix`
- `bun run test` (77 pass)
- `bun run knip`
- `bun run typecheck`
- `bun run docs`
- `bun run format`
- `bun run format:check`
- `bun run changeset:status` (major bump recognized)
