### PR TITLE
Add canonical app deployment contracts

### DIFF
--- a/.changeset/calm-app-deploy-contracts.md
+++ b/.changeset/calm-app-deploy-contracts.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Add canonical provider-neutral app deployment contracts for Web, Android, and iOS, expose them through `AppManifest.deploy` and `@ankhorage/contracts/deploy`, and validate the serialized deployment subtree through the canonical AppManifest parser.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
       "types": "./dist/db.d.ts",
       "default": "./dist/db.js"
     },
+    "./deploy": {
+      "types": "./dist/deploy.d.ts",
+      "default": "./dist/deploy.js"
+    },
     "./runtime": {
       "types": "./dist/runtimeCallbacks.d.ts",
       "default": "./dist/runtimeCallbacks.js"

--- a/src/appManifest.ts
+++ b/src/appManifest.ts
@@ -1,5 +1,6 @@
 import { isComponentDataBindingRegistry } from './appManifest/bindings';
 import { isDataSourceRegistry } from './appManifest/dataSources';
+import { isAppDeployManifest } from './appManifest/deploy';
 import { isGeneratedApiRegistry } from './appManifest/generatedApis';
 import { isInfraManifest } from './appManifest/infra';
 import { isMediaManifest } from './appManifest/media';
@@ -24,6 +25,7 @@ const APP_MANIFEST_KEY_POLICY = {
   activeThemeMode: 'optional',
   splashScreen: 'optional',
   media: 'optional',
+  deploy: 'optional',
   infra: 'required',
   navigator: 'required',
   screens: 'required',
@@ -58,6 +60,7 @@ export function isAppManifest(value: unknown): value is AppManifest {
     isActiveThemeMode(value.activeThemeMode) &&
     (value.splashScreen === undefined || isSplashScreenSpec(value.splashScreen)) &&
     (value.media === undefined || isMediaManifest(value.media)) &&
+    (value.deploy === undefined || isAppDeployManifest(value.deploy)) &&
     isInfraManifest(value.infra) &&
     isNavigatorSpec(value.navigator) &&
     isScreenRegistry(value.screens) &&

--- a/src/appManifest/deploy.ts
+++ b/src/appManifest/deploy.ts
@@ -16,11 +16,7 @@ const ANDROID_KEYS = new Set(['enabled', 'package', 'providers']);
 const IOS_KEYS = new Set(['enabled', 'bundleIdentifier', 'providers']);
 
 export function isAppDeployManifest(value: unknown): value is AppDeployManifest {
-  return (
-    isRecord(value) &&
-    hasOnlyKeys(value, DEPLOY_KEYS) &&
-    isAppDeployTargets(value.targets)
-  );
+  return isRecord(value) && hasOnlyKeys(value, DEPLOY_KEYS) && isAppDeployTargets(value.targets);
 }
 
 function isAppDeployTargets(value: unknown): value is AppDeployTargets {

--- a/src/appManifest/deploy.ts
+++ b/src/appManifest/deploy.ts
@@ -1,0 +1,84 @@
+import type {
+  AppDeployAndroidTargetConfig,
+  AppDeployIosTargetConfig,
+  AppDeployManifest,
+  AppDeployProviderSelection,
+  AppDeployTargets,
+  AppDeployWebTargetConfig,
+} from '../deploy';
+import { isRecord } from './shared';
+
+const DEPLOY_KEYS = new Set(['targets']);
+const TARGET_KEYS = new Set(['web', 'android', 'ios']);
+const PROVIDER_KEYS = new Set(['build', 'publish']);
+const WEB_KEYS = new Set(['enabled', 'providers']);
+const ANDROID_KEYS = new Set(['enabled', 'package', 'providers']);
+const IOS_KEYS = new Set(['enabled', 'bundleIdentifier', 'providers']);
+
+export function isAppDeployManifest(value: unknown): value is AppDeployManifest {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, DEPLOY_KEYS) &&
+    isAppDeployTargets(value.targets)
+  );
+}
+
+function isAppDeployTargets(value: unknown): value is AppDeployTargets {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, TARGET_KEYS) &&
+    (value.web === undefined || isWebTarget(value.web)) &&
+    (value.android === undefined || isAndroidTarget(value.android)) &&
+    (value.ios === undefined || isIosTarget(value.ios))
+  );
+}
+
+function isWebTarget(value: unknown): value is AppDeployWebTargetConfig {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, WEB_KEYS) &&
+    typeof value.enabled === 'boolean' &&
+    isOptionalProviders(value.providers)
+  );
+}
+
+function isAndroidTarget(value: unknown): value is AppDeployAndroidTargetConfig {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ANDROID_KEYS) &&
+    typeof value.enabled === 'boolean' &&
+    isNonEmptyString(value.package) &&
+    isOptionalProviders(value.providers)
+  );
+}
+
+function isIosTarget(value: unknown): value is AppDeployIosTargetConfig {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, IOS_KEYS) &&
+    typeof value.enabled === 'boolean' &&
+    isNonEmptyString(value.bundleIdentifier) &&
+    isOptionalProviders(value.providers)
+  );
+}
+
+function isOptionalProviders(value: unknown): value is AppDeployProviderSelection | undefined {
+  return value === undefined || isProviderSelection(value);
+}
+
+function isProviderSelection(value: unknown): value is AppDeployProviderSelection {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, PROVIDER_KEYS) &&
+    (value.build === undefined || isNonEmptyString(value.build)) &&
+    (value.publish === undefined || isNonEmptyString(value.publish))
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
+  return Object.keys(value).every((key) => allowed.has(key));
+}

