### PR TITLE
feat: support category-root CLI commands

### DIFF
--- a/.changeset/gentle-root-command.md
+++ b/.changeset/gentle-root-command.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Allow CLI provider manifests to declare category-root commands with an empty command path.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # CONTRACTS
 
-![license: MIT](././paradox/badges/license.svg) ![npm: v7.6.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
+![license: MIT](././paradox/badges/license.svg) ![npm: v7.8.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
 
 Serializable app, action, theme, auth, and secret-store contracts for Ankhorage.
 

--- a/paradox/badges/npm.svg
+++ b/paradox/badges/npm.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="npm: v7.6.0">
-<title>npm: v7.6.0</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="npm: v7.8.0">
+<title>npm: v7.8.0</title>
 <rect width="38" height="20" fill="#374151"/>
 <rect x="38" width="52" height="20" fill="#cb3837"/>
 <text x="19" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">npm</text>
-<text x="64" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v7.6.0</text>
+<text x="64" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v7.8.0</text>
 </svg>

--- a/paradox/diagrams/architecture-overview.mmd
+++ b/paradox/diagrams/architecture-overview.mmd
@@ -44,6 +44,7 @@ graph TD
   package__ankhorage_contracts -.-> module_src_appManifest_shared_ts
   module_src_auth_ts["src/auth.ts"]
   package__ankhorage_contracts -.-> module_src_auth_ts
+  module_src_auth_ts --> module_src_deploy_ts
   module_src_auth_ts --> module_src_secrets_ts
   module_src_auth_ts --> module_src_types_ts
   module_src_bindings_ts["src/bindings.ts"]

--- a/paradox/diagrams/export-graph.mmd
+++ b/paradox/diagrams/export-graph.mmd
@@ -142,10 +142,18 @@ graph LR
   module_src_auth_ts --> export_AUTH_OAUTH_ERROR_STAGES
   export_AUTH_OAUTH_PROVIDER_IDS["AUTH_OAUTH_PROVIDER_IDS"]
   module_src_auth_ts --> export_AUTH_OAUTH_PROVIDER_IDS
+  export_AUTH_OAUTH_SETUP_CALLBACK_ROLES["AUTH_OAUTH_SETUP_CALLBACK_ROLES"]
+  module_src_auth_ts --> export_AUTH_OAUTH_SETUP_CALLBACK_ROLES
+  export_AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS["AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS"]
+  module_src_auth_ts --> export_AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS
+  export_AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES["AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES"]
+  module_src_auth_ts --> export_AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES
   export_AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS["AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS"]
   module_src_auth_ts --> export_AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS
   export_AUTH_OAUTH_TRANSPORT_ERROR_CODES["AUTH_OAUTH_TRANSPORT_ERROR_CODES"]
   module_src_auth_ts --> export_AUTH_OAUTH_TRANSPORT_ERROR_CODES
+  export_AUTH_OAUTH_TRANSPORT_IDS["AUTH_OAUTH_TRANSPORT_IDS"]
+  module_src_auth_ts --> export_AUTH_OAUTH_TRANSPORT_IDS
   export_AUTH_PROFILE_CREATE_STRATEGIES["AUTH_PROFILE_CREATE_STRATEGIES"]
   module_src_types_ts --> export_AUTH_PROFILE_CREATE_STRATEGIES
   export_AUTH_PROFILE_FIELDS["AUTH_PROFILE_FIELDS"]
@@ -221,6 +229,27 @@ graph LR
   export_AuthOAuthProviderConfig -.-> export_IconSpec
   export_AuthOAuthProviderId["AuthOAuthProviderId"]
   module_src_auth_ts --> export_AuthOAuthProviderId
+  export_AuthOAuthSetupCallbackRequirement["AuthOAuthSetupCallbackRequirement"]
+  module_src_auth_ts --> export_AuthOAuthSetupCallbackRequirement
+  export_AuthOAuthSetupCallbackRole["AuthOAuthSetupCallbackRole"]
+  module_src_auth_ts --> export_AuthOAuthSetupCallbackRole
+  export_AuthOAuthSetupCapabilities["AuthOAuthSetupCapabilities"]
+  module_src_auth_ts --> export_AuthOAuthSetupCapabilities
+  export_AuthOAuthSetupCapabilities -.-> export_AuthOAuthProviderId
+  export_AuthOAuthSetupCapabilities -.-> export_AuthOAuthTransportId
+  export_AuthOAuthSetupFieldPersistence["AuthOAuthSetupFieldPersistence"]
+  module_src_auth_ts --> export_AuthOAuthSetupFieldPersistence
+  export_AuthOAuthSetupFieldRequirement["AuthOAuthSetupFieldRequirement"]
+  module_src_auth_ts --> export_AuthOAuthSetupFieldRequirement
+  export_AuthOAuthSetupFieldSensitivity["AuthOAuthSetupFieldSensitivity"]
+  module_src_auth_ts --> export_AuthOAuthSetupFieldSensitivity
+  export_AuthOAuthSetupPlan["AuthOAuthSetupPlan"]
+  module_src_auth_ts --> export_AuthOAuthSetupPlan
+  export_AuthOAuthSetupPlan -.-> export_AuthOAuthProviderId
+  export_AuthOAuthSetupPlan -.-> export_AuthOAuthSetupRequirement
+  export_AuthOAuthSetupPlan -.-> export_AuthOAuthTransportId
+  export_AuthOAuthSetupRequirement["AuthOAuthSetupRequirement"]
+  module_src_auth_ts --> export_AuthOAuthSetupRequirement
   export_AuthOAuthStartResult["AuthOAuthStartResult"]
   module_src_auth_ts --> export_AuthOAuthStartResult
   export_AuthOAuthTransportCancellationReason["AuthOAuthTransportCancellationReason"]
@@ -229,6 +258,8 @@ graph LR
   module_src_auth_ts --> export_AuthOAuthTransportError
   export_AuthOAuthTransportErrorCode["AuthOAuthTransportErrorCode"]
   module_src_auth_ts --> export_AuthOAuthTransportErrorCode
+  export_AuthOAuthTransportId["AuthOAuthTransportId"]
+  module_src_auth_ts --> export_AuthOAuthTransportId
   export_AuthProfileCreateStrategy["AuthProfileCreateStrategy"]
   module_src_types_ts --> export_AuthProfileCreateStrategy
   export_AuthProfileField["AuthProfileField"]
@@ -671,6 +702,8 @@ graph LR
   module_src_media_ts --> export_isMediaAssetReference
   export_KnownAuthOAuthProviderId["KnownAuthOAuthProviderId"]
   module_src_auth_ts --> export_KnownAuthOAuthProviderId
+  export_KnownAuthOAuthTransportId["KnownAuthOAuthTransportId"]
+  module_src_auth_ts --> export_KnownAuthOAuthTransportId
   export_KnownAuthProfileField["KnownAuthProfileField"]
   module_src_types_ts --> export_KnownAuthProfileField
   export_KnownAuthProvider["KnownAuthProvider"]

--- a/paradox/diagrams/module-relationships.mmd
+++ b/paradox/diagrams/module-relationships.mmd
@@ -56,6 +56,7 @@ graph LR
   module_src_appManifest_screens_ts --> module_src_appManifest_bindings_ts
   module_src_appManifest_screens_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_screens_ts --> module_src_types_ts
+  module_src_auth_ts --> module_src_deploy_ts
   module_src_auth_ts --> module_src_secrets_ts
   module_src_auth_ts --> module_src_types_ts
   module_src_bindings_ts --> module_src_data_index_ts

--- a/paradox/exports.json
+++ b/paradox/exports.json
@@ -234,7 +234,7 @@
       {
         "name": "path",
         "kind": "property",
-        "type": "readonly [string, ...string[]]",
+        "type": "readonly string[]",
         "required": true,
         "description": null
       },
@@ -257,7 +257,7 @@
     "modulePath": "src/cli/index.ts",
     "sourceLocation": {
       "filePath": "src/cli/index.ts",
-      "line": 15,
+      "line": 20,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -383,7 +383,7 @@
     "modulePath": "src/cli/index.ts",
     "sourceLocation": {
       "filePath": "src/cli/index.ts",
-      "line": 23,
+      "line": 28,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -472,7 +472,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -521,7 +521,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -966,14 +966,14 @@
       {
         "name": "dataBindings",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/bindings\").ComponentDataBinding>> | undefined",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/bindings\").ComponentDataBinding>> | undefined",
         "required": false,
         "description": null
       },
       {
         "name": "dataSources",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSourceConfig>> | undefined",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSourceConfig>> | undefined",
         "required": false,
         "description": null
       },
@@ -987,7 +987,7 @@
       {
         "name": "generatedApis",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").GeneratedApiDefinition>> | undefined",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").GeneratedApiDefinition>> | undefined",
         "required": false,
         "description": null
       },
@@ -1110,7 +1110,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 4,
+      "line": 5,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1128,7 +1128,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 217,
+      "line": 282,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1146,7 +1146,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 184,
+      "line": 249,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1164,7 +1164,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 174,
+      "line": 239,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1182,7 +1182,61 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 17,
+      "line": 18,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "AUTH_OAUTH_SETUP_CALLBACK_ROLES",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 56,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 46,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 53,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1200,7 +1254,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 210,
+      "line": 275,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1218,7 +1272,25 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 223,
+      "line": 288,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "AUTH_OAUTH_TRANSPORT_IDS",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 42,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1362,7 +1434,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 7,
+      "line": 8,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1398,7 +1470,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 317,
+      "line": 382,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1491,7 +1563,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 309,
+      "line": 374,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1545,7 +1617,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 126,
+      "line": 191,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1585,7 +1657,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 46,
+      "line": 111,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1653,7 +1725,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 41,
+      "line": 106,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1686,7 +1758,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 5,
+      "line": 6,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1704,7 +1776,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 302,
+      "line": 367,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1750,7 +1822,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 242,
+      "line": 307,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1797,7 +1869,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 259,
+      "line": 324,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1815,7 +1887,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 221,
+      "line": 286,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1833,7 +1905,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 297,
+      "line": 362,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1859,7 +1931,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 278,
+      "line": 343,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1877,7 +1949,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 89,
+      "line": 154,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1917,7 +1989,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 203,
+      "line": 268,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1962,7 +2034,7 @@
       {
         "name": "stage",
         "kind": "property",
-        "type": "\"start\" | \"transport\" | \"callback\" | \"exchange\" | \"session\" | \"profile\"",
+        "type": "\"callback\" | \"start\" | \"transport\" | \"exchange\" | \"session\" | \"profile\"",
         "required": true,
         "description": null
       }
@@ -1978,7 +2050,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 201,
+      "line": 266,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1996,7 +2068,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 182,
+      "line": 247,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2014,7 +2086,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 78,
+      "line": 143,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2082,7 +2154,302 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 39,
+      "line": 40,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "AuthOAuthSetupCallbackRequirement",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 72,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "description",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "kind",
+        "kind": "property",
+        "type": "\"callback\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "label",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "required",
+        "kind": "property",
+        "type": "boolean",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "role",
+        "kind": "property",
+        "type": "\"provider\" | \"app\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "target",
+        "kind": "property",
+        "type": "\"web\" | \"android\" | \"ios\" | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "AuthOAuthSetupCallbackRole",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 57,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "AuthOAuthSetupCapabilities",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 101,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["AuthOAuthProviderId", "AuthOAuthTransportId"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "providers",
+        "kind": "property",
+        "type": "readonly AuthOAuthProviderId[]",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "transports",
+        "kind": "property",
+        "type": "readonly AuthOAuthTransportId[]",
+        "required": true,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "AuthOAuthSetupFieldPersistence",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 50,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "AuthOAuthSetupFieldRequirement",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 59,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "description",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "key",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "kind",
+        "kind": "property",
+        "type": "\"field\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "label",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "persistence",
+        "kind": "property",
+        "type": "\"trustedCredential\" | \"publicConfig\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "required",
+        "kind": "property",
+        "type": "boolean",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "sensitivity",
+        "kind": "property",
+        "type": "\"public\" | \"secret\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "target",
+        "kind": "property",
+        "type": "\"web\" | \"android\" | \"ios\" | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "AuthOAuthSetupFieldSensitivity",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 54,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "AuthOAuthSetupPlan",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 91,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["AuthOAuthProviderId", "AuthOAuthSetupRequirement", "AuthOAuthTransportId"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "environment",
+        "kind": "property",
+        "type": "\"local\" | \"preview\" | \"production\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "provider",
+        "kind": "property",
+        "type": "AuthOAuthProviderId",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "requirements",
+        "kind": "property",
+        "type": "readonly AuthOAuthSetupRequirement[]",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "targets",
+        "kind": "property",
+        "type": "readonly (\"web\" | \"android\" | \"ios\")[]",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "transport",
+        "kind": "property",
+        "type": "AuthOAuthTransportId",
+        "required": true,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "AuthOAuthSetupRequirement",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 82,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2100,7 +2467,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 249,
+      "line": 314,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2118,7 +2485,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 214,
+      "line": 279,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2136,7 +2503,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 229,
+      "line": 294,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2176,7 +2543,25 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 227,
+      "line": 292,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "AuthOAuthTransportId",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 44,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2258,7 +2643,7 @@
       {
         "name": "createStrategy",
         "kind": "property",
-        "type": "\"api\" | \"trigger\" | \"app\" | undefined",
+        "type": "\"app\" | \"api\" | \"trigger\" | undefined",
         "required": false,
         "description": null
       },
@@ -2286,7 +2671,7 @@
       {
         "name": "updateStrategy",
         "kind": "property",
-        "type": "\"api\" | \"app\" | undefined",
+        "type": "\"app\" | \"api\" | undefined",
         "required": false,
         "description": null
       }
@@ -2338,7 +2723,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 95,
+      "line": 160,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2399,7 +2784,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 132,
+      "line": 197,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2435,7 +2820,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 118,
+      "line": 183,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2489,7 +2874,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 69,
+      "line": 134,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2559,7 +2944,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 73,
+      "line": 138,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2592,7 +2977,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 15,
+      "line": 16,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2751,7 +3136,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 108,
+      "line": 173,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3323,7 +3708,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 273,
+      "line": 338,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3809,7 +4194,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -3844,7 +4229,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -4857,7 +5242,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -4892,7 +5277,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -6183,7 +6568,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 56,
+      "line": 121,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -6370,7 +6755,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -6433,7 +6818,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -6486,7 +6871,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -6542,7 +6927,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -7082,7 +7467,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -7138,7 +7523,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -7471,7 +7856,25 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 38,
+      "line": 39,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "KnownAuthOAuthTransportId",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/auth.ts",
+    "sourceLocation": {
+      "filePath": "src/auth.ts",
+      "line": 43,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7525,7 +7928,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 14,
+      "line": 15,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8434,7 +8837,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 162,
+      "line": 227,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8533,7 +8936,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 65,
+      "line": 130,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8898,7 +9301,7 @@
       {
         "name": "dataLoaders",
         "kind": "property",
-        "type": "readonly import(\"./src/bindings\").OperationScreenDataLoaderDefinition[] | undefined",
+        "type": "readonly import(\"/Users/a_rtiphishl_e/git/contracts/src/bindings\").OperationScreenDataLoaderDefinition[] | undefined",
         "required": false,
         "description": null
       },
@@ -9611,7 +10014,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 142,
+      "line": 207,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9665,7 +10068,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 158,
+      "line": 223,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9691,7 +10094,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 150,
+      "line": 215,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9904,7 +10307,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 235,
+      "line": 300,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10279,7 +10682,7 @@
       {
         "name": "persistence",
         "kind": "property",
-        "type": "\"database\" | \"none\" | \"local\" | \"secure\" | undefined",
+        "type": "\"local\" | \"database\" | \"none\" | \"secure\" | undefined",
         "required": false,
         "description": null
       },
@@ -12764,7 +13167,7 @@
     "modulePath": "src/auth.ts",
     "sourceLocation": {
       "filePath": "src/auth.ts",
-      "line": 167,
+      "line": 232,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],

--- a/paradox/exports.md
+++ b/paradox/exports.md
@@ -78,14 +78,14 @@ Source: `src/cli/index.ts:7:1`
 | aliases    | property | `readonly string[] \| undefined` | no       |             |
 | capability | property | `${string}.${string}`            | yes      |             |
 | examples   | property | `readonly string[] \| undefined` | no       |             |
-| path       | property | `readonly [string, ...string[]]` | yes      |             |
+| path       | property | `readonly string[]`              | yes      |             |
 | summary    | property | `string`                         | yes      |             |
 
 ## AnkhCommandProviderManifest
 
 Kind: `type`
 Module: `src/cli/index.ts`
-Source: `src/cli/index.ts:15:1`
+Source: `src/cli/index.ts:20:1`
 
 ### Members
 
@@ -125,7 +125,7 @@ Source: `src/requirements.ts:12:1`
 
 Kind: `type`
 Module: `src/cli/index.ts`
-Source: `src/cli/index.ts:23:1`
+Source: `src/cli/index.ts:28:1`
 
 ### Members
 
@@ -149,18 +149,18 @@ Source: `src/data/sources.ts:22:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                      | Required | Description |
-| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
-| description | property | `string \| undefined`                                                     | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                  | yes      |             |
-| kind        | property | `"api"`                                                                   | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
-| name        | property | `string \| undefined`                                                     | no       |             |
-| origin      | property | `ApiOrigin`                                                               | yes      |             |
-| protocol    | property | `ApiProtocol`                                                             | yes      |             |
-| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                                                       | Required | Description |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| credential  | property | `CredentialRef \| undefined`                                                                               | no       |             |
+| description | property | `string \| undefined`                                                                                      | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
+| id          | property | `string`                                                                                                   | yes      |             |
+| kind        | property | `"api"`                                                                                                    | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                                                           | no       |             |
+| name        | property | `string \| undefined`                                                                                      | no       |             |
+| origin      | property | `ApiOrigin`                                                                                                | yes      |             |
+| protocol    | property | `ApiProtocol`                                                                                              | yes      |             |
+| schemas     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
 
 ## ApiDataSourceConfig
 
@@ -310,10 +310,10 @@ Source: `src/types.ts:389:1`
 | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------- |
 | activeThemeId   | property | `string`                                                                                                                       | yes      |             |
 | activeThemeMode | property | `"dark" \| "light" \| undefined`                                                                                               | no       |             |
-| dataBindings    | property | `Readonly<Record<string, import("./src/bindings").ComponentDataBinding>> \| undefined`                                         | no       |             |
-| dataSources     | property | `Readonly<Record<string, import("./src/index").DataSourceConfig>> \| undefined`                                                | no       |             |
+| dataBindings    | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/bindings").ComponentDataBinding>> \| undefined`        | no       |             |
+| dataSources     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSourceConfig>> \| undefined`               | no       |             |
 | deploy          | property | `AppDeployManifest \| undefined`                                                                                               | no       |             |
-| generatedApis   | property | `Readonly<Record<string, import("./src/index").GeneratedApiDefinition>> \| undefined`                                          | no       |             |
+| generatedApis   | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").GeneratedApiDefinition>> \| undefined`         | no       |             |
 | infra           | property | `InfraManifest`                                                                                                                | yes      |             |
 | media           | property | `MediaManifest \| undefined`                                                                                                   | no       |             |
 | metadata        | property | `{ name: string; slug: string; version: string; category: AppCategory; themeId: string; created?: string; updated?: string; }` | yes      |             |
@@ -346,43 +346,67 @@ Source: `src/types.ts:381:1`
 
 Kind: `value`
 Module: `src/auth.ts`
-Source: `src/auth.ts:4:14`
+Source: `src/auth.ts:5:14`
 
 ## AUTH_OAUTH_CANCELLATION_REASONS
 
 Kind: `value`
 Module: `src/auth.ts`
-Source: `src/auth.ts:217:14`
+Source: `src/auth.ts:282:14`
 
 ## AUTH_OAUTH_ERROR_CODES
 
 Kind: `value`
 Module: `src/auth.ts`
-Source: `src/auth.ts:184:14`
+Source: `src/auth.ts:249:14`
 
 ## AUTH_OAUTH_ERROR_STAGES
 
 Kind: `value`
 Module: `src/auth.ts`
-Source: `src/auth.ts:174:14`
+Source: `src/auth.ts:239:14`
 
 ## AUTH_OAUTH_PROVIDER_IDS
 
 Kind: `value`
 Module: `src/auth.ts`
-Source: `src/auth.ts:17:14`
+Source: `src/auth.ts:18:14`
+
+## AUTH_OAUTH_SETUP_CALLBACK_ROLES
+
+Kind: `value`
+Module: `src/auth.ts`
+Source: `src/auth.ts:56:14`
+
+## AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS
+
+Kind: `value`
+Module: `src/auth.ts`
+Source: `src/auth.ts:46:14`
+
+## AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES
+
+Kind: `value`
+Module: `src/auth.ts`
+Source: `src/auth.ts:53:14`
 
 ## AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS
 
 Kind: `value`
 Module: `src/auth.ts`
-Source: `src/auth.ts:210:14`
+Source: `src/auth.ts:275:14`
 
 ## AUTH_OAUTH_TRANSPORT_ERROR_CODES
 
 Kind: `value`
 Module: `src/auth.ts`
-Source: `src/auth.ts:223:14`
+Source: `src/auth.ts:288:14`
+
+## AUTH_OAUTH_TRANSPORT_IDS
+
+Kind: `value`
+Module: `src/auth.ts`
+Source: `src/auth.ts:42:14`
 
 ## AUTH_PROFILE_CREATE_STRATEGIES
 
@@ -430,7 +454,7 @@ Source: `src/types.ts:211:14`
 
 Kind: `value`
 Module: `src/auth.ts`
-Source: `src/auth.ts:7:14`
+Source: `src/auth.ts:8:14`
 
 ## AUTH_SIGN_UP_POLICIES
 
@@ -442,7 +466,7 @@ Source: `src/types.ts:214:14`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:317:1`
+Source: `src/auth.ts:382:1`
 
 ### Members
 
@@ -462,7 +486,7 @@ Source: `src/auth.ts:317:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:309:1`
+Source: `src/auth.ts:374:1`
 
 ### Members
 
@@ -478,7 +502,7 @@ Source: `src/auth.ts:309:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:126:1`
+Source: `src/auth.ts:191:1`
 
 ### Members
 
@@ -492,7 +516,7 @@ Source: `src/auth.ts:126:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:46:1`
+Source: `src/auth.ts:111:1`
 
 ### Members
 
@@ -510,7 +534,7 @@ Source: `src/auth.ts:46:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:41:1`
+Source: `src/auth.ts:106:1`
 
 ### Members
 
@@ -523,13 +547,13 @@ Source: `src/auth.ts:41:1`
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:5:1`
+Source: `src/auth.ts:6:1`
 
 ## AuthOAuthAdapter
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:302:1`
+Source: `src/auth.ts:367:1`
 
 ### Members
 
@@ -543,7 +567,7 @@ Source: `src/auth.ts:302:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:242:1`
+Source: `src/auth.ts:307:1`
 
 ### Members
 
@@ -558,19 +582,19 @@ Source: `src/auth.ts:242:1`
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:259:1`
+Source: `src/auth.ts:324:1`
 
 ## AuthOAuthCancellationReason
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:221:1`
+Source: `src/auth.ts:286:1`
 
 ## AuthOAuthCapabilities
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:297:1`
+Source: `src/auth.ts:362:1`
 
 ### Members
 
@@ -582,13 +606,13 @@ Source: `src/auth.ts:297:1`
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:278:1`
+Source: `src/auth.ts:343:1`
 
 ## AuthOAuthConfig
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:89:1`
+Source: `src/auth.ts:154:1`
 
 ### Members
 
@@ -602,7 +626,7 @@ Source: `src/auth.ts:89:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:203:1`
+Source: `src/auth.ts:268:1`
 
 ### Members
 
@@ -613,25 +637,25 @@ Source: `src/auth.ts:203:1`
 | message     | property | `string`                                                                                                                                                                                                                                                                                                                                                                                     | yes      |             |
 | provider    | property | `AuthOAuthProviderId \| undefined`                                                                                                                                                                                                                                                                                                                                                           | no       |             |
 | recoverable | property | `boolean`                                                                                                                                                                                                                                                                                                                                                                                    | yes      |             |
-| stage       | property | `"start" \| "transport" \| "callback" \| "exchange" \| "session" \| "profile"`                                                                                                                                                                                                                                                                                                               | yes      |             |
+| stage       | property | `"callback" \| "start" \| "transport" \| "exchange" \| "session" \| "profile"`                                                                                                                                                                                                                                                                                                               | yes      |             |
 
 ## AuthOAuthErrorCode
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:201:1`
+Source: `src/auth.ts:266:1`
 
 ## AuthOAuthErrorStage
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:182:1`
+Source: `src/auth.ts:247:1`
 
 ## AuthOAuthProviderConfig
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:78:1`
+Source: `src/auth.ts:143:1`
 
 ### Members
 
@@ -649,25 +673,114 @@ Source: `src/auth.ts:78:1`
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:39:1`
+Source: `src/auth.ts:40:1`
+
+## AuthOAuthSetupCallbackRequirement
+
+Kind: `type`
+Module: `src/auth.ts`
+Source: `src/auth.ts:72:1`
+
+### Members
+
+| Name        | Kind     | Type                                       | Required | Description |
+| ----------- | -------- | ------------------------------------------ | -------- | ----------- |
+| description | property | `string \| undefined`                      | no       |             |
+| kind        | property | `"callback"`                               | yes      |             |
+| label       | property | `string`                                   | yes      |             |
+| required    | property | `boolean`                                  | yes      |             |
+| role        | property | `"provider" \| "app"`                      | yes      |             |
+| target      | property | `"web" \| "android" \| "ios" \| undefined` | no       |             |
+
+## AuthOAuthSetupCallbackRole
+
+Kind: `unknown`
+Module: `src/auth.ts`
+Source: `src/auth.ts:57:1`
+
+## AuthOAuthSetupCapabilities
+
+Kind: `type`
+Module: `src/auth.ts`
+Source: `src/auth.ts:101:1`
+
+### Members
+
+| Name       | Kind     | Type                              | Required | Description |
+| ---------- | -------- | --------------------------------- | -------- | ----------- |
+| providers  | property | `readonly AuthOAuthProviderId[]`  | yes      |             |
+| transports | property | `readonly AuthOAuthTransportId[]` | yes      |             |
+
+## AuthOAuthSetupFieldPersistence
+
+Kind: `unknown`
+Module: `src/auth.ts`
+Source: `src/auth.ts:50:1`
+
+## AuthOAuthSetupFieldRequirement
+
+Kind: `type`
+Module: `src/auth.ts`
+Source: `src/auth.ts:59:1`
+
+### Members
+
+| Name        | Kind     | Type                                       | Required | Description |
+| ----------- | -------- | ------------------------------------------ | -------- | ----------- |
+| description | property | `string \| undefined`                      | no       |             |
+| key         | property | `string`                                   | yes      |             |
+| kind        | property | `"field"`                                  | yes      |             |
+| label       | property | `string`                                   | yes      |             |
+| persistence | property | `"trustedCredential" \| "publicConfig"`    | yes      |             |
+| required    | property | `boolean`                                  | yes      |             |
+| sensitivity | property | `"public" \| "secret"`                     | yes      |             |
+| target      | property | `"web" \| "android" \| "ios" \| undefined` | no       |             |
+
+## AuthOAuthSetupFieldSensitivity
+
+Kind: `unknown`
+Module: `src/auth.ts`
+Source: `src/auth.ts:54:1`
+
+## AuthOAuthSetupPlan
+
+Kind: `type`
+Module: `src/auth.ts`
+Source: `src/auth.ts:91:1`
+
+### Members
+
+| Name         | Kind     | Type                                       | Required | Description |
+| ------------ | -------- | ------------------------------------------ | -------- | ----------- |
+| environment  | property | `"local" \| "preview" \| "production"`     | yes      |             |
+| provider     | property | `AuthOAuthProviderId`                      | yes      |             |
+| requirements | property | `readonly AuthOAuthSetupRequirement[]`     | yes      |             |
+| targets      | property | `readonly ("web" \| "android" \| "ios")[]` | yes      |             |
+| transport    | property | `AuthOAuthTransportId`                     | yes      |             |
+
+## AuthOAuthSetupRequirement
+
+Kind: `unknown`
+Module: `src/auth.ts`
+Source: `src/auth.ts:82:1`
 
 ## AuthOAuthStartResult
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:249:1`
+Source: `src/auth.ts:314:1`
 
 ## AuthOAuthTransportCancellationReason
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:214:1`
+Source: `src/auth.ts:279:1`
 
 ## AuthOAuthTransportError
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:229:1`
+Source: `src/auth.ts:294:1`
 
 ### Members
 
@@ -681,7 +794,13 @@ Source: `src/auth.ts:229:1`
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:227:1`
+Source: `src/auth.ts:292:1`
+
+## AuthOAuthTransportId
+
+Kind: `unknown`
+Module: `src/auth.ts`
+Source: `src/auth.ts:44:1`
 
 ## AuthProfileCreateStrategy
 
@@ -711,11 +830,11 @@ Source: `src/types.ts:346:1`
 
 | Name           | Kind     | Type                                       | Required | Description |
 | -------------- | -------- | ------------------------------------------ | -------- | ----------- |
-| createStrategy | property | `"api" \| "trigger" \| "app" \| undefined` | no       |             |
+| createStrategy | property | `"app" \| "api" \| "trigger" \| undefined` | no       |             |
 | fields         | property | `AuthProfileField[]`                       | yes      |             |
 | primaryKey     | property | `"authUserId" \| undefined`                | no       |             |
 | table          | property | `string \| undefined`                      | no       |             |
-| updateStrategy | property | `"api" \| "app" \| undefined`              | no       |             |
+| updateStrategy | property | `"app" \| "api" \| undefined`              | no       |             |
 
 ## AuthProfileUpdateStrategy
 
@@ -733,7 +852,7 @@ Source: `src/types.ts:209:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:95:1`
+Source: `src/auth.ts:160:1`
 
 ### Members
 
@@ -750,7 +869,7 @@ Source: `src/auth.ts:95:1`
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:132:1`
+Source: `src/auth.ts:197:1`
 
 ## AuthScope
 
@@ -762,7 +881,7 @@ Source: `src/types.ts:205:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:118:1`
+Source: `src/auth.ts:183:1`
 
 ### Members
 
@@ -778,7 +897,7 @@ Source: `src/auth.ts:118:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:69:1`
+Source: `src/auth.ts:134:1`
 
 ### Members
 
@@ -808,7 +927,7 @@ Source: `src/types.ts:336:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:73:1`
+Source: `src/auth.ts:138:1`
 
 ### Members
 
@@ -821,7 +940,7 @@ Source: `src/auth.ts:73:1`
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:15:1`
+Source: `src/auth.ts:16:1`
 
 ## AuthSignUpPolicy
 
@@ -866,7 +985,7 @@ Source: `src/types.ts:354:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:108:1`
+Source: `src/auth.ts:173:1`
 
 ### Members
 
@@ -1062,7 +1181,7 @@ Source: `src/types.ts:127:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:273:1`
+Source: `src/auth.ts:338:1`
 
 ### Members
 
@@ -1219,17 +1338,17 @@ Source: `src/data/sources.ts:63:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                      | Required | Description |
-| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| adapter     | property | `DatabaseAdapterRef`                                                      | yes      |             |
-| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
-| description | property | `string \| undefined`                                                     | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                  | yes      |             |
-| kind        | property | `"database"`                                                              | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
-| name        | property | `string \| undefined`                                                     | no       |             |
-| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                                                       | Required | Description |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| adapter     | property | `DatabaseAdapterRef`                                                                                       | yes      |             |
+| credential  | property | `CredentialRef \| undefined`                                                                               | no       |             |
+| description | property | `string \| undefined`                                                                                      | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
+| id          | property | `string`                                                                                                   | yes      |             |
+| kind        | property | `"database"`                                                                                               | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                                                           | no       |             |
+| name        | property | `string \| undefined`                                                                                      | no       |             |
+| schemas     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
 
 ## DatabaseProvider
 
@@ -1517,16 +1636,16 @@ Source: `src/data/sources.ts:11:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                      | Required | Description |
-| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
-| description | property | `string \| undefined`                                                     | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                  | yes      |             |
-| kind        | property | `DataSourceKind`                                                          | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
-| name        | property | `string \| undefined`                                                     | no       |             |
-| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                                                       | Required | Description |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| credential  | property | `CredentialRef \| undefined`                                                                               | no       |             |
+| description | property | `string \| undefined`                                                                                      | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
+| id          | property | `string`                                                                                                   | yes      |             |
+| kind        | property | `DataSourceKind`                                                                                           | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                                                           | no       |             |
+| name        | property | `string \| undefined`                                                                                      | no       |             |
+| schemas     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
 
 ## DataSourceConfig
 
@@ -1945,7 +2064,7 @@ Source: `src/db.ts:77:1`
 
 Kind: `value`
 Module: `src/auth.ts`
-Source: `src/auth.ts:56:14`
+Source: `src/auth.ts:121:14`
 
 ## DEPLOYMENT_TARGETS
 
@@ -2006,20 +2125,20 @@ Source: `src/data/sources.ts:41:1`
 
 ### Members
 
-| Name          | Kind     | Type                                                                           | Required | Description |
-| ------------- | -------- | ------------------------------------------------------------------------------ | -------- | ----------- |
-| credential    | property | `CredentialRef \| undefined`                                                   | no       |             |
-| description   | property | `string \| undefined`                                                          | no       |             |
-| endpoints     | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`           | yes      |             |
-| endpointUrl   | property | `string`                                                                       | yes      |             |
-| id            | property | `string`                                                                       | yes      |             |
-| introspection | property | `{ readonly enabled: boolean; readonly schemaVersion?: string; } \| undefined` | no       |             |
-| kind          | property | `"api"`                                                                        | yes      |             |
-| metadata      | property | `DataContractValue \| undefined`                                               | no       |             |
-| name          | property | `string \| undefined`                                                          | no       |             |
-| origin        | property | `"external"`                                                                   | yes      |             |
-| protocol      | property | `"graphql"`                                                                    | yes      |             |
-| schemas       | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined`      | no       |             |
+| Name          | Kind     | Type                                                                                                       | Required | Description |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| credential    | property | `CredentialRef \| undefined`                                                                               | no       |             |
+| description   | property | `string \| undefined`                                                                                      | no       |             |
+| endpoints     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
+| endpointUrl   | property | `string`                                                                                                   | yes      |             |
+| id            | property | `string`                                                                                                   | yes      |             |
+| introspection | property | `{ readonly enabled: boolean; readonly schemaVersion?: string; } \| undefined`                             | no       |             |
+| kind          | property | `"api"`                                                                                                    | yes      |             |
+| metadata      | property | `DataContractValue \| undefined`                                                                           | no       |             |
+| name          | property | `string \| undefined`                                                                                      | no       |             |
+| origin        | property | `"external"`                                                                                               | yes      |             |
+| protocol      | property | `"graphql"`                                                                                                | yes      |             |
+| schemas       | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
 
 ## ExternalRestApiDataSourceConfig
 
@@ -2029,20 +2148,20 @@ Source: `src/data/sources.ts:34:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                      | Required | Description |
-| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| baseUrl     | property | `string`                                                                  | yes      |             |
-| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
-| description | property | `string \| undefined`                                                     | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                  | yes      |             |
-| kind        | property | `"api"`                                                                   | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
-| name        | property | `string \| undefined`                                                     | no       |             |
-| openApi     | property | `OpenApiDocumentRef \| undefined`                                         | no       |             |
-| origin      | property | `"external"`                                                              | yes      |             |
-| protocol    | property | `"rest"`                                                                  | yes      |             |
-| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                                                       | Required | Description |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| baseUrl     | property | `string`                                                                                                   | yes      |             |
+| credential  | property | `CredentialRef \| undefined`                                                                               | no       |             |
+| description | property | `string \| undefined`                                                                                      | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
+| id          | property | `string`                                                                                                   | yes      |             |
+| kind        | property | `"api"`                                                                                                    | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                                                           | no       |             |
+| name        | property | `string \| undefined`                                                                                      | no       |             |
+| openApi     | property | `OpenApiDocumentRef \| undefined`                                                                          | no       |             |
+| origin      | property | `"external"`                                                                                               | yes      |             |
+| protocol    | property | `"rest"`                                                                                                   | yes      |             |
+| schemas     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
 
 ## FilterAction
 
@@ -2200,20 +2319,20 @@ Source: `src/data/sources.ts:51:1`
 
 ### Members
 
-| Name           | Kind     | Type                                                                      | Required | Description |
-| -------------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| adapter        | property | `DatabaseAdapterRef`                                                      | yes      |             |
-| credential     | property | `CredentialRef \| undefined`                                              | no       |             |
-| description    | property | `string \| undefined`                                                     | no       |             |
-| endpoints      | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
-| generatedApiId | property | `string`                                                                  | yes      |             |
-| id             | property | `string`                                                                  | yes      |             |
-| kind           | property | `"api"`                                                                   | yes      |             |
-| metadata       | property | `DataContractValue \| undefined`                                          | no       |             |
-| name           | property | `string \| undefined`                                                     | no       |             |
-| origin         | property | `"generated"`                                                             | yes      |             |
-| protocol       | property | `"rest"`                                                                  | yes      |             |
-| schemas        | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+| Name           | Kind     | Type                                                                                                       | Required | Description |
+| -------------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| adapter        | property | `DatabaseAdapterRef`                                                                                       | yes      |             |
+| credential     | property | `CredentialRef \| undefined`                                                                               | no       |             |
+| description    | property | `string \| undefined`                                                                                      | no       |             |
+| endpoints      | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
+| generatedApiId | property | `string`                                                                                                   | yes      |             |
+| id             | property | `string`                                                                                                   | yes      |             |
+| kind           | property | `"api"`                                                                                                    | yes      |             |
+| metadata       | property | `DataContractValue \| undefined`                                                                           | no       |             |
+| name           | property | `string \| undefined`                                                                                      | no       |             |
+| origin         | property | `"generated"`                                                                                              | yes      |             |
+| protocol       | property | `"rest"`                                                                                                   | yes      |             |
+| schemas        | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
 
 ## IconSpec
 
@@ -2322,7 +2441,13 @@ Source: `src/media.ts:58:1`
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:38:1`
+Source: `src/auth.ts:39:1`
+
+## KnownAuthOAuthTransportId
+
+Kind: `unknown`
+Module: `src/auth.ts`
+Source: `src/auth.ts:43:1`
 
 ## KnownAuthProfileField
 
@@ -2340,7 +2465,7 @@ Source: `src/types.ts:208:1`
 
 Kind: `unknown`
 Module: `src/auth.ts`
-Source: `src/auth.ts:14:1`
+Source: `src/auth.ts:15:1`
 
 ## KnownComponentEventDto
 
@@ -2646,7 +2771,7 @@ Source: `src/appManifest.ts:45:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:162:1`
+Source: `src/auth.ts:227:1`
 
 ### Members
 
@@ -2676,7 +2801,7 @@ Source: `src/bindings.ts:67:1`
 
 Kind: `function`
 Module: `src/auth.ts`
-Source: `src/auth.ts:65:1`
+Source: `src/auth.ts:130:1`
 
 ### Signatures
 
@@ -2805,15 +2930,15 @@ Source: `src/types.ts:260:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                                   | Required | Description |
-| ----------- | -------- | -------------------------------------------------------------------------------------- | -------- | ----------- |
-| dataLoaders | property | `readonly import("./src/bindings").OperationScreenDataLoaderDefinition[] \| undefined` | no       |             |
-| description | property | `string \| undefined`                                                                  | no       |             |
-| id          | property | `string`                                                                               | yes      |             |
-| name        | property | `string`                                                                               | yes      |             |
-| requires    | property | `ScreenRequirements \| undefined`                                                      | no       |             |
-| root        | property | `UiNode`                                                                               | yes      |             |
-| title       | property | `string \| undefined`                                                                  | no       |             |
+| Name        | Kind     | Type                                                                                                                    | Required | Description |
+| ----------- | -------- | ----------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| dataLoaders | property | `readonly import("/Users/a_rtiphishl_e/git/contracts/src/bindings").OperationScreenDataLoaderDefinition[] \| undefined` | no       |             |
+| description | property | `string \| undefined`                                                                                                   | no       |             |
+| id          | property | `string`                                                                                                                | yes      |             |
+| name        | property | `string`                                                                                                                | yes      |             |
+| requires    | property | `ScreenRequirements \| undefined`                                                                                       | no       |             |
+| root        | property | `UiNode`                                                                                                                | yes      |             |
+| title       | property | `string \| undefined`                                                                                                   | no       |             |
 
 ## SearchAction
 
@@ -3038,7 +3163,7 @@ Source: `src/types.ts:65:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:142:1`
+Source: `src/auth.ts:207:1`
 
 ### Members
 
@@ -3054,7 +3179,7 @@ Source: `src/auth.ts:142:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:158:1`
+Source: `src/auth.ts:223:1`
 
 ### Members
 
@@ -3066,7 +3191,7 @@ Source: `src/auth.ts:158:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:150:1`
+Source: `src/auth.ts:215:1`
 
 ### Members
 
@@ -3133,7 +3258,7 @@ Source: `src/types.ts:307:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:235:1`
+Source: `src/auth.ts:300:1`
 
 ### Members
 
@@ -3259,7 +3384,7 @@ Source: `src/types.ts:326:1`
 
 | Name        | Kind     | Type                                                       | Required | Description |
 | ----------- | -------- | ---------------------------------------------------------- | -------- | ----------- |
-| persistence | property | `"database" \| "none" \| "local" \| "secure" \| undefined` | no       |             |
+| persistence | property | `"local" \| "database" \| "none" \| "secure" \| undefined` | no       |             |
 | provider    | property | `StateProvider`                                            | yes      |             |
 
 ## StateSubscription
@@ -4065,7 +4190,7 @@ Source: `src/secrets.ts:146:1`
 
 Kind: `type`
 Module: `src/auth.ts`
-Source: `src/auth.ts:167:1`
+Source: `src/auth.ts:232:1`
 
 ### Members
 

--- a/paradox/index.html
+++ b/paradox/index.html
@@ -279,7 +279,7 @@
           <section class="panel">
             <h2>Package overview</h2>
             <div class="summary">
-              <div><strong>382</strong><span class="muted">public exports</span></div>
+              <div><strong>396</strong><span class="muted">public exports</span></div>
               <div><strong>0</strong><span class="muted">components</span></div>
               <div><strong>35</strong><span class="muted">modules</span></div>
               <div><strong>1</strong><span class="muted">entrypoints</span></div>
@@ -410,20 +410,24 @@
             </article>
             <article
               class="item"
-              data-search="src/auth.ts src/secrets.ts src/types.ts AUTH_IDENTIFIER_KINDS AUTH_OAUTH_CANCELLATION_REASONS AUTH_OAUTH_ERROR_CODES AUTH_OAUTH_ERROR_STAGES AUTH_OAUTH_PROVIDER_IDS AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS AUTH_OAUTH_TRANSPORT_ERROR_CODES AUTH_SIGN_UP_FIELDS AuthAdapter AuthAdapterCapabilities AuthAdapterError AuthFlowConfig AuthIdentifier AuthIdentifierKind AuthOAuthAdapter AuthOAuthAuthorizationRequest AuthOAuthAuthorizationResponse AuthOAuthCancellationReason AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthConfig AuthOAuthError AuthOAuthErrorCode AuthOAuthErrorStage AuthOAuthProviderConfig AuthOAuthProviderId AuthOAuthStartResult AuthOAuthTransportCancellationReason AuthOAuthTransportError AuthOAuthTransportErrorCode AuthProviderConfig AuthResult AuthSession AuthSignInConfig AuthSignUpConfig AuthSignUpField AuthUser CompleteOAuthAuthorizationInput DEFAULT_AUTH_FLOW KnownAuthOAuthProviderId KnownAuthSignUpField PasswordResetInput resolveAuthFlow SignInInput SignOutInput SignUpInput StartOAuthAuthorizationInput VerifyOtpInput"
+              data-search="src/auth.ts src/deploy.ts src/secrets.ts src/types.ts AUTH_IDENTIFIER_KINDS AUTH_OAUTH_CANCELLATION_REASONS AUTH_OAUTH_ERROR_CODES AUTH_OAUTH_ERROR_STAGES AUTH_OAUTH_PROVIDER_IDS AUTH_OAUTH_SETUP_CALLBACK_ROLES AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS AUTH_OAUTH_TRANSPORT_ERROR_CODES AUTH_OAUTH_TRANSPORT_IDS AUTH_SIGN_UP_FIELDS AuthAdapter AuthAdapterCapabilities AuthAdapterError AuthFlowConfig AuthIdentifier AuthIdentifierKind AuthOAuthAdapter AuthOAuthAuthorizationRequest AuthOAuthAuthorizationResponse AuthOAuthCancellationReason AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthConfig AuthOAuthError AuthOAuthErrorCode AuthOAuthErrorStage AuthOAuthProviderConfig AuthOAuthProviderId AuthOAuthSetupCallbackRequirement AuthOAuthSetupCallbackRole AuthOAuthSetupCapabilities AuthOAuthSetupFieldPersistence AuthOAuthSetupFieldRequirement AuthOAuthSetupFieldSensitivity AuthOAuthSetupPlan AuthOAuthSetupRequirement AuthOAuthStartResult AuthOAuthTransportCancellationReason AuthOAuthTransportError AuthOAuthTransportErrorCode AuthOAuthTransportId AuthProviderConfig AuthResult AuthSession AuthSignInConfig AuthSignUpConfig AuthSignUpField AuthUser CompleteOAuthAuthorizationInput DEFAULT_AUTH_FLOW KnownAuthOAuthProviderId KnownAuthOAuthTransportId KnownAuthSignUpField PasswordResetInput resolveAuthFlow SignInInput SignOutInput SignUpInput StartOAuthAuthorizationInput VerifyOtpInput"
             >
               <h3>src/auth.ts</h3>
               <p class="muted">Referenced module</p>
               <p>
-                <strong>Dependencies:</strong> <code>src/secrets.ts</code>,
-                <code>src/types.ts</code>
+                <strong>Dependencies:</strong> <code>src/deploy.ts</code>,
+                <code>src/secrets.ts</code>, <code>src/types.ts</code>
               </p>
               <p>
                 <strong>Exports:</strong> <code>AUTH_IDENTIFIER_KINDS</code>,
                 <code>AUTH_OAUTH_CANCELLATION_REASONS</code>, <code>AUTH_OAUTH_ERROR_CODES</code>,
                 <code>AUTH_OAUTH_ERROR_STAGES</code>, <code>AUTH_OAUTH_PROVIDER_IDS</code>,
+                <code>AUTH_OAUTH_SETUP_CALLBACK_ROLES</code>,
+                <code>AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS</code>,
+                <code>AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES</code>,
                 <code>AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS</code>,
-                <code>AUTH_OAUTH_TRANSPORT_ERROR_CODES</code>, <code>AUTH_SIGN_UP_FIELDS</code>,
+                <code>AUTH_OAUTH_TRANSPORT_ERROR_CODES</code>,
+                <code>AUTH_OAUTH_TRANSPORT_IDS</code>, <code>AUTH_SIGN_UP_FIELDS</code>,
                 <code>AuthAdapter</code>, <code>AuthAdapterCapabilities</code>,
                 <code>AuthAdapterError</code>, <code>AuthFlowConfig</code>,
                 <code>AuthIdentifier</code>, <code>AuthIdentifierKind</code>,
@@ -433,17 +437,23 @@
                 <code>AuthOAuthCompletionResult</code>, <code>AuthOAuthConfig</code>,
                 <code>AuthOAuthError</code>, <code>AuthOAuthErrorCode</code>,
                 <code>AuthOAuthErrorStage</code>, <code>AuthOAuthProviderConfig</code>,
-                <code>AuthOAuthProviderId</code>, <code>AuthOAuthStartResult</code>,
+                <code>AuthOAuthProviderId</code>, <code>AuthOAuthSetupCallbackRequirement</code>,
+                <code>AuthOAuthSetupCallbackRole</code>, <code>AuthOAuthSetupCapabilities</code>,
+                <code>AuthOAuthSetupFieldPersistence</code>,
+                <code>AuthOAuthSetupFieldRequirement</code>,
+                <code>AuthOAuthSetupFieldSensitivity</code>, <code>AuthOAuthSetupPlan</code>,
+                <code>AuthOAuthSetupRequirement</code>, <code>AuthOAuthStartResult</code>,
                 <code>AuthOAuthTransportCancellationReason</code>,
                 <code>AuthOAuthTransportError</code>, <code>AuthOAuthTransportErrorCode</code>,
-                <code>AuthProviderConfig</code>, <code>AuthResult</code>, <code>AuthSession</code>,
-                <code>AuthSignInConfig</code>, <code>AuthSignUpConfig</code>,
-                <code>AuthSignUpField</code>, <code>AuthUser</code>,
+                <code>AuthOAuthTransportId</code>, <code>AuthProviderConfig</code>,
+                <code>AuthResult</code>, <code>AuthSession</code>, <code>AuthSignInConfig</code>,
+                <code>AuthSignUpConfig</code>, <code>AuthSignUpField</code>, <code>AuthUser</code>,
                 <code>CompleteOAuthAuthorizationInput</code>, <code>DEFAULT_AUTH_FLOW</code>,
-                <code>KnownAuthOAuthProviderId</code>, <code>KnownAuthSignUpField</code>,
-                <code>PasswordResetInput</code>, <code>resolveAuthFlow</code>,
-                <code>SignInInput</code>, <code>SignOutInput</code>, <code>SignUpInput</code>,
-                <code>StartOAuthAuthorizationInput</code>, <code>VerifyOtpInput</code>
+                <code>KnownAuthOAuthProviderId</code>, <code>KnownAuthOAuthTransportId</code>,
+                <code>KnownAuthSignUpField</code>, <code>PasswordResetInput</code>,
+                <code>resolveAuthFlow</code>, <code>SignInInput</code>, <code>SignOutInput</code>,
+                <code>SignUpInput</code>, <code>StartOAuthAuthorizationInput</code>,
+                <code>VerifyOtpInput</code>
               </p>
             </article>
             <article
@@ -704,7 +714,7 @@
             </article>
             <article
               class="item"
-              data-search="src/index.ts Action ActionType AdapterId AdapterKind AdapterRef AlertAction AnkhCapabilityId AnkhCommandCategory AnkhCommandDescriptor AnkhCommandProviderManifest ANKHORAGE_CAPABILITY_NAMES ANKHORAGE_PERMISSION_NAMES AnkhorageCapabilityName AnkhoragePermissionName AnkhPackageMetadata AnkhProviderReference ApiDataSourceBaseConfig ApiDataSourceConfig ApiOrigin ApiProtocol APP_CATEGORIES APP_DEPLOY_ENVIRONMENT_IDS APP_DEPLOY_TARGET_IDS AppCategory AppDeployAndroidTargetConfig AppDeployEnvironmentId AppDeployIosTargetConfig AppDeployManifest AppDeployProviderSelection AppDeployTargetId AppDeployTargets AppDeployWebTargetConfig AppManifest AppManifestParseResult AppSettings AUTH_IDENTIFIER_KINDS AUTH_OAUTH_CANCELLATION_REASONS AUTH_OAUTH_ERROR_CODES AUTH_OAUTH_ERROR_STAGES AUTH_OAUTH_PROVIDER_IDS AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS AUTH_OAUTH_TRANSPORT_ERROR_CODES AUTH_PROFILE_CREATE_STRATEGIES AUTH_PROFILE_FIELDS AUTH_PROFILE_PRIMARY_KEY_STRATEGIES AUTH_PROFILE_UPDATE_STRATEGIES AUTH_PROVIDERS AUTH_SCOPES AUTH_SIGN_IN_IDENTIFIERS AUTH_SIGN_UP_FIELDS AUTH_SIGN_UP_POLICIES AuthAdapter AuthAdapterCapabilities AuthAdapterError AuthFlowConfig AuthIdentifier AuthIdentifierKind AuthOAuthAdapter AuthOAuthAuthorizationRequest AuthOAuthAuthorizationResponse AuthOAuthCancellationReason AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthConfig AuthOAuthError AuthOAuthErrorCode AuthOAuthErrorStage AuthOAuthProviderConfig AuthOAuthProviderId AuthOAuthStartResult AuthOAuthTransportCancellationReason AuthOAuthTransportError AuthOAuthTransportErrorCode AuthProfileCreateStrategy AuthProfileField AuthProfilePrimaryKeyStrategy AuthProfileSpec AuthProfileUpdateStrategy AuthProvider AuthProviderConfig AuthResult AuthScope AuthSession AuthSignInConfig AuthSignInIdentifier AuthSignInSpec AuthSignUpConfig AuthSignUpField AuthSignUpPolicy AuthSignUpSpec AuthSpec AuthUser AUTHZ_ENGINES AUTHZ_KINDS AuthzEngine AuthzKind AuthzSpec BindingCondition BindingConditionOperator BindingDataPath BindingFallback BindingInputMap BindingInputValue BindingLifecycleBehavior BindingLifecycleState BindingOperationRef BindingValue BindingValueExpression BindingValueSource BindingValueTransform ButtonPressEventDto CollectionItemPressEventDto CollectionItemPressPayload CompleteOAuthAuthorizationInput ComponentDataBinding ComponentDataBindingRegistry ComponentEventDto ComponentEventDtoKind ComponentEventPayloadValue ComponentInstanceId ComponentRequirements ComponentTypeId ConsoleAction CredentialId CredentialKind CredentialRef DATABASE_PROVIDERS DATABASE_TIERS DatabaseAdapterRef DatabaseDataSourceConfig DatabaseProvider DatabaseSpec DatabaseTier DataContractValue DataDiagnosticCode DataDiagnosticSeverity DataEndpointConfig DataEndpointKind DataEndpointRegistry DataOperationConfig DataOperationIntent DataOperationMethod DataOperationPagination DataOperationParameter DataOperationParameterLocation DataOperationProtocol DataOperationRegistry DataOperationRequest DataOperationResponse DataPath DataSchema DataSchemaPrimitiveType DataSchemaProperty DataSchemaRef DataSchemaRegistry DataSchemaSlot DataSourceBaseConfig DataSourceConfig DataSourceDiagnostic DataSourceDiagnosticResult DataSourceId DataSourceKind DataSourceRegistry DbAdapter DbAdapterCapabilities DbAdapterError DbAdminAdapter DbAdminAdapterCapabilities DbAdminResult DbChangeEvent DbChangeKind DbChangeListener DbCollectionDefinition DbCollectionReference DbCollectionSubscriptionInput DbDeleteInput DbFieldDefinition DbFieldType DbFilter DbFilterOperator DbFindByIdInput DbInsertInput DbPage DbRealtimeAdapter DbRecord DbRecordSubscriptionInput DbResult DbSelectInput DbSort DbSortDirection DbSubscription DbSuccess DbTableInput DbUpdateInput DEFAULT_AUTH_FLOW DEPLOYMENT_TARGETS DeploymentSpec DeploymentTarget EndpointId EventBinding EventBindingTarget ExternalGraphQlApiDataSourceConfig ExternalRestApiDataSourceConfig FilterAction findForbiddenInlineSecretFields FORBIDDEN_INLINE_SECRET_FIELDS FormSubmitEventDto FormSubmitValues GENERATED_API_CRUD_OPERATIONS GeneratedApiAuthRequirement GeneratedApiCrudOperation GeneratedApiDefinition GeneratedApiId GeneratedApiOperationPolicyRef GeneratedApiRegistry GeneratedApiResourceDefinition GeneratedApiResourceId GeneratedApiSeedRecord GeneratedRestApiDataSourceConfig IconSpec ImageAssetSource ImageMetadata InfraManifest InfraSecretStoreSpec isAppDeployManifest isAppManifest isMediaAssetReference KnownAuthOAuthProviderId KnownAuthProfileField KnownAuthProvider KnownAuthSignUpField KnownComponentEventDto KnownDatabaseProvider KnownDeploymentTarget KnownSecretStoreProvider KnownStateProvider ManifestValue MEDIA_ASSET_KINDS MediaAsset MediaAssetKind MediaAssetMetadata MediaAssetReference MediaAssetRegistry MediaAssetSource MediaBundledSource MediaManifest MediaStorageAdapter MediaStorageSource MediaUrlSource NavigateAction NAVIGATOR_TYPES NavigatorSpec NavigatorType NetworkingSpec normalizeSecretRef normalizeSecretScope OpenApiDocumentRef OperationId OperationScreenDataLoaderDefinition parseAppManifest PasswordResetInput PropBinding resolveAuthFlow RouteDefinition RuntimeCallback RuntimeCallbackArgs RuntimeCallbackMap RuntimeNodePropsResolver RuntimeResolveNodePropsArgs SchemaId ScreenCapabilityRequirement ScreenDataLoaderDefinition ScreenPermissionRequirement ScreenRequirements ScreenSpec SearchAction SECRET_STORE_ERROR_CODES SECRET_STORE_PROVIDERS SecretCreateInput SecretGetMetadataInput SecretListInput SecretMetadata SecretPayload SecretRef SecretRemoveInput SecretReplaceInput SecretResolveInput SecretScope SecretStoreAdapter SecretStoreError SecretStoreErrorCode SecretStoreOkResult SecretStoreProvider SecretStoreResult SetLanguageAction SignInInput SignOutInput SignUpInput SplashScreenAssetSpec SplashScreenModeSpec SplashScreenResizeMode SplashScreenSpec StartOAuthAuthorizationInput STATE_PERSISTENCE_MODES STATE_PROVIDERS StateAdapter StateAdapterCapabilities StateAdapterError StateListener StatePath StatePersistenceMode StatePrimitive StateProvider StateResult StateSnapshot StateSpec StateSubscription StateSuccess StateValue STORAGE_PROVIDERS StorageAdapter StorageAdapterError StorageAssetReference StorageImageAssetSource StorageListAdapter StorageListInput StorageListResult StorageObjectMetadata StorageOkResult StorageProvider StoragePublicUrlInput StoragePublicUrlResult StorageRemoveInput StorageResolveAdapter StorageResolvedAccess StorageResolvedAsset StorageResolveInput StorageResolveResult StorageResult StorageSpec StorageUploadInput StorageUploadResult ThemeConfig ThemeGlobalTokenOverrides ThemeModeConfig ThemeNumericTokenOverrides ThemeRecipeFieldOverrides ThemeRecipeOverrides ThemeRecipeOverrideValue ThemeStringTokenOverrides ThemeTypographyHeadingOverrides ThemeTypographyTokenOverrides ToggleDarkModeAction UiBindableEventMeta UiBindableEventPayloadMeta UiBindablePropMeta UiBindableValueFieldMeta UiBindableValueMeta UiBindableValueType UiComponentBindingMeta UiComponentBlueprint UiComponentBlueprintIcon UiComponentCategory UiComponentEventMeta UiComponentEventPayloadFieldMeta UiComponentEventPayloadFieldType UiComponentEventPayloadKind UiComponentI18nFieldMeta UiComponentI18nMeta UiComponentMeta UiComponentMetaRegistry UiComponentPackageManifest UiComponentPropArrayItemSchema UiComponentPropSchema UiComponentPropType UiComponentPropValue UiComponentSlotMeta UiNode UiNodeRepeatSpec UrlImageAssetSource validateSecretPayload VerifyOtpInput"
+              data-search="src/index.ts Action ActionType AdapterId AdapterKind AdapterRef AlertAction AnkhCapabilityId AnkhCommandCategory AnkhCommandDescriptor AnkhCommandProviderManifest ANKHORAGE_CAPABILITY_NAMES ANKHORAGE_PERMISSION_NAMES AnkhorageCapabilityName AnkhoragePermissionName AnkhPackageMetadata AnkhProviderReference ApiDataSourceBaseConfig ApiDataSourceConfig ApiOrigin ApiProtocol APP_CATEGORIES APP_DEPLOY_ENVIRONMENT_IDS APP_DEPLOY_TARGET_IDS AppCategory AppDeployAndroidTargetConfig AppDeployEnvironmentId AppDeployIosTargetConfig AppDeployManifest AppDeployProviderSelection AppDeployTargetId AppDeployTargets AppDeployWebTargetConfig AppManifest AppManifestParseResult AppSettings AUTH_IDENTIFIER_KINDS AUTH_OAUTH_CANCELLATION_REASONS AUTH_OAUTH_ERROR_CODES AUTH_OAUTH_ERROR_STAGES AUTH_OAUTH_PROVIDER_IDS AUTH_OAUTH_SETUP_CALLBACK_ROLES AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS AUTH_OAUTH_TRANSPORT_ERROR_CODES AUTH_OAUTH_TRANSPORT_IDS AUTH_PROFILE_CREATE_STRATEGIES AUTH_PROFILE_FIELDS AUTH_PROFILE_PRIMARY_KEY_STRATEGIES AUTH_PROFILE_UPDATE_STRATEGIES AUTH_PROVIDERS AUTH_SCOPES AUTH_SIGN_IN_IDENTIFIERS AUTH_SIGN_UP_FIELDS AUTH_SIGN_UP_POLICIES AuthAdapter AuthAdapterCapabilities AuthAdapterError AuthFlowConfig AuthIdentifier AuthIdentifierKind AuthOAuthAdapter AuthOAuthAuthorizationRequest AuthOAuthAuthorizationResponse AuthOAuthCancellationReason AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthConfig AuthOAuthError AuthOAuthErrorCode AuthOAuthErrorStage AuthOAuthProviderConfig AuthOAuthProviderId AuthOAuthSetupCallbackRequirement AuthOAuthSetupCallbackRole AuthOAuthSetupCapabilities AuthOAuthSetupFieldPersistence AuthOAuthSetupFieldRequirement AuthOAuthSetupFieldSensitivity AuthOAuthSetupPlan AuthOAuthSetupRequirement AuthOAuthStartResult AuthOAuthTransportCancellationReason AuthOAuthTransportError AuthOAuthTransportErrorCode AuthOAuthTransportId AuthProfileCreateStrategy AuthProfileField AuthProfilePrimaryKeyStrategy AuthProfileSpec AuthProfileUpdateStrategy AuthProvider AuthProviderConfig AuthResult AuthScope AuthSession AuthSignInConfig AuthSignInIdentifier AuthSignInSpec AuthSignUpConfig AuthSignUpField AuthSignUpPolicy AuthSignUpSpec AuthSpec AuthUser AUTHZ_ENGINES AUTHZ_KINDS AuthzEngine AuthzKind AuthzSpec BindingCondition BindingConditionOperator BindingDataPath BindingFallback BindingInputMap BindingInputValue BindingLifecycleBehavior BindingLifecycleState BindingOperationRef BindingValue BindingValueExpression BindingValueSource BindingValueTransform ButtonPressEventDto CollectionItemPressEventDto CollectionItemPressPayload CompleteOAuthAuthorizationInput ComponentDataBinding ComponentDataBindingRegistry ComponentEventDto ComponentEventDtoKind ComponentEventPayloadValue ComponentInstanceId ComponentRequirements ComponentTypeId ConsoleAction CredentialId CredentialKind CredentialRef DATABASE_PROVIDERS DATABASE_TIERS DatabaseAdapterRef DatabaseDataSourceConfig DatabaseProvider DatabaseSpec DatabaseTier DataContractValue DataDiagnosticCode DataDiagnosticSeverity DataEndpointConfig DataEndpointKind DataEndpointRegistry DataOperationConfig DataOperationIntent DataOperationMethod DataOperationPagination DataOperationParameter DataOperationParameterLocation DataOperationProtocol DataOperationRegistry DataOperationRequest DataOperationResponse DataPath DataSchema DataSchemaPrimitiveType DataSchemaProperty DataSchemaRef DataSchemaRegistry DataSchemaSlot DataSourceBaseConfig DataSourceConfig DataSourceDiagnostic DataSourceDiagnosticResult DataSourceId DataSourceKind DataSourceRegistry DbAdapter DbAdapterCapabilities DbAdapterError DbAdminAdapter DbAdminAdapterCapabilities DbAdminResult DbChangeEvent DbChangeKind DbChangeListener DbCollectionDefinition DbCollectionReference DbCollectionSubscriptionInput DbDeleteInput DbFieldDefinition DbFieldType DbFilter DbFilterOperator DbFindByIdInput DbInsertInput DbPage DbRealtimeAdapter DbRecord DbRecordSubscriptionInput DbResult DbSelectInput DbSort DbSortDirection DbSubscription DbSuccess DbTableInput DbUpdateInput DEFAULT_AUTH_FLOW DEPLOYMENT_TARGETS DeploymentSpec DeploymentTarget EndpointId EventBinding EventBindingTarget ExternalGraphQlApiDataSourceConfig ExternalRestApiDataSourceConfig FilterAction findForbiddenInlineSecretFields FORBIDDEN_INLINE_SECRET_FIELDS FormSubmitEventDto FormSubmitValues GENERATED_API_CRUD_OPERATIONS GeneratedApiAuthRequirement GeneratedApiCrudOperation GeneratedApiDefinition GeneratedApiId GeneratedApiOperationPolicyRef GeneratedApiRegistry GeneratedApiResourceDefinition GeneratedApiResourceId GeneratedApiSeedRecord GeneratedRestApiDataSourceConfig IconSpec ImageAssetSource ImageMetadata InfraManifest InfraSecretStoreSpec isAppDeployManifest isAppManifest isMediaAssetReference KnownAuthOAuthProviderId KnownAuthOAuthTransportId KnownAuthProfileField KnownAuthProvider KnownAuthSignUpField KnownComponentEventDto KnownDatabaseProvider KnownDeploymentTarget KnownSecretStoreProvider KnownStateProvider ManifestValue MEDIA_ASSET_KINDS MediaAsset MediaAssetKind MediaAssetMetadata MediaAssetReference MediaAssetRegistry MediaAssetSource MediaBundledSource MediaManifest MediaStorageAdapter MediaStorageSource MediaUrlSource NavigateAction NAVIGATOR_TYPES NavigatorSpec NavigatorType NetworkingSpec normalizeSecretRef normalizeSecretScope OpenApiDocumentRef OperationId OperationScreenDataLoaderDefinition parseAppManifest PasswordResetInput PropBinding resolveAuthFlow RouteDefinition RuntimeCallback RuntimeCallbackArgs RuntimeCallbackMap RuntimeNodePropsResolver RuntimeResolveNodePropsArgs SchemaId ScreenCapabilityRequirement ScreenDataLoaderDefinition ScreenPermissionRequirement ScreenRequirements ScreenSpec SearchAction SECRET_STORE_ERROR_CODES SECRET_STORE_PROVIDERS SecretCreateInput SecretGetMetadataInput SecretListInput SecretMetadata SecretPayload SecretRef SecretRemoveInput SecretReplaceInput SecretResolveInput SecretScope SecretStoreAdapter SecretStoreError SecretStoreErrorCode SecretStoreOkResult SecretStoreProvider SecretStoreResult SetLanguageAction SignInInput SignOutInput SignUpInput SplashScreenAssetSpec SplashScreenModeSpec SplashScreenResizeMode SplashScreenSpec StartOAuthAuthorizationInput STATE_PERSISTENCE_MODES STATE_PROVIDERS StateAdapter StateAdapterCapabilities StateAdapterError StateListener StatePath StatePersistenceMode StatePrimitive StateProvider StateResult StateSnapshot StateSpec StateSubscription StateSuccess StateValue STORAGE_PROVIDERS StorageAdapter StorageAdapterError StorageAssetReference StorageImageAssetSource StorageListAdapter StorageListInput StorageListResult StorageObjectMetadata StorageOkResult StorageProvider StoragePublicUrlInput StoragePublicUrlResult StorageRemoveInput StorageResolveAdapter StorageResolvedAccess StorageResolvedAsset StorageResolveInput StorageResolveResult StorageResult StorageSpec StorageUploadInput StorageUploadResult ThemeConfig ThemeGlobalTokenOverrides ThemeModeConfig ThemeNumericTokenOverrides ThemeRecipeFieldOverrides ThemeRecipeOverrides ThemeRecipeOverrideValue ThemeStringTokenOverrides ThemeTypographyHeadingOverrides ThemeTypographyTokenOverrides ToggleDarkModeAction UiBindableEventMeta UiBindableEventPayloadMeta UiBindablePropMeta UiBindableValueFieldMeta UiBindableValueMeta UiBindableValueType UiComponentBindingMeta UiComponentBlueprint UiComponentBlueprintIcon UiComponentCategory UiComponentEventMeta UiComponentEventPayloadFieldMeta UiComponentEventPayloadFieldType UiComponentEventPayloadKind UiComponentI18nFieldMeta UiComponentI18nMeta UiComponentMeta UiComponentMetaRegistry UiComponentPackageManifest UiComponentPropArrayItemSchema UiComponentPropSchema UiComponentPropType UiComponentPropValue UiComponentSlotMeta UiNode UiNodeRepeatSpec UrlImageAssetSource validateSecretPayload VerifyOtpInput"
             >
               <h3>src/index.ts</h3>
               <p class="muted">Configured entrypoint</p>
@@ -729,10 +739,13 @@
                 <code>AppSettings</code>, <code>AUTH_IDENTIFIER_KINDS</code>,
                 <code>AUTH_OAUTH_CANCELLATION_REASONS</code>, <code>AUTH_OAUTH_ERROR_CODES</code>,
                 <code>AUTH_OAUTH_ERROR_STAGES</code>, <code>AUTH_OAUTH_PROVIDER_IDS</code>,
+                <code>AUTH_OAUTH_SETUP_CALLBACK_ROLES</code>,
+                <code>AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS</code>,
+                <code>AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES</code>,
                 <code>AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS</code>,
                 <code>AUTH_OAUTH_TRANSPORT_ERROR_CODES</code>,
-                <code>AUTH_PROFILE_CREATE_STRATEGIES</code>, <code>AUTH_PROFILE_FIELDS</code>,
-                <code>AUTH_PROFILE_PRIMARY_KEY_STRATEGIES</code>,
+                <code>AUTH_OAUTH_TRANSPORT_IDS</code>, <code>AUTH_PROFILE_CREATE_STRATEGIES</code>,
+                <code>AUTH_PROFILE_FIELDS</code>, <code>AUTH_PROFILE_PRIMARY_KEY_STRATEGIES</code>,
                 <code>AUTH_PROFILE_UPDATE_STRATEGIES</code>, <code>AUTH_PROVIDERS</code>,
                 <code>AUTH_SCOPES</code>, <code>AUTH_SIGN_IN_IDENTIFIERS</code>,
                 <code>AUTH_SIGN_UP_FIELDS</code>, <code>AUTH_SIGN_UP_POLICIES</code>,
@@ -745,14 +758,19 @@
                 <code>AuthOAuthCompletionResult</code>, <code>AuthOAuthConfig</code>,
                 <code>AuthOAuthError</code>, <code>AuthOAuthErrorCode</code>,
                 <code>AuthOAuthErrorStage</code>, <code>AuthOAuthProviderConfig</code>,
-                <code>AuthOAuthProviderId</code>, <code>AuthOAuthStartResult</code>,
+                <code>AuthOAuthProviderId</code>, <code>AuthOAuthSetupCallbackRequirement</code>,
+                <code>AuthOAuthSetupCallbackRole</code>, <code>AuthOAuthSetupCapabilities</code>,
+                <code>AuthOAuthSetupFieldPersistence</code>,
+                <code>AuthOAuthSetupFieldRequirement</code>,
+                <code>AuthOAuthSetupFieldSensitivity</code>, <code>AuthOAuthSetupPlan</code>,
+                <code>AuthOAuthSetupRequirement</code>, <code>AuthOAuthStartResult</code>,
                 <code>AuthOAuthTransportCancellationReason</code>,
                 <code>AuthOAuthTransportError</code>, <code>AuthOAuthTransportErrorCode</code>,
-                <code>AuthProfileCreateStrategy</code>, <code>AuthProfileField</code>,
-                <code>AuthProfilePrimaryKeyStrategy</code>, <code>AuthProfileSpec</code>,
-                <code>AuthProfileUpdateStrategy</code>, <code>AuthProvider</code>,
-                <code>AuthProviderConfig</code>, <code>AuthResult</code>, <code>AuthScope</code>,
-                <code>AuthSession</code>, <code>AuthSignInConfig</code>,
+                <code>AuthOAuthTransportId</code>, <code>AuthProfileCreateStrategy</code>,
+                <code>AuthProfileField</code>, <code>AuthProfilePrimaryKeyStrategy</code>,
+                <code>AuthProfileSpec</code>, <code>AuthProfileUpdateStrategy</code>,
+                <code>AuthProvider</code>, <code>AuthProviderConfig</code>, <code>AuthResult</code>,
+                <code>AuthScope</code>, <code>AuthSession</code>, <code>AuthSignInConfig</code>,
                 <code>AuthSignInIdentifier</code>, <code>AuthSignInSpec</code>,
                 <code>AuthSignUpConfig</code>, <code>AuthSignUpField</code>,
                 <code>AuthSignUpPolicy</code>, <code>AuthSignUpSpec</code>, <code>AuthSpec</code>,
@@ -820,11 +838,12 @@
                 <code>InfraManifest</code>, <code>InfraSecretStoreSpec</code>,
                 <code>isAppDeployManifest</code>, <code>isAppManifest</code>,
                 <code>isMediaAssetReference</code>, <code>KnownAuthOAuthProviderId</code>,
-                <code>KnownAuthProfileField</code>, <code>KnownAuthProvider</code>,
-                <code>KnownAuthSignUpField</code>, <code>KnownComponentEventDto</code>,
-                <code>KnownDatabaseProvider</code>, <code>KnownDeploymentTarget</code>,
-                <code>KnownSecretStoreProvider</code>, <code>KnownStateProvider</code>,
-                <code>ManifestValue</code>, <code>MEDIA_ASSET_KINDS</code>, <code>MediaAsset</code>,
+                <code>KnownAuthOAuthTransportId</code>, <code>KnownAuthProfileField</code>,
+                <code>KnownAuthProvider</code>, <code>KnownAuthSignUpField</code>,
+                <code>KnownComponentEventDto</code>, <code>KnownDatabaseProvider</code>,
+                <code>KnownDeploymentTarget</code>, <code>KnownSecretStoreProvider</code>,
+                <code>KnownStateProvider</code>, <code>ManifestValue</code>,
+                <code>MEDIA_ASSET_KINDS</code>, <code>MediaAsset</code>,
                 <code>MediaAssetKind</code>, <code>MediaAssetMetadata</code>,
                 <code>MediaAssetReference</code>, <code>MediaAssetRegistry</code>,
                 <code>MediaAssetSource</code>, <code>MediaBundledSource</code>,
@@ -1242,7 +1261,7 @@
                 data-search="AUTH_IDENTIFIER_KINDS value src/auth.ts "
               >
                 <h4>AUTH_IDENTIFIER_KINDS</h4>
-                <p class="muted">value • <code>src/auth.ts:4:14</code></p>
+                <p class="muted">value • <code>src/auth.ts:5:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1253,7 +1272,7 @@
                 data-search="AUTH_OAUTH_CANCELLATION_REASONS value src/auth.ts "
               >
                 <h4>AUTH_OAUTH_CANCELLATION_REASONS</h4>
-                <p class="muted">value • <code>src/auth.ts:217:14</code></p>
+                <p class="muted">value • <code>src/auth.ts:282:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1264,7 +1283,7 @@
                 data-search="AUTH_OAUTH_ERROR_CODES value src/auth.ts "
               >
                 <h4>AUTH_OAUTH_ERROR_CODES</h4>
-                <p class="muted">value • <code>src/auth.ts:184:14</code></p>
+                <p class="muted">value • <code>src/auth.ts:249:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1275,7 +1294,7 @@
                 data-search="AUTH_OAUTH_ERROR_STAGES value src/auth.ts "
               >
                 <h4>AUTH_OAUTH_ERROR_STAGES</h4>
-                <p class="muted">value • <code>src/auth.ts:174:14</code></p>
+                <p class="muted">value • <code>src/auth.ts:239:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1286,7 +1305,40 @@
                 data-search="AUTH_OAUTH_PROVIDER_IDS value src/auth.ts "
               >
                 <h4>AUTH_OAUTH_PROVIDER_IDS</h4>
-                <p class="muted">value • <code>src/auth.ts:17:14</code></p>
+                <p class="muted">value • <code>src/auth.ts:18:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-auth-oauth-setup-callback-roles"
+                data-search="AUTH_OAUTH_SETUP_CALLBACK_ROLES value src/auth.ts "
+              >
+                <h4>AUTH_OAUTH_SETUP_CALLBACK_ROLES</h4>
+                <p class="muted">value • <code>src/auth.ts:56:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-auth-oauth-setup-field-persistence-kinds"
+                data-search="AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS value src/auth.ts "
+              >
+                <h4>AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS</h4>
+                <p class="muted">value • <code>src/auth.ts:46:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-auth-oauth-setup-field-sensitivities"
+                data-search="AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES value src/auth.ts "
+              >
+                <h4>AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES</h4>
+                <p class="muted">value • <code>src/auth.ts:53:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1297,7 +1349,7 @@
                 data-search="AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS value src/auth.ts "
               >
                 <h4>AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS</h4>
-                <p class="muted">value • <code>src/auth.ts:210:14</code></p>
+                <p class="muted">value • <code>src/auth.ts:275:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1308,7 +1360,18 @@
                 data-search="AUTH_OAUTH_TRANSPORT_ERROR_CODES value src/auth.ts "
               >
                 <h4>AUTH_OAUTH_TRANSPORT_ERROR_CODES</h4>
-                <p class="muted">value • <code>src/auth.ts:223:14</code></p>
+                <p class="muted">value • <code>src/auth.ts:288:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-auth-oauth-transport-ids"
+                data-search="AUTH_OAUTH_TRANSPORT_IDS value src/auth.ts "
+              >
+                <h4>AUTH_OAUTH_TRANSPORT_IDS</h4>
+                <p class="muted">value • <code>src/auth.ts:42:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1319,7 +1382,7 @@
                 data-search="AUTH_SIGN_UP_FIELDS value src/auth.ts "
               >
                 <h4>AUTH_SIGN_UP_FIELDS</h4>
-                <p class="muted">value • <code>src/auth.ts:7:14</code></p>
+                <p class="muted">value • <code>src/auth.ts:8:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1330,7 +1393,7 @@
                 data-search="AuthAdapter type src/auth.ts  AuthAdapterCapabilities AuthOAuthAdapter AuthResult AuthSession AuthUser PasswordResetInput SignInInput SignOutInput SignUpInput VerifyOtpInput"
               >
                 <h4>AuthAdapter</h4>
-                <p class="muted">type • <code>src/auth.ts:317:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:382:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -1459,7 +1522,7 @@
                 data-search="AuthAdapterCapabilities type src/auth.ts "
               >
                 <h4>AuthAdapterCapabilities</h4>
-                <p class="muted">type • <code>src/auth.ts:309:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:374:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1523,7 +1586,7 @@
                 data-search="AuthAdapterError type src/auth.ts "
               >
                 <h4>AuthAdapterError</h4>
-                <p class="muted">type • <code>src/auth.ts:126:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:191:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1569,7 +1632,7 @@
                 data-search="AuthFlowConfig type src/auth.ts "
               >
                 <h4>AuthFlowConfig</h4>
-                <p class="muted">type • <code>src/auth.ts:46:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:111:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1643,7 +1706,7 @@
                 data-search="AuthIdentifier type src/auth.ts "
               >
                 <h4>AuthIdentifier</h4>
-                <p class="muted">type • <code>src/auth.ts:41:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:106:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1684,7 +1747,7 @@
                 data-search="AuthIdentifierKind unknown src/auth.ts "
               >
                 <h4>AuthIdentifierKind</h4>
-                <p class="muted">unknown • <code>src/auth.ts:5:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:6:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1695,7 +1758,7 @@
                 data-search="AuthOAuthAdapter type src/auth.ts  AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthStartResult CompleteOAuthAuthorizationInput StartOAuthAuthorizationInput"
               >
                 <h4>AuthOAuthAdapter</h4>
-                <p class="muted">type • <code>src/auth.ts:302:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:367:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -1760,7 +1823,7 @@
                 data-search="AuthOAuthAuthorizationRequest type src/auth.ts  AuthOAuthProviderId"
               >
                 <h4>AuthOAuthAuthorizationRequest</h4>
-                <p class="muted">type • <code>src/auth.ts:242:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:307:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -1818,7 +1881,7 @@
                 data-search="AuthOAuthAuthorizationResponse unknown src/auth.ts "
               >
                 <h4>AuthOAuthAuthorizationResponse</h4>
-                <p class="muted">unknown • <code>src/auth.ts:259:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:324:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1829,7 +1892,7 @@
                 data-search="AuthOAuthCancellationReason unknown src/auth.ts "
               >
                 <h4>AuthOAuthCancellationReason</h4>
-                <p class="muted">unknown • <code>src/auth.ts:221:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:286:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1840,7 +1903,7 @@
                 data-search="AuthOAuthCapabilities type src/auth.ts  AuthOAuthProviderId"
               >
                 <h4>AuthOAuthCapabilities</h4>
-                <p class="muted">type • <code>src/auth.ts:297:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:362:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -1877,7 +1940,7 @@
                 data-search="AuthOAuthCompletionResult unknown src/auth.ts "
               >
                 <h4>AuthOAuthCompletionResult</h4>
-                <p class="muted">unknown • <code>src/auth.ts:278:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:343:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1888,7 +1951,7 @@
                 data-search="AuthOAuthConfig type src/auth.ts  AuthOAuthProviderConfig"
               >
                 <h4>AuthOAuthConfig</h4>
-                <p class="muted">type • <code>src/auth.ts:89:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:154:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -1939,7 +2002,7 @@
                 data-search="AuthOAuthError type src/auth.ts  AuthOAuthProviderId"
               >
                 <h4>AuthOAuthError</h4>
-                <p class="muted">type • <code>src/auth.ts:203:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:268:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2011,7 +2074,7 @@
                       <td>property</td>
                       <td>
                         <code
-                          >&quot;start&quot; | &quot;transport&quot; | &quot;callback&quot; |
+                          >&quot;callback&quot; | &quot;start&quot; | &quot;transport&quot; |
                           &quot;exchange&quot; | &quot;session&quot; | &quot;profile&quot;</code
                         >
                       </td>
@@ -2027,7 +2090,7 @@
                 data-search="AuthOAuthErrorCode unknown src/auth.ts "
               >
                 <h4>AuthOAuthErrorCode</h4>
-                <p class="muted">unknown • <code>src/auth.ts:201:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:266:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2038,7 +2101,7 @@
                 data-search="AuthOAuthErrorStage unknown src/auth.ts "
               >
                 <h4>AuthOAuthErrorStage</h4>
-                <p class="muted">unknown • <code>src/auth.ts:182:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:247:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2049,7 +2112,7 @@
                 data-search="AuthOAuthProviderConfig type src/auth.ts  AuthOAuthProviderId IconSpec"
               >
                 <h4>AuthOAuthProviderConfig</h4>
-                <p class="muted">type • <code>src/auth.ts:78:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:143:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2129,7 +2192,328 @@
                 data-search="AuthOAuthProviderId unknown src/auth.ts "
               >
                 <h4>AuthOAuthProviderId</h4>
-                <p class="muted">unknown • <code>src/auth.ts:39:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:40:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-authoauthsetupcallbackrequirement"
+                data-search="AuthOAuthSetupCallbackRequirement type src/auth.ts "
+              >
+                <h4>AuthOAuthSetupCallbackRequirement</h4>
+                <p class="muted">type • <code>src/auth.ts:72:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>description</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>kind</code></td>
+                      <td>property</td>
+                      <td><code>&quot;callback&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>label</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>required</code></td>
+                      <td>property</td>
+                      <td><code>boolean</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>role</code></td>
+                      <td>property</td>
+                      <td><code>&quot;provider&quot; | &quot;app&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>target</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >&quot;web&quot; | &quot;android&quot; | &quot;ios&quot; | undefined</code
+                        >
+                      </td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-authoauthsetupcallbackrole"
+                data-search="AuthOAuthSetupCallbackRole unknown src/auth.ts "
+              >
+                <h4>AuthOAuthSetupCallbackRole</h4>
+                <p class="muted">unknown • <code>src/auth.ts:57:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-authoauthsetupcapabilities"
+                data-search="AuthOAuthSetupCapabilities type src/auth.ts  AuthOAuthProviderId AuthOAuthTransportId"
+              >
+                <h4>AuthOAuthSetupCapabilities</h4>
+                <p class="muted">type • <code>src/auth.ts:101:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">AuthOAuthProviderId</li>
+                    <li class="chip">AuthOAuthTransportId</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>providers</code></td>
+                      <td>property</td>
+                      <td><code>readonly AuthOAuthProviderId[]</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>transports</code></td>
+                      <td>property</td>
+                      <td><code>readonly AuthOAuthTransportId[]</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-authoauthsetupfieldpersistence"
+                data-search="AuthOAuthSetupFieldPersistence unknown src/auth.ts "
+              >
+                <h4>AuthOAuthSetupFieldPersistence</h4>
+                <p class="muted">unknown • <code>src/auth.ts:50:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-authoauthsetupfieldrequirement"
+                data-search="AuthOAuthSetupFieldRequirement type src/auth.ts "
+              >
+                <h4>AuthOAuthSetupFieldRequirement</h4>
+                <p class="muted">type • <code>src/auth.ts:59:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>description</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>key</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>kind</code></td>
+                      <td>property</td>
+                      <td><code>&quot;field&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>label</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>persistence</code></td>
+                      <td>property</td>
+                      <td><code>&quot;trustedCredential&quot; | &quot;publicConfig&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>required</code></td>
+                      <td>property</td>
+                      <td><code>boolean</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>sensitivity</code></td>
+                      <td>property</td>
+                      <td><code>&quot;public&quot; | &quot;secret&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>target</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >&quot;web&quot; | &quot;android&quot; | &quot;ios&quot; | undefined</code
+                        >
+                      </td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-authoauthsetupfieldsensitivity"
+                data-search="AuthOAuthSetupFieldSensitivity unknown src/auth.ts "
+              >
+                <h4>AuthOAuthSetupFieldSensitivity</h4>
+                <p class="muted">unknown • <code>src/auth.ts:54:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-authoauthsetupplan"
+                data-search="AuthOAuthSetupPlan type src/auth.ts  AuthOAuthProviderId AuthOAuthSetupRequirement AuthOAuthTransportId"
+              >
+                <h4>AuthOAuthSetupPlan</h4>
+                <p class="muted">type • <code>src/auth.ts:91:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">AuthOAuthProviderId</li>
+                    <li class="chip">AuthOAuthSetupRequirement</li>
+                    <li class="chip">AuthOAuthTransportId</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>environment</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >&quot;local&quot; | &quot;preview&quot; | &quot;production&quot;</code
+                        >
+                      </td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>provider</code></td>
+                      <td>property</td>
+                      <td><code>AuthOAuthProviderId</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>requirements</code></td>
+                      <td>property</td>
+                      <td><code>readonly AuthOAuthSetupRequirement[]</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>targets</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >readonly (&quot;web&quot; | &quot;android&quot; |
+                          &quot;ios&quot;)[]</code
+                        >
+                      </td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>transport</code></td>
+                      <td>property</td>
+                      <td><code>AuthOAuthTransportId</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-authoauthsetuprequirement"
+                data-search="AuthOAuthSetupRequirement unknown src/auth.ts "
+              >
+                <h4>AuthOAuthSetupRequirement</h4>
+                <p class="muted">unknown • <code>src/auth.ts:82:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2140,7 +2524,7 @@
                 data-search="AuthOAuthStartResult unknown src/auth.ts "
               >
                 <h4>AuthOAuthStartResult</h4>
-                <p class="muted">unknown • <code>src/auth.ts:249:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:314:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2151,7 +2535,7 @@
                 data-search="AuthOAuthTransportCancellationReason unknown src/auth.ts "
               >
                 <h4>AuthOAuthTransportCancellationReason</h4>
-                <p class="muted">unknown • <code>src/auth.ts:214:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:279:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2162,7 +2546,7 @@
                 data-search="AuthOAuthTransportError type src/auth.ts "
               >
                 <h4>AuthOAuthTransportError</h4>
-                <p class="muted">type • <code>src/auth.ts:229:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:294:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2210,7 +2594,18 @@
                 data-search="AuthOAuthTransportErrorCode unknown src/auth.ts "
               >
                 <h4>AuthOAuthTransportErrorCode</h4>
-                <p class="muted">unknown • <code>src/auth.ts:227:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:292:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-authoauthtransportid"
+                data-search="AuthOAuthTransportId unknown src/auth.ts "
+              >
+                <h4>AuthOAuthTransportId</h4>
+                <p class="muted">unknown • <code>src/auth.ts:44:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2221,7 +2616,7 @@
                 data-search="AuthProviderConfig type src/auth.ts  AuthOAuthConfig AuthSignInConfig AuthSignUpConfig"
               >
                 <h4>AuthProviderConfig</h4>
-                <p class="muted">type • <code>src/auth.ts:95:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:160:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2295,7 +2690,7 @@
                 data-search="AuthResult unknown src/auth.ts "
               >
                 <h4>AuthResult</h4>
-                <p class="muted">unknown • <code>src/auth.ts:132:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:197:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2306,7 +2701,7 @@
                 data-search="AuthSession type src/auth.ts  AuthUser"
               >
                 <h4>AuthSession</h4>
-                <p class="muted">type • <code>src/auth.ts:118:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:183:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2371,7 +2766,7 @@
                 data-search="AuthSignInConfig type src/auth.ts "
               >
                 <h4>AuthSignInConfig</h4>
-                <p class="muted">type • <code>src/auth.ts:69:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:134:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2407,7 +2802,7 @@
                 data-search="AuthSignUpConfig type src/auth.ts  AuthSignUpField"
               >
                 <h4>AuthSignUpConfig</h4>
-                <p class="muted">type • <code>src/auth.ts:73:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:138:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2451,14 +2846,14 @@
                 data-search="AuthSignUpField unknown src/auth.ts "
               >
                 <h4>AuthSignUpField</h4>
-                <p class="muted">unknown • <code>src/auth.ts:15:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:16:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
               </article>
               <article class="item" id="symbol-authuser" data-search="AuthUser type src/auth.ts ">
                 <h4>AuthUser</h4>
-                <p class="muted">type • <code>src/auth.ts:108:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:173:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2532,7 +2927,7 @@
                 data-search="CompleteOAuthAuthorizationInput type src/auth.ts  AuthOAuthAuthorizationResponse"
               >
                 <h4>CompleteOAuthAuthorizationInput</h4>
-                <p class="muted">type • <code>src/auth.ts:273:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:338:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2576,7 +2971,7 @@
                 data-search="DEFAULT_AUTH_FLOW value src/auth.ts "
               >
                 <h4>DEFAULT_AUTH_FLOW</h4>
-                <p class="muted">value • <code>src/auth.ts:56:14</code></p>
+                <p class="muted">value • <code>src/auth.ts:121:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2587,7 +2982,18 @@
                 data-search="KnownAuthOAuthProviderId unknown src/auth.ts "
               >
                 <h4>KnownAuthOAuthProviderId</h4>
-                <p class="muted">unknown • <code>src/auth.ts:38:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:39:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-knownauthoauthtransportid"
+                data-search="KnownAuthOAuthTransportId unknown src/auth.ts "
+              >
+                <h4>KnownAuthOAuthTransportId</h4>
+                <p class="muted">unknown • <code>src/auth.ts:43:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2598,7 +3004,7 @@
                 data-search="KnownAuthSignUpField unknown src/auth.ts "
               >
                 <h4>KnownAuthSignUpField</h4>
-                <p class="muted">unknown • <code>src/auth.ts:14:1</code></p>
+                <p class="muted">unknown • <code>src/auth.ts:15:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2609,7 +3015,7 @@
                 data-search="PasswordResetInput type src/auth.ts  AuthIdentifier"
               >
                 <h4>PasswordResetInput</h4>
-                <p class="muted">type • <code>src/auth.ts:162:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:227:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2653,7 +3059,7 @@
                 data-search="resolveAuthFlow function src/auth.ts  AuthFlowConfig (flow?: AuthFlowConfig | undefined) =&gt; AuthFlowConfig"
               >
                 <h4>resolveAuthFlow</h4>
-                <p class="muted">function • <code>src/auth.ts:65:1</code></p>
+                <p class="muted">function • <code>src/auth.ts:130:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2692,7 +3098,7 @@
                 data-search="SignInInput type src/auth.ts  AuthIdentifier"
               >
                 <h4>SignInInput</h4>
-                <p class="muted">type • <code>src/auth.ts:142:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:207:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2757,7 +3163,7 @@
                 data-search="SignOutInput type src/auth.ts "
               >
                 <h4>SignOutInput</h4>
-                <p class="muted">type • <code>src/auth.ts:158:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:223:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -2789,7 +3195,7 @@
                 data-search="SignUpInput type src/auth.ts  AuthIdentifier"
               >
                 <h4>SignUpInput</h4>
-                <p class="muted">type • <code>src/auth.ts:150:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:215:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2854,7 +3260,7 @@
                 data-search="StartOAuthAuthorizationInput type src/auth.ts  AuthOAuthProviderId"
               >
                 <h4>StartOAuthAuthorizationInput</h4>
-                <p class="muted">type • <code>src/auth.ts:235:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:300:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -2912,7 +3318,7 @@
                 data-search="VerifyOtpInput type src/auth.ts  AuthIdentifier"
               >
                 <h4>VerifyOtpInput</h4>
-                <p class="muted">type • <code>src/auth.ts:167:1</code></p>
+                <p class="muted">type • <code>src/auth.ts:232:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -3683,7 +4089,7 @@
                     <tr>
                       <td><code>path</code></td>
                       <td>property</td>
-                      <td><code>readonly [string, ...string[]]</code></td>
+                      <td><code>readonly string[]</code></td>
                       <td>yes</td>
                       <td></td>
                     </tr>
@@ -3703,7 +4109,7 @@
                 data-search="AnkhCommandProviderManifest type src/cli/index.ts  AnkhCommandDescriptor"
               >
                 <h4>AnkhCommandProviderManifest</h4>
-                <p class="muted">type • <code>src/cli/index.ts:15:1</code></p>
+                <p class="muted">type • <code>src/cli/index.ts:20:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -3768,7 +4174,7 @@
                 data-search="AnkhPackageMetadata type src/cli/index.ts "
               >
                 <h4>AnkhPackageMetadata</h4>
-                <p class="muted">type • <code>src/cli/index.ts:23:1</code></p>
+                <p class="muted">type • <code>src/cli/index.ts:28:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -5545,7 +5951,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -5599,7 +6005,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
+                          | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -5699,7 +6106,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -5739,7 +6146,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
+                          | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -5799,7 +6207,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -5839,7 +6247,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
+                          | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -5931,7 +6340,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -6004,7 +6413,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
+                          | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -6071,7 +6481,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -6132,7 +6542,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
+                          | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -6199,7 +6610,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -6260,7 +6671,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
+                          | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -11564,8 +11976,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/bindings&quot;).ComponentDataBinding&gt;&gt; |
-                          undefined</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/bindings&quot;).ComponentDataBinding&gt;&gt;
+                          | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -11577,7 +11989,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSourceConfig&gt;&gt; | undefined</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSourceConfig&gt;&gt;
+                          | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -11596,8 +12009,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).GeneratedApiDefinition&gt;&gt; |
-                          undefined</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).GeneratedApiDefinition&gt;&gt;
+                          | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -11859,7 +12272,7 @@
                       <td>property</td>
                       <td>
                         <code
-                          >&quot;api&quot; | &quot;trigger&quot; | &quot;app&quot; | undefined</code
+                          >&quot;app&quot; | &quot;api&quot; | &quot;trigger&quot; | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -11889,7 +12302,7 @@
                     <tr>
                       <td><code>updateStrategy</code></td>
                       <td>property</td>
-                      <td><code>&quot;api&quot; | &quot;app&quot; | undefined</code></td>
+                      <td><code>&quot;app&quot; | &quot;api&quot; | undefined</code></td>
                       <td>no</td>
                       <td></td>
                     </tr>
@@ -13119,8 +13532,8 @@
                       <td>
                         <code
                           >readonly
-                          import(&quot;./src/bindings&quot;).OperationScreenDataLoaderDefinition[] |
-                          undefined</code
+                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/bindings&quot;).OperationScreenDataLoaderDefinition[]
+                          | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -13511,7 +13924,7 @@
                       <td>property</td>
                       <td>
                         <code
-                          >&quot;database&quot; | &quot;none&quot; | &quot;local&quot; |
+                          >&quot;local&quot; | &quot;database&quot; | &quot;none&quot; |
                           &quot;secure&quot; | undefined</code
                         >
                       </td>
@@ -15019,8 +15432,8 @@
                 module_src_appManifest_shared_ts[&quot;src/appManifest/shared.ts&quot;]
                 package__ankhorage_contracts -.-&gt; module_src_appManifest_shared_ts
                 module_src_auth_ts[&quot;src/auth.ts&quot;] package__ankhorage_contracts -.-&gt;
-                module_src_auth_ts module_src_auth_ts --&gt; module_src_secrets_ts
-                module_src_auth_ts --&gt; module_src_types_ts
+                module_src_auth_ts module_src_auth_ts --&gt; module_src_deploy_ts module_src_auth_ts
+                --&gt; module_src_secrets_ts module_src_auth_ts --&gt; module_src_types_ts
                 module_src_bindings_ts[&quot;src/bindings.ts&quot;] package__ankhorage_contracts
                 -.-&gt; module_src_bindings_ts module_src_bindings_ts --&gt;
                 module_src_data_index_ts module_src_cli_index_ts[&quot;src/cli/index.ts&quot;]
@@ -15141,6 +15554,7 @@ graph TD
   package__ankhorage_contracts -.-&gt; module_src_appManifest_shared_ts
   module_src_auth_ts[&quot;src/auth.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_auth_ts
+  module_src_auth_ts --&gt; module_src_deploy_ts
   module_src_auth_ts --&gt; module_src_secrets_ts
   module_src_auth_ts --&gt; module_src_types_ts
   module_src_bindings_ts[&quot;src/bindings.ts&quot;]
@@ -15292,11 +15706,11 @@ graph TD
                 module_src_appManifest_screens_ts --&gt; module_src_appManifest_bindings_ts
                 module_src_appManifest_screens_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_screens_ts --&gt; module_src_types_ts module_src_auth_ts
-                --&gt; module_src_secrets_ts module_src_auth_ts --&gt; module_src_types_ts
-                module_src_bindings_ts --&gt; module_src_data_index_ts module_src_data_apis_ts
-                --&gt; module_src_data_refs_ts module_src_data_apis_ts --&gt;
-                module_src_data_values_ts module_src_data_apis_ts --&gt; module_src_db_ts
-                module_src_data_diagnostics_ts --&gt; module_src_data_ids_ts
+                --&gt; module_src_deploy_ts module_src_auth_ts --&gt; module_src_secrets_ts
+                module_src_auth_ts --&gt; module_src_types_ts module_src_bindings_ts --&gt;
+                module_src_data_index_ts module_src_data_apis_ts --&gt; module_src_data_refs_ts
+                module_src_data_apis_ts --&gt; module_src_data_values_ts module_src_data_apis_ts
+                --&gt; module_src_db_ts module_src_data_diagnostics_ts --&gt; module_src_data_ids_ts
                 module_src_data_endpoints_ts --&gt; module_src_data_ids_ts
                 module_src_data_endpoints_ts --&gt; module_src_data_operations_ts
                 module_src_data_endpoints_ts --&gt; module_src_data_refs_ts
@@ -15382,6 +15796,7 @@ graph LR
   module_src_appManifest_screens_ts --&gt; module_src_appManifest_bindings_ts
   module_src_appManifest_screens_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_screens_ts --&gt; module_src_types_ts
+  module_src_auth_ts --&gt; module_src_deploy_ts
   module_src_auth_ts --&gt; module_src_secrets_ts
   module_src_auth_ts --&gt; module_src_types_ts
   module_src_bindings_ts --&gt; module_src_data_index_ts
@@ -15552,10 +15967,18 @@ graph LR
                 module_src_auth_ts --&gt; export_AUTH_OAUTH_ERROR_STAGES
                 export_AUTH_OAUTH_PROVIDER_IDS[&quot;AUTH_OAUTH_PROVIDER_IDS&quot;]
                 module_src_auth_ts --&gt; export_AUTH_OAUTH_PROVIDER_IDS
+                export_AUTH_OAUTH_SETUP_CALLBACK_ROLES[&quot;AUTH_OAUTH_SETUP_CALLBACK_ROLES&quot;]
+                module_src_auth_ts --&gt; export_AUTH_OAUTH_SETUP_CALLBACK_ROLES
+                export_AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS[&quot;AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS&quot;]
+                module_src_auth_ts --&gt; export_AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS
+                export_AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES[&quot;AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES&quot;]
+                module_src_auth_ts --&gt; export_AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES
                 export_AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS[&quot;AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS&quot;]
                 module_src_auth_ts --&gt; export_AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS
                 export_AUTH_OAUTH_TRANSPORT_ERROR_CODES[&quot;AUTH_OAUTH_TRANSPORT_ERROR_CODES&quot;]
                 module_src_auth_ts --&gt; export_AUTH_OAUTH_TRANSPORT_ERROR_CODES
+                export_AUTH_OAUTH_TRANSPORT_IDS[&quot;AUTH_OAUTH_TRANSPORT_IDS&quot;]
+                module_src_auth_ts --&gt; export_AUTH_OAUTH_TRANSPORT_IDS
                 export_AUTH_PROFILE_CREATE_STRATEGIES[&quot;AUTH_PROFILE_CREATE_STRATEGIES&quot;]
                 module_src_types_ts --&gt; export_AUTH_PROFILE_CREATE_STRATEGIES
                 export_AUTH_PROFILE_FIELDS[&quot;AUTH_PROFILE_FIELDS&quot;] module_src_types_ts
@@ -15620,6 +16043,27 @@ graph LR
                 export_AuthOAuthProviderConfig -.-&gt; export_IconSpec
                 export_AuthOAuthProviderId[&quot;AuthOAuthProviderId&quot;] module_src_auth_ts
                 --&gt; export_AuthOAuthProviderId
+                export_AuthOAuthSetupCallbackRequirement[&quot;AuthOAuthSetupCallbackRequirement&quot;]
+                module_src_auth_ts --&gt; export_AuthOAuthSetupCallbackRequirement
+                export_AuthOAuthSetupCallbackRole[&quot;AuthOAuthSetupCallbackRole&quot;]
+                module_src_auth_ts --&gt; export_AuthOAuthSetupCallbackRole
+                export_AuthOAuthSetupCapabilities[&quot;AuthOAuthSetupCapabilities&quot;]
+                module_src_auth_ts --&gt; export_AuthOAuthSetupCapabilities
+                export_AuthOAuthSetupCapabilities -.-&gt; export_AuthOAuthProviderId
+                export_AuthOAuthSetupCapabilities -.-&gt; export_AuthOAuthTransportId
+                export_AuthOAuthSetupFieldPersistence[&quot;AuthOAuthSetupFieldPersistence&quot;]
+                module_src_auth_ts --&gt; export_AuthOAuthSetupFieldPersistence
+                export_AuthOAuthSetupFieldRequirement[&quot;AuthOAuthSetupFieldRequirement&quot;]
+                module_src_auth_ts --&gt; export_AuthOAuthSetupFieldRequirement
+                export_AuthOAuthSetupFieldSensitivity[&quot;AuthOAuthSetupFieldSensitivity&quot;]
+                module_src_auth_ts --&gt; export_AuthOAuthSetupFieldSensitivity
+                export_AuthOAuthSetupPlan[&quot;AuthOAuthSetupPlan&quot;] module_src_auth_ts --&gt;
+                export_AuthOAuthSetupPlan export_AuthOAuthSetupPlan -.-&gt;
+                export_AuthOAuthProviderId export_AuthOAuthSetupPlan -.-&gt;
+                export_AuthOAuthSetupRequirement export_AuthOAuthSetupPlan -.-&gt;
+                export_AuthOAuthTransportId
+                export_AuthOAuthSetupRequirement[&quot;AuthOAuthSetupRequirement&quot;]
+                module_src_auth_ts --&gt; export_AuthOAuthSetupRequirement
                 export_AuthOAuthStartResult[&quot;AuthOAuthStartResult&quot;] module_src_auth_ts
                 --&gt; export_AuthOAuthStartResult
                 export_AuthOAuthTransportCancellationReason[&quot;AuthOAuthTransportCancellationReason&quot;]
@@ -15628,6 +16072,8 @@ graph LR
                 module_src_auth_ts --&gt; export_AuthOAuthTransportError
                 export_AuthOAuthTransportErrorCode[&quot;AuthOAuthTransportErrorCode&quot;]
                 module_src_auth_ts --&gt; export_AuthOAuthTransportErrorCode
+                export_AuthOAuthTransportId[&quot;AuthOAuthTransportId&quot;] module_src_auth_ts
+                --&gt; export_AuthOAuthTransportId
                 export_AuthProfileCreateStrategy[&quot;AuthProfileCreateStrategy&quot;]
                 module_src_types_ts --&gt; export_AuthProfileCreateStrategy
                 export_AuthProfileField[&quot;AuthProfileField&quot;] module_src_types_ts --&gt;
@@ -15994,6 +16440,8 @@ graph LR
                 module_src_media_ts --&gt; export_isMediaAssetReference
                 export_KnownAuthOAuthProviderId[&quot;KnownAuthOAuthProviderId&quot;]
                 module_src_auth_ts --&gt; export_KnownAuthOAuthProviderId
+                export_KnownAuthOAuthTransportId[&quot;KnownAuthOAuthTransportId&quot;]
+                module_src_auth_ts --&gt; export_KnownAuthOAuthTransportId
                 export_KnownAuthProfileField[&quot;KnownAuthProfileField&quot;] module_src_types_ts
                 --&gt; export_KnownAuthProfileField
                 export_KnownAuthProvider[&quot;KnownAuthProvider&quot;] module_src_types_ts --&gt;
@@ -16513,10 +16961,18 @@ graph LR
   module_src_auth_ts --&gt; export_AUTH_OAUTH_ERROR_STAGES
   export_AUTH_OAUTH_PROVIDER_IDS[&quot;AUTH_OAUTH_PROVIDER_IDS&quot;]
   module_src_auth_ts --&gt; export_AUTH_OAUTH_PROVIDER_IDS
+  export_AUTH_OAUTH_SETUP_CALLBACK_ROLES[&quot;AUTH_OAUTH_SETUP_CALLBACK_ROLES&quot;]
+  module_src_auth_ts --&gt; export_AUTH_OAUTH_SETUP_CALLBACK_ROLES
+  export_AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS[&quot;AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS&quot;]
+  module_src_auth_ts --&gt; export_AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS
+  export_AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES[&quot;AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES&quot;]
+  module_src_auth_ts --&gt; export_AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES
   export_AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS[&quot;AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS&quot;]
   module_src_auth_ts --&gt; export_AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS
   export_AUTH_OAUTH_TRANSPORT_ERROR_CODES[&quot;AUTH_OAUTH_TRANSPORT_ERROR_CODES&quot;]
   module_src_auth_ts --&gt; export_AUTH_OAUTH_TRANSPORT_ERROR_CODES
+  export_AUTH_OAUTH_TRANSPORT_IDS[&quot;AUTH_OAUTH_TRANSPORT_IDS&quot;]
+  module_src_auth_ts --&gt; export_AUTH_OAUTH_TRANSPORT_IDS
   export_AUTH_PROFILE_CREATE_STRATEGIES[&quot;AUTH_PROFILE_CREATE_STRATEGIES&quot;]
   module_src_types_ts --&gt; export_AUTH_PROFILE_CREATE_STRATEGIES
   export_AUTH_PROFILE_FIELDS[&quot;AUTH_PROFILE_FIELDS&quot;]
@@ -16592,6 +17048,27 @@ graph LR
   export_AuthOAuthProviderConfig -.-&gt; export_IconSpec
   export_AuthOAuthProviderId[&quot;AuthOAuthProviderId&quot;]
   module_src_auth_ts --&gt; export_AuthOAuthProviderId
+  export_AuthOAuthSetupCallbackRequirement[&quot;AuthOAuthSetupCallbackRequirement&quot;]
+  module_src_auth_ts --&gt; export_AuthOAuthSetupCallbackRequirement
+  export_AuthOAuthSetupCallbackRole[&quot;AuthOAuthSetupCallbackRole&quot;]
+  module_src_auth_ts --&gt; export_AuthOAuthSetupCallbackRole
+  export_AuthOAuthSetupCapabilities[&quot;AuthOAuthSetupCapabilities&quot;]
+  module_src_auth_ts --&gt; export_AuthOAuthSetupCapabilities
+  export_AuthOAuthSetupCapabilities -.-&gt; export_AuthOAuthProviderId
+  export_AuthOAuthSetupCapabilities -.-&gt; export_AuthOAuthTransportId
+  export_AuthOAuthSetupFieldPersistence[&quot;AuthOAuthSetupFieldPersistence&quot;]
+  module_src_auth_ts --&gt; export_AuthOAuthSetupFieldPersistence
+  export_AuthOAuthSetupFieldRequirement[&quot;AuthOAuthSetupFieldRequirement&quot;]
+  module_src_auth_ts --&gt; export_AuthOAuthSetupFieldRequirement
+  export_AuthOAuthSetupFieldSensitivity[&quot;AuthOAuthSetupFieldSensitivity&quot;]
+  module_src_auth_ts --&gt; export_AuthOAuthSetupFieldSensitivity
+  export_AuthOAuthSetupPlan[&quot;AuthOAuthSetupPlan&quot;]
+  module_src_auth_ts --&gt; export_AuthOAuthSetupPlan
+  export_AuthOAuthSetupPlan -.-&gt; export_AuthOAuthProviderId
+  export_AuthOAuthSetupPlan -.-&gt; export_AuthOAuthSetupRequirement
+  export_AuthOAuthSetupPlan -.-&gt; export_AuthOAuthTransportId
+  export_AuthOAuthSetupRequirement[&quot;AuthOAuthSetupRequirement&quot;]
+  module_src_auth_ts --&gt; export_AuthOAuthSetupRequirement
   export_AuthOAuthStartResult[&quot;AuthOAuthStartResult&quot;]
   module_src_auth_ts --&gt; export_AuthOAuthStartResult
   export_AuthOAuthTransportCancellationReason[&quot;AuthOAuthTransportCancellationReason&quot;]
@@ -16600,6 +17077,8 @@ graph LR
   module_src_auth_ts --&gt; export_AuthOAuthTransportError
   export_AuthOAuthTransportErrorCode[&quot;AuthOAuthTransportErrorCode&quot;]
   module_src_auth_ts --&gt; export_AuthOAuthTransportErrorCode
+  export_AuthOAuthTransportId[&quot;AuthOAuthTransportId&quot;]
+  module_src_auth_ts --&gt; export_AuthOAuthTransportId
   export_AuthProfileCreateStrategy[&quot;AuthProfileCreateStrategy&quot;]
   module_src_types_ts --&gt; export_AuthProfileCreateStrategy
   export_AuthProfileField[&quot;AuthProfileField&quot;]
@@ -17042,6 +17521,8 @@ graph LR
   module_src_media_ts --&gt; export_isMediaAssetReference
   export_KnownAuthOAuthProviderId[&quot;KnownAuthOAuthProviderId&quot;]
   module_src_auth_ts --&gt; export_KnownAuthOAuthProviderId
+  export_KnownAuthOAuthTransportId[&quot;KnownAuthOAuthTransportId&quot;]
+  module_src_auth_ts --&gt; export_KnownAuthOAuthTransportId
   export_KnownAuthProfileField[&quot;KnownAuthProfileField&quot;]
   module_src_types_ts --&gt; export_KnownAuthProfileField
   export_KnownAuthProvider[&quot;KnownAuthProvider&quot;]
@@ -18177,7 +18658,7 @@ graph LR
             <h2>src/auth.ts</h2>
             <article class="item" data-search="resolveAuthFlow src/auth.ts ">
               <h3>resolveAuthFlow</h3>
-              <p class="muted"><code>src/auth.ts:65:1</code></p>
+              <p class="muted"><code>src/auth.ts:130:1</code></p>
               <p class="empty">No description available.</p>
             </article>
           </section>

--- a/paradox/paradox.json
+++ b/paradox/paradox.json
@@ -12,7 +12,7 @@
     {
       "id": "npm",
       "label": "npm",
-      "value": "v7.6.0",
+      "value": "v7.8.0",
       "color": "cb3837"
     },
     {
@@ -59,10 +59,7 @@
     }
   ],
   "usage": null,
-  "readmeUsageDescription": null,
   "readmeUsage": [],
-  "readmeCli": null,
-  "readmeConfig": null,
   "config": null,
   "entrypoints": ["src/index.ts"],
   "modules": [
@@ -151,15 +148,19 @@
     {
       "path": "src/auth.ts",
       "isEntrypoint": false,
-      "dependencies": ["src/secrets.ts", "src/types.ts"],
+      "dependencies": ["src/deploy.ts", "src/secrets.ts", "src/types.ts"],
       "exports": [
         "AUTH_IDENTIFIER_KINDS",
         "AUTH_OAUTH_CANCELLATION_REASONS",
         "AUTH_OAUTH_ERROR_CODES",
         "AUTH_OAUTH_ERROR_STAGES",
         "AUTH_OAUTH_PROVIDER_IDS",
+        "AUTH_OAUTH_SETUP_CALLBACK_ROLES",
+        "AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS",
+        "AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES",
         "AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS",
         "AUTH_OAUTH_TRANSPORT_ERROR_CODES",
+        "AUTH_OAUTH_TRANSPORT_IDS",
         "AUTH_SIGN_UP_FIELDS",
         "AuthAdapter",
         "AuthAdapterCapabilities",
@@ -179,10 +180,19 @@
         "AuthOAuthErrorStage",
         "AuthOAuthProviderConfig",
         "AuthOAuthProviderId",
+        "AuthOAuthSetupCallbackRequirement",
+        "AuthOAuthSetupCallbackRole",
+        "AuthOAuthSetupCapabilities",
+        "AuthOAuthSetupFieldPersistence",
+        "AuthOAuthSetupFieldRequirement",
+        "AuthOAuthSetupFieldSensitivity",
+        "AuthOAuthSetupPlan",
+        "AuthOAuthSetupRequirement",
         "AuthOAuthStartResult",
         "AuthOAuthTransportCancellationReason",
         "AuthOAuthTransportError",
         "AuthOAuthTransportErrorCode",
+        "AuthOAuthTransportId",
         "AuthProviderConfig",
         "AuthResult",
         "AuthSession",
@@ -193,6 +203,7 @@
         "CompleteOAuthAuthorizationInput",
         "DEFAULT_AUTH_FLOW",
         "KnownAuthOAuthProviderId",
+        "KnownAuthOAuthTransportId",
         "KnownAuthSignUpField",
         "PasswordResetInput",
         "resolveAuthFlow",
@@ -543,8 +554,12 @@
         "AUTH_OAUTH_ERROR_CODES",
         "AUTH_OAUTH_ERROR_STAGES",
         "AUTH_OAUTH_PROVIDER_IDS",
+        "AUTH_OAUTH_SETUP_CALLBACK_ROLES",
+        "AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS",
+        "AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES",
         "AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS",
         "AUTH_OAUTH_TRANSPORT_ERROR_CODES",
+        "AUTH_OAUTH_TRANSPORT_IDS",
         "AUTH_PROFILE_CREATE_STRATEGIES",
         "AUTH_PROFILE_FIELDS",
         "AUTH_PROFILE_PRIMARY_KEY_STRATEGIES",
@@ -572,10 +587,19 @@
         "AuthOAuthErrorStage",
         "AuthOAuthProviderConfig",
         "AuthOAuthProviderId",
+        "AuthOAuthSetupCallbackRequirement",
+        "AuthOAuthSetupCallbackRole",
+        "AuthOAuthSetupCapabilities",
+        "AuthOAuthSetupFieldPersistence",
+        "AuthOAuthSetupFieldRequirement",
+        "AuthOAuthSetupFieldSensitivity",
+        "AuthOAuthSetupPlan",
+        "AuthOAuthSetupRequirement",
         "AuthOAuthStartResult",
         "AuthOAuthTransportCancellationReason",
         "AuthOAuthTransportError",
         "AuthOAuthTransportErrorCode",
+        "AuthOAuthTransportId",
         "AuthProfileCreateStrategy",
         "AuthProfileField",
         "AuthProfilePrimaryKeyStrategy",
@@ -731,6 +755,7 @@
         "isAppManifest",
         "isMediaAssetReference",
         "KnownAuthOAuthProviderId",
+        "KnownAuthOAuthTransportId",
         "KnownAuthProfileField",
         "KnownAuthProvider",
         "KnownAuthSignUpField",
@@ -1402,7 +1427,7 @@
         {
           "name": "path",
           "kind": "property",
-          "type": "readonly [string, ...string[]]",
+          "type": "readonly string[]",
           "required": true,
           "description": null
         },
@@ -1425,7 +1450,7 @@
       "modulePath": "src/cli/index.ts",
       "sourceLocation": {
         "filePath": "src/cli/index.ts",
-        "line": 15,
+        "line": 20,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1551,7 +1576,7 @@
       "modulePath": "src/cli/index.ts",
       "sourceLocation": {
         "filePath": "src/cli/index.ts",
-        "line": 23,
+        "line": 28,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1640,7 +1665,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -1689,7 +1714,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -2134,14 +2159,14 @@
         {
           "name": "dataBindings",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/bindings\").ComponentDataBinding>> | undefined",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/bindings\").ComponentDataBinding>> | undefined",
           "required": false,
           "description": null
         },
         {
           "name": "dataSources",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSourceConfig>> | undefined",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSourceConfig>> | undefined",
           "required": false,
           "description": null
         },
@@ -2155,7 +2180,7 @@
         {
           "name": "generatedApis",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").GeneratedApiDefinition>> | undefined",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").GeneratedApiDefinition>> | undefined",
           "required": false,
           "description": null
         },
@@ -2278,7 +2303,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 4,
+        "line": 5,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2296,7 +2321,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 217,
+        "line": 282,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2314,7 +2339,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 184,
+        "line": 249,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2332,7 +2357,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 174,
+        "line": 239,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2350,7 +2375,61 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 17,
+        "line": 18,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "AUTH_OAUTH_SETUP_CALLBACK_ROLES",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 56,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 46,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 53,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2368,7 +2447,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 210,
+        "line": 275,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2386,7 +2465,25 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 223,
+        "line": 288,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "AUTH_OAUTH_TRANSPORT_IDS",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 42,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2530,7 +2627,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 7,
+        "line": 8,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2566,7 +2663,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 317,
+        "line": 382,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2659,7 +2756,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 309,
+        "line": 374,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2713,7 +2810,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 126,
+        "line": 191,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2753,7 +2850,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 46,
+        "line": 111,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2821,7 +2918,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 41,
+        "line": 106,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2854,7 +2951,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 5,
+        "line": 6,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2872,7 +2969,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 302,
+        "line": 367,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2918,7 +3015,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 242,
+        "line": 307,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2965,7 +3062,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 259,
+        "line": 324,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2983,7 +3080,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 221,
+        "line": 286,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3001,7 +3098,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 297,
+        "line": 362,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3027,7 +3124,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 278,
+        "line": 343,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3045,7 +3142,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 89,
+        "line": 154,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3085,7 +3182,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 203,
+        "line": 268,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3130,7 +3227,7 @@
         {
           "name": "stage",
           "kind": "property",
-          "type": "\"start\" | \"transport\" | \"callback\" | \"exchange\" | \"session\" | \"profile\"",
+          "type": "\"callback\" | \"start\" | \"transport\" | \"exchange\" | \"session\" | \"profile\"",
           "required": true,
           "description": null
         }
@@ -3146,7 +3243,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 201,
+        "line": 266,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3164,7 +3261,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 182,
+        "line": 247,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3182,7 +3279,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 78,
+        "line": 143,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3250,7 +3347,306 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 39,
+        "line": 40,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "AuthOAuthSetupCallbackRequirement",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 72,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "description",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "kind",
+          "kind": "property",
+          "type": "\"callback\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "label",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "required",
+          "kind": "property",
+          "type": "boolean",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "role",
+          "kind": "property",
+          "type": "\"provider\" | \"app\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "target",
+          "kind": "property",
+          "type": "\"web\" | \"android\" | \"ios\" | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "AuthOAuthSetupCallbackRole",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 57,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "AuthOAuthSetupCapabilities",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 101,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["AuthOAuthProviderId", "AuthOAuthTransportId"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "providers",
+          "kind": "property",
+          "type": "readonly AuthOAuthProviderId[]",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "transports",
+          "kind": "property",
+          "type": "readonly AuthOAuthTransportId[]",
+          "required": true,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "AuthOAuthSetupFieldPersistence",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 50,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "AuthOAuthSetupFieldRequirement",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 59,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "description",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "key",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "kind",
+          "kind": "property",
+          "type": "\"field\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "label",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "persistence",
+          "kind": "property",
+          "type": "\"trustedCredential\" | \"publicConfig\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "required",
+          "kind": "property",
+          "type": "boolean",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "sensitivity",
+          "kind": "property",
+          "type": "\"public\" | \"secret\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "target",
+          "kind": "property",
+          "type": "\"web\" | \"android\" | \"ios\" | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "AuthOAuthSetupFieldSensitivity",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 54,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "AuthOAuthSetupPlan",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 91,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [
+        "AuthOAuthProviderId",
+        "AuthOAuthSetupRequirement",
+        "AuthOAuthTransportId"
+      ],
+      "signatures": [],
+      "members": [
+        {
+          "name": "environment",
+          "kind": "property",
+          "type": "\"local\" | \"preview\" | \"production\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "provider",
+          "kind": "property",
+          "type": "AuthOAuthProviderId",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "requirements",
+          "kind": "property",
+          "type": "readonly AuthOAuthSetupRequirement[]",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "targets",
+          "kind": "property",
+          "type": "readonly (\"web\" | \"android\" | \"ios\")[]",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "transport",
+          "kind": "property",
+          "type": "AuthOAuthTransportId",
+          "required": true,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "AuthOAuthSetupRequirement",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 82,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3268,7 +3664,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 249,
+        "line": 314,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3286,7 +3682,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 214,
+        "line": 279,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3304,7 +3700,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 229,
+        "line": 294,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3344,7 +3740,25 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 227,
+        "line": 292,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "AuthOAuthTransportId",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 44,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3426,7 +3840,7 @@
         {
           "name": "createStrategy",
           "kind": "property",
-          "type": "\"api\" | \"trigger\" | \"app\" | undefined",
+          "type": "\"app\" | \"api\" | \"trigger\" | undefined",
           "required": false,
           "description": null
         },
@@ -3454,7 +3868,7 @@
         {
           "name": "updateStrategy",
           "kind": "property",
-          "type": "\"api\" | \"app\" | undefined",
+          "type": "\"app\" | \"api\" | undefined",
           "required": false,
           "description": null
         }
@@ -3506,7 +3920,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 95,
+        "line": 160,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3567,7 +3981,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 132,
+        "line": 197,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3603,7 +4017,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 118,
+        "line": 183,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3657,7 +4071,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 69,
+        "line": 134,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3727,7 +4141,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 73,
+        "line": 138,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3760,7 +4174,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 15,
+        "line": 16,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3919,7 +4333,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 108,
+        "line": 173,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4491,7 +4905,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 273,
+        "line": 338,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4977,7 +5391,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -5012,7 +5426,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -6025,7 +6439,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -6060,7 +6474,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -7351,7 +7765,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 56,
+        "line": 121,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -7538,7 +7952,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -7601,7 +8015,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -7654,7 +8068,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -7710,7 +8124,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -8250,7 +8664,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -8306,7 +8720,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -8639,7 +9053,25 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 38,
+        "line": 39,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "KnownAuthOAuthTransportId",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/auth.ts",
+      "sourceLocation": {
+        "filePath": "src/auth.ts",
+        "line": 43,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8693,7 +9125,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 14,
+        "line": 15,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9602,7 +10034,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 162,
+        "line": 227,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9701,7 +10133,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 65,
+        "line": 130,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10066,7 +10498,7 @@
         {
           "name": "dataLoaders",
           "kind": "property",
-          "type": "readonly import(\"./src/bindings\").OperationScreenDataLoaderDefinition[] | undefined",
+          "type": "readonly import(\"/Users/a_rtiphishl_e/git/contracts/src/bindings\").OperationScreenDataLoaderDefinition[] | undefined",
           "required": false,
           "description": null
         },
@@ -10779,7 +11211,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 142,
+        "line": 207,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10833,7 +11265,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 158,
+        "line": 223,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10859,7 +11291,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 150,
+        "line": 215,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11072,7 +11504,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 235,
+        "line": 300,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11447,7 +11879,7 @@
         {
           "name": "persistence",
           "kind": "property",
-          "type": "\"database\" | \"none\" | \"local\" | \"secure\" | undefined",
+          "type": "\"local\" | \"database\" | \"none\" | \"secure\" | undefined",
           "required": false,
           "description": null
         },
@@ -13932,7 +14364,7 @@
       "modulePath": "src/auth.ts",
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 167,
+        "line": 232,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -14914,7 +15346,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/auth.ts",
-        "line": 65,
+        "line": 130,
         "column": 1
       }
     },
@@ -15084,6 +15516,11 @@
         "fromPath": "src/appManifest.ts",
         "toPath": "src/types.ts",
         "sourcePath": "src/appManifest.ts"
+      },
+      {
+        "fromPath": "src/auth.ts",
+        "toPath": "src/deploy.ts",
+        "sourcePath": "src/auth.ts"
       },
       {
         "fromPath": "src/auth.ts",
@@ -17005,6 +17442,31 @@
         "sourcePath": "src/auth.ts"
       },
       {
+        "fromSymbol": "AuthOAuthSetupPlan",
+        "toType": "AuthOAuthProviderId",
+        "sourcePath": "src/auth.ts"
+      },
+      {
+        "fromSymbol": "AuthOAuthSetupPlan",
+        "toType": "AuthOAuthSetupRequirement",
+        "sourcePath": "src/auth.ts"
+      },
+      {
+        "fromSymbol": "AuthOAuthSetupPlan",
+        "toType": "AuthOAuthTransportId",
+        "sourcePath": "src/auth.ts"
+      },
+      {
+        "fromSymbol": "AuthOAuthSetupCapabilities",
+        "toType": "AuthOAuthProviderId",
+        "sourcePath": "src/auth.ts"
+      },
+      {
+        "fromSymbol": "AuthOAuthSetupCapabilities",
+        "toType": "AuthOAuthTransportId",
+        "sourcePath": "src/auth.ts"
+      },
+      {
         "fromSymbol": "AuthSignUpConfig",
         "toType": "AuthSignUpField",
         "sourcePath": "src/auth.ts"
@@ -17540,6 +18002,11 @@
         "sourcePath": "src/data/sources.ts"
       },
       {
+        "fromSymbol": "DataSourceBaseConfig",
+        "toType": "Users",
+        "sourcePath": "src/data/sources.ts"
+      },
+      {
         "fromSymbol": "ApiDataSourceBaseConfig",
         "toType": "ApiOrigin",
         "sourcePath": "src/data/sources.ts"
@@ -17575,6 +18042,11 @@
         "sourcePath": "src/data/sources.ts"
       },
       {
+        "fromSymbol": "ApiDataSourceBaseConfig",
+        "toType": "Users",
+        "sourcePath": "src/data/sources.ts"
+      },
+      {
         "fromSymbol": "ExternalRestApiDataSourceConfig",
         "toType": "CredentialRef",
         "sourcePath": "src/data/sources.ts"
@@ -17605,6 +18077,11 @@
         "sourcePath": "src/data/sources.ts"
       },
       {
+        "fromSymbol": "ExternalRestApiDataSourceConfig",
+        "toType": "Users",
+        "sourcePath": "src/data/sources.ts"
+      },
+      {
         "fromSymbol": "ExternalGraphQlApiDataSourceConfig",
         "toType": "CredentialRef",
         "sourcePath": "src/data/sources.ts"
@@ -17627,6 +18104,11 @@
       {
         "fromSymbol": "ExternalGraphQlApiDataSourceConfig",
         "toType": "Readonly",
+        "sourcePath": "src/data/sources.ts"
+      },
+      {
+        "fromSymbol": "ExternalGraphQlApiDataSourceConfig",
+        "toType": "Users",
         "sourcePath": "src/data/sources.ts"
       },
       {
@@ -17660,6 +18142,11 @@
         "sourcePath": "src/data/sources.ts"
       },
       {
+        "fromSymbol": "GeneratedRestApiDataSourceConfig",
+        "toType": "Users",
+        "sourcePath": "src/data/sources.ts"
+      },
+      {
         "fromSymbol": "DatabaseDataSourceConfig",
         "toType": "CredentialRef",
         "sourcePath": "src/data/sources.ts"
@@ -17687,6 +18174,11 @@
       {
         "fromSymbol": "DatabaseDataSourceConfig",
         "toType": "Readonly",
+        "sourcePath": "src/data/sources.ts"
+      },
+      {
+        "fromSymbol": "DatabaseDataSourceConfig",
+        "toType": "Users",
         "sourcePath": "src/data/sources.ts"
       },
       {
@@ -18370,6 +18862,11 @@
         "sourcePath": "src/types.ts"
       },
       {
+        "fromSymbol": "ScreenSpec",
+        "toType": "Users",
+        "sourcePath": "src/types.ts"
+      },
+      {
         "fromSymbol": "NavigatorSpec",
         "toType": "RouteDefinition",
         "sourcePath": "src/types.ts"
@@ -18572,6 +19069,11 @@
       {
         "fromSymbol": "AppManifest",
         "toType": "ThemeConfig",
+        "sourcePath": "src/types.ts"
+      },
+      {
+        "fromSymbol": "AppManifest",
+        "toType": "Users",
         "sourcePath": "src/types.ts"
       },
       {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -38,6 +38,26 @@ describe('cli contracts', () => {
     expect(manifest.commands[0].path).toEqual(['up']);
   });
 
+  it('accepts an empty path as a category-root command', () => {
+    const deployCommand = {
+      path: [],
+      summary: 'Deploy the authored release',
+      capability: 'deploy.release',
+      examples: ['ankh deploy'],
+    } as const satisfies AnkhCommandDescriptor;
+
+    const manifest = {
+      id: '@ankhorage/deploy',
+      category: 'deploy',
+      version: '1.0.0',
+      capabilities: ['deploy.release'],
+      commands: [deployCommand],
+    } as const satisfies AnkhCommandProviderManifest;
+
+    expect(manifest.commands[0].path).toEqual([]);
+    expect(JSON.parse(JSON.stringify(manifest))).toEqual(manifest);
+  });
+
   it('accepts metadata-only packages without a provider module', () => {
     const packageMetadata = {
       category: 'contracts',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,12 @@ export type AnkhProviderReference = `./${string}`;
 export type AnkhCapabilityId = `${string}.${string}`;
 
 export interface AnkhCommandDescriptor {
-  readonly path: readonly [string, ...string[]];
+  /**
+   * Command path relative to the provider category.
+   *
+   * An empty path declares the command at the category root.
+   */
+  readonly path: readonly string[];
   readonly summary: string;
   readonly capability: AnkhCapabilityId;
   readonly aliases?: readonly string[];


### PR DESCRIPTION
## Summary

Allow Ankh CLI provider manifests to declare a command directly at the provider category root using an empty command path.

This enables first-class commands such as:

ankh deploy

without introducing an artificial subcommand such as `ankh deploy release`.

## Changes

- allow `AnkhCommandDescriptor.path` to be empty
- define `[]` as a category-root command
- preserve existing relative non-root command paths
- add contract coverage for `ankh deploy`
- update generated documentation
- add minor Changeset

## Roadmap

Part of ankhorage/deploy#31 — DEP 11 Phase 1.

This is the upstream release gate required before `@ankhorage/ankh` can implement root-command dispatch.