### PR TITLE
Rename canonical module infra fields

### DIFF
--- a/.changeset/canonical-module-infra-fields.md
+++ b/.changeset/canonical-module-infra-fields.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': major
+---
+
+Replace the Ankhorage module registry fields on `InfraManifest` with the canonical `modules` and `modulesConfig` names. The obsolete `plugins` and `pluginsConfig` fields are removed without compatibility aliases.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # CONTRACTS
 
-![license: MIT](././paradox/badges/license.svg) ![npm: v4.0.2](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
+![license: MIT](././paradox/badges/license.svg) ![npm: v5.0.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
 
 Serializable app, action, theme, auth, and secret-store contracts for Ankhorage.
 

--- a/paradox/badges/npm.svg
+++ b/paradox/badges/npm.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="npm: v4.0.2">
-<title>npm: v4.0.2</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="npm: v5.0.0">
+<title>npm: v5.0.0</title>
 <rect width="38" height="20" fill="#374151"/>
 <rect x="38" width="52" height="20" fill="#cb3837"/>
 <text x="19" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">npm</text>
-<text x="64" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v4.0.2</text>
+<text x="64" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v5.0.0</text>
 </svg>

--- a/paradox/exports.json
+++ b/paradox/exports.json
@@ -6960,23 +6960,23 @@
         "description": null
       },
       {
-        "name": "networking",
-        "kind": "property",
-        "type": "NetworkingSpec | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "plugins",
+        "name": "modules",
         "kind": "property",
         "type": "string[]",
         "required": true,
         "description": null
       },
       {
-        "name": "pluginsConfig",
+        "name": "modulesConfig",
         "kind": "property",
         "type": "Record<string, unknown> | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "networking",
+        "kind": "property",
+        "type": "NetworkingSpec | undefined",
         "required": false,
         "description": null
       },

--- a/paradox/exports.md
+++ b/paradox/exports.md
@@ -2149,9 +2149,9 @@ Source: `src/types.ts:363:1`
 | auth          | property | `AuthSpec \| undefined`                | no       |             |
 | database      | property | `DatabaseSpec \| undefined`            | no       |             |
 | deployment    | property | `DeploymentSpec \| undefined`          | no       |             |
+| modules       | property | `string[]`                             | yes      |             |
+| modulesConfig | property | `Record<string, unknown> \| undefined` | no       |             |
 | networking    | property | `NetworkingSpec \| undefined`          | no       |             |
-| plugins       | property | `string[]`                             | yes      |             |
-| pluginsConfig | property | `Record<string, unknown> \| undefined` | no       |             |
 | secretStore   | property | `InfraSecretStoreSpec \| undefined`    | no       |             |
 | state         | property | `StateSpec \| undefined`               | no       |             |
 | storage       | property | `StorageSpec \| undefined`             | no       |             |

--- a/paradox/index.html
+++ b/paradox/index.html
@@ -12799,23 +12799,23 @@
                       <td></td>
                     </tr>
                     <tr>
-                      <td><code>networking</code></td>
-                      <td>property</td>
-                      <td><code>NetworkingSpec | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>plugins</code></td>
+                      <td><code>modules</code></td>
                       <td>property</td>
                       <td><code>string[]</code></td>
                       <td>yes</td>
                       <td></td>
                     </tr>
                     <tr>
-                      <td><code>pluginsConfig</code></td>
+                      <td><code>modulesConfig</code></td>
                       <td>property</td>
                       <td><code>Record&lt;string, unknown&gt; | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>networking</code></td>
+                      <td>property</td>
+                      <td><code>NetworkingSpec | undefined</code></td>
                       <td>no</td>
                       <td></td>
                     </tr>

--- a/paradox/paradox.json
+++ b/paradox/paradox.json
@@ -12,7 +12,7 @@
     {
       "id": "npm",
       "label": "npm",
-      "value": "v4.0.2",
+      "value": "v5.0.0",
       "color": "cb3837"
     },
     {
@@ -8102,23 +8102,23 @@
           "description": null
         },
         {
-          "name": "networking",
-          "kind": "property",
-          "type": "NetworkingSpec | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "plugins",
+          "name": "modules",
           "kind": "property",
           "type": "string[]",
           "required": true,
           "description": null
         },
         {
-          "name": "pluginsConfig",
+          "name": "modulesConfig",
           "kind": "property",
           "type": "Record<string, unknown> | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "networking",
+          "kind": "property",
+          "type": "NetworkingSpec | undefined",
           "required": false,
           "description": null
         },

--- a/src/bindings.test.ts
+++ b/src/bindings.test.ts
@@ -490,7 +490,7 @@ describe('component data-binding contracts', () => {
       ],
       activeThemeId: 'default',
       infra: {
-        plugins: [],
+        modules: [],
       },
       navigator: {
         type: 'stack',

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -25,6 +25,7 @@ import {
   DEPLOYMENT_TARGETS,
   type FormSubmitEventDto,
   type ImageAssetSource,
+  type InfraManifest,
   NAVIGATOR_TYPES,
   type RouteDefinition,
   type SplashScreenSpec,
@@ -242,16 +243,47 @@ describe('contracts', () => {
     const manifest: Pick<AppManifest, 'infra'> = {
       infra: {
         state,
-        plugins: [],
+        modules: [],
+        modulesConfig: {
+          localization: {
+            defaultLocale: 'en',
+          },
+        },
       },
     };
 
     expect(JSON.parse(JSON.stringify(manifest))).toEqual({
       infra: {
         state,
-        plugins: [],
+        modules: [],
+        modulesConfig: {
+          localization: {
+            defaultLocale: 'en',
+          },
+        },
       },
     });
+  });
+
+  it('exposes only canonical module fields on the infra contract', () => {
+    type HasLegacyModules = 'plugins' extends keyof InfraManifest ? true : false;
+    type HasLegacyModulesConfig = 'pluginsConfig' extends keyof InfraManifest ? true : false;
+
+    const hasLegacyModules: HasLegacyModules = false;
+    const hasLegacyModulesConfig: HasLegacyModulesConfig = false;
+    const infra: InfraManifest = {
+      modules: ['expo-localization'],
+      modulesConfig: {
+        'expo-localization': {
+          defaultLocale: 'en',
+          locales: ['en', 'de'],
+        },
+      },
+    };
+
+    expect(hasLegacyModules).toBe(false);
+    expect(hasLegacyModulesConfig).toBe(false);
+    expect(Object.keys(infra).sort()).toEqual(['modules', 'modulesConfig']);
   });
 
   it('ThemeModeConfig.harmony accepts all ColorHarmony values', () => {
@@ -286,6 +318,8 @@ describe('contracts', () => {
       'suggested' + 'Color' + 'Tone',
       'APP_CATEGORY_' + 'THEME_RECOMMENDATIONS',
       'hide' + 'InTabBar',
+      'plug' + 'ins',
+      'plug' + 'insConfig',
     ];
 
     const srcFiles = await collectTypeScriptFiles(join(process.cwd(), 'src'));

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -265,7 +265,7 @@ describe('contracts', () => {
     });
   });
 
-  it('exposes only canonical module fields on the infra contract', () => {
+  it('exposes only canonical module fields without reserving external plugin terminology', () => {
     type HasLegacyModules = 'plugins' extends keyof InfraManifest ? true : false;
     type HasLegacyModulesConfig = 'pluginsConfig' extends keyof InfraManifest ? true : false;
 
@@ -280,10 +280,16 @@ describe('contracts', () => {
         },
       },
     };
+    // `plugins` remains valid when it names an unrelated external ecosystem concept,
+    // such as Expo configuration plugins rather than Ankhorage Orchestrator modules.
+    const expoConfig: { plugins: string[] } = {
+      plugins: ['expo-router'],
+    };
 
     expect(hasLegacyModules).toBe(false);
     expect(hasLegacyModulesConfig).toBe(false);
     expect(Object.keys(infra).sort()).toEqual(['modules', 'modulesConfig']);
+    expect(expoConfig.plugins).toEqual(['expo-router']);
   });
 
   it('ThemeModeConfig.harmony accepts all ColorHarmony values', () => {
@@ -318,8 +324,6 @@ describe('contracts', () => {
       'suggested' + 'Color' + 'Tone',
       'APP_CATEGORY_' + 'THEME_RECOMMENDATIONS',
       'hide' + 'InTabBar',
-      'plug' + 'ins',
-      'plug' + 'insConfig',
     ];
 
     const srcFiles = await collectTypeScriptFiles(join(process.cwd(), 'src'));

--- a/src/secrets.test.ts
+++ b/src/secrets.test.ts
@@ -69,7 +69,7 @@ describe('secret-store contracts', () => {
     };
 
     const infra: InfraManifest = {
-      plugins: [],
+      modules: [],
       secretStore: { provider: 'supabase-vault' },
       auth: {
         scope: 'global',

--- a/src/types.ts
+++ b/src/types.ts
@@ -367,8 +367,8 @@ export interface InfraManifest {
   storage?: StorageSpec;
   state?: StateSpec;
   networking?: NetworkingSpec;
-  plugins: string[];
-  pluginsConfig?: Record<string, unknown>;
+  modules: string[];
+  modulesConfig?: Record<string, unknown>;
 }
 
 export interface AppSettings {


### PR DESCRIPTION
## Summary

- rename the canonical Ankhorage module registry fields on `InfraManifest` from `plugins` / `pluginsConfig` to `modules` / `modulesConfig`
- remove the obsolete field names without aliases, dual reads, or compatibility paths
- add type/source invariants that prevent the legacy names from returning
- regenerate Paradox documentation and add a major changeset

## Why

This is the owner-first Contracts boundary required by [ankhorage/studio#125](https://github.com/ankhorage/studio/issues/125). Ankhorage Orchestrator modules must use one canonical vocabulary before Orchestrator, module packages, Infra, Templates, and Studio migrate downstream.

## Impact

This is intentionally breaking. Consumers must migrate their app manifests to `infra.modules` and `infra.modulesConfig` after `@ankhorage/contracts` 6.0.0 is released. No downstream compatibility alias is provided.

Per the roadmap release rule, ADM 10 stops at this PR until the Contracts release is available.

## Validation

- `bun run lint:fix`
- `bun run build`
- `bun run test` (78 passing)
- `bun run knip`
- `bun run typecheck`
- `bun run docs`
- `bun run format:check`
- `bun run changeset:status` (major bump confirmed)