--- a/src/deploy.test.ts
+++ b/src/deploy.test.ts
@@ -1,0 +1,121 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'bun:test';
+
+import { isAppManifest } from './appManifest';
+import { APP_DEPLOY_TARGET_IDS, isAppDeployManifest } from './deploy';
+import { DEPLOYMENT_TARGETS } from './types';
+
+function createManifest(deploy?: unknown): Record<string, unknown> {
+  return {
+    metadata: {
+      name: 'Example',
+      slug: 'example',
+      version: '1.0.0',
+      category: 'developer_tools',
+      themeId: 'default',
+    },
+    themes: [
+      {
+        id: 'default',
+        name: 'Default',
+        light: { primaryColor: '#3366ff', harmony: 'analogous' },
+        dark: { primaryColor: '#6699ff', harmony: 'analogous' },
+      },
+    ],
+    activeThemeId: 'default',
+    ...(deploy === undefined ? {} : { deploy }),
+    infra: { deployment: { target: 'minikube', monitoring: true }, modules: [] },
+    navigator: { type: 'stack', routes: [] },
+    screens: {},
+    settings: { localization: { defaultLocale: 'en', locales: ['en'] } },
+  };
+}
+
+describe('app deployment contracts', () => {
+  it('keeps app distribution targets distinct from Infra deployment targets', () => {
+    expect(APP_DEPLOY_TARGET_IDS).toEqual(['web', 'android', 'ios']);
+    expect(DEPLOYMENT_TARGETS).toEqual(['minikube']);
+  });
+
+  it('accepts canonical web, Android, and iOS desired state', () => {
+    const deploy = {
+      targets: {
+        web: { enabled: true, providers: { publish: 'eas' } },
+        android: {
+          enabled: true,
+          package: 'com.example.app',
+          providers: { build: 'eas', publish: 'google-play' },
+        },
+        ios: {
+          enabled: false,
+          bundleIdentifier: 'com.example.app',
+          providers: { build: 'eas', publish: 'app-store-connect' },
+        },
+      },
+    };
+
+    expect(isAppDeployManifest(deploy)).toBe(true);
+    expect(isAppManifest(createManifest(deploy))).toBe(true);
+  });
+
+  it('keeps deployment optional and accepts an empty target registry structurally', () => {
+    expect(isAppManifest(createManifest())).toBe(true);
+    expect(isAppDeployManifest({ targets: {} })).toBe(true);
+  });
+
+  it('keeps provider identifiers opaque but non-empty', () => {
+    expect(
+      isAppDeployManifest({
+        targets: {
+          web: {
+            enabled: true,
+            providers: { build: 'custom-build', publish: 'custom-host' },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects malformed, unknown, and credential-shaped deployment fields', () => {
+    const invalidValues: readonly unknown[] = [
+      null,
+      {},
+      { targets: null },
+      { targets: { desktop: { enabled: true } } },
+      { targets: { web: { enabled: 'yes' } } },
+      { targets: { android: { enabled: true, package: '' } } },
+      { targets: { ios: { enabled: true, bundleIdentifier: ' ' } } },
+      { targets: { web: { enabled: true, providers: { publish: '' } } } },
+      { targets: { web: { enabled: true, providerConfig: { region: 'eu' } } } },
+      { targets: { web: { enabled: true, credentials: { token: 'secret' } } } },
+      { targets: {}, credentials: { token: 'secret' } },
+    ];
+
+    for (const value of invalidValues) {
+      expect(isAppDeployManifest(value)).toBe(false);
+    }
+  });
+
+  it('rejects a malformed deploy subtree through the canonical AppManifest parser', () => {
+    expect(
+      isAppManifest(
+        createManifest({
+          targets: { android: { enabled: true, package: 'com.example.app', credentials: {} } },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('publishes the focused deployment contract subpath', async () => {
+    const packageJson = JSON.parse(await readFile(join(process.cwd(), 'package.json'), 'utf8')) as {
+      exports?: Record<string, { default?: string; types?: string }>;
+    };
+
+    expect(packageJson.exports?.['./deploy']).toEqual({
+      types: './dist/deploy.d.ts',
+      default: './dist/deploy.js',
+    });
+  });
+});

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,0 +1,35 @@
+export const APP_DEPLOY_TARGET_IDS = ['web', 'android', 'ios'] as const;
+
+export type AppDeployTargetId = (typeof APP_DEPLOY_TARGET_IDS)[number];
+
+export interface AppDeployProviderSelection {
+  readonly build?: string;
+  readonly publish?: string;
+}
+
+export interface AppDeployWebTargetConfig {
+  readonly enabled: boolean;
+  readonly providers?: AppDeployProviderSelection;
+}
+
+export interface AppDeployAndroidTargetConfig {
+  readonly enabled: boolean;
+  readonly package: string;
+  readonly providers?: AppDeployProviderSelection;
+}
+
+export interface AppDeployIosTargetConfig {
+  readonly enabled: boolean;
+  readonly bundleIdentifier: string;
+  readonly providers?: AppDeployProviderSelection;
+}
+
+export interface AppDeployTargets {
+  readonly web?: AppDeployWebTargetConfig;
+  readonly android?: AppDeployAndroidTargetConfig;
+  readonly ios?: AppDeployIosTargetConfig;
+}
+
+export interface AppDeployManifest {
+  readonly targets: AppDeployTargets;
+}

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -33,3 +33,5 @@ export interface AppDeployTargets {
 export interface AppDeployManifest {
   readonly targets: AppDeployTargets;
 }
+
+export { isAppDeployManifest } from './appManifest/deploy';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from './bindings';
 export * from './cli';
 export * from './data';
 export * from './db';
+export * from './deploy';
 export * from './media';
 export * from './requirements';
 export * from './runtimeCallbacks';

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ import type {
   ScreenDataLoaderDefinition,
 } from './bindings';
 import type { DataSourceRegistry, GeneratedApiRegistry } from './data';
+import type { AppDeployManifest } from './deploy';
 import type { MediaManifest } from './media';
 import type { ScreenRequirements } from './requirements';
 import type { ThemeGlobalTokenOverrides, ThemeRecipeOverrides } from './theme';
@@ -401,6 +402,8 @@ export interface AppManifest {
   splashScreen?: SplashScreenSpec;
   /** Studio-managed authoring media. Runtime/user uploads are intentionally separate. */
   media?: MediaManifest;
+  /** App distribution desired state. Infrastructure deployment remains under `infra.deployment`. */
+  deploy?: AppDeployManifest;
   infra: InfraManifest;
   navigator: NavigatorSpec;
   screens: Record<string, ScreenSpec>;


### PR DESCRIPTION
Roadmap: https://github.com/ankhorage/deploy/issues/1
DEP 1: https://github.com/ankhorage/deploy/issues/2

## Summary

- add provider-neutral Web / Android / iOS app deployment contracts
- add optional canonical `AppManifest.deploy`
- keep app distribution distinct from existing `infra.deployment`
- expose focused `@ankhorage/contracts/deploy`
- add one strict deploy-subtree validator and compose it into the canonical AppManifest parser
- reject unknown target/config/credential-shaped fields instead of creating a provider-specific escape hatch
- keep provider IDs opaque so provider capability semantics remain owned by `@ankhorage/deploy`
- add behavior-focused parsing/public-export tests and a minor changeset

## Architecture

```text
ankh.config.json
      |
      v
@ankhorage/contracts
  AppManifest.deploy
      |
      v
@ankhorage/deploy
  semantic validation
  inspect / plan / execute / verify
```

Existing Infra deployment remains separate:

```text
infra.deployment -> infrastructure runtime target (e.g. minikube)
AppManifest.deploy -> app distribution targets (web / android / ios)
```

## Scope deliberately excluded

This PR does not add listing content, store assets, release notes, rollout state, monetization, deployment history, credentials, provider SDK payloads, or Deploy execution semantics. Those belong to later DEP roadmap steps.

## Release boundary

After this PR is merged and `@ankhorage/contracts` is released, implementation continues in `@ankhorage/deploy`. No source/deep-import bridge should be used before that release.