### PR TITLE
feat: add ebook reader requirement capability

### DIFF
--- a/.changeset/calm-pages-read.md
+++ b/.changeset/calm-pages-read.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': patch
+---
+
+Add the canonical `ebookReader` platform requirement capability for manifest-authored EPUB and PDF reader surfaces.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # CONTRACTS
 
-![license: MIT](././paradox/badges/license.svg) ![npm: v7.8.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
+![license: MIT](././paradox/badges/license.svg) ![npm: v8.0.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
 
 Serializable app, action, theme, auth, and secret-store contracts for Ankhorage.
 

--- a/paradox/badges/npm.svg
+++ b/paradox/badges/npm.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="npm: v7.8.0">
-<title>npm: v7.8.0</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="npm: v8.0.0">
+<title>npm: v8.0.0</title>
 <rect width="38" height="20" fill="#374151"/>
 <rect x="38" width="52" height="20" fill="#cb3837"/>
 <text x="19" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">npm</text>
-<text x="64" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v7.8.0</text>
+<text x="64" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v8.0.0</text>
 </svg>

--- a/paradox/diagrams/architecture-overview.mmd
+++ b/paradox/diagrams/architecture-overview.mmd
@@ -7,27 +7,33 @@ graph TD
   module_src_appManifest_ts --> module_src_appManifest_bindings_ts
   module_src_appManifest_ts --> module_src_appManifest_dataSources_ts
   module_src_appManifest_ts --> module_src_appManifest_deploy_ts
-  module_src_appManifest_ts --> module_src_appManifest_generatedApis_ts
   module_src_appManifest_ts --> module_src_appManifest_infra_ts
   module_src_appManifest_ts --> module_src_appManifest_media_ts
   module_src_appManifest_ts --> module_src_appManifest_screens_ts
   module_src_appManifest_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_ts --> module_src_types_ts
+  module_src_appManifest_apis_ts["src/appManifest/apis.ts"]
+  package__ankhorage_contracts -.-> module_src_appManifest_apis_ts
+  module_src_appManifest_apis_ts --> module_src_appManifest_data_ts
+  module_src_appManifest_apis_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_apis_ts --> module_src_data_index_ts
   module_src_appManifest_bindings_ts["src/appManifest/bindings.ts"]
   package__ankhorage_contracts -.-> module_src_appManifest_bindings_ts
   module_src_appManifest_bindings_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_data_ts["src/appManifest/data.ts"]
+  package__ankhorage_contracts -.-> module_src_appManifest_data_ts
+  module_src_appManifest_data_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_dataSources_ts["src/appManifest/dataSources.ts"]
   package__ankhorage_contracts -.-> module_src_appManifest_dataSources_ts
+  module_src_appManifest_dataSources_ts --> module_src_appManifest_data_ts
   module_src_appManifest_dataSources_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts["src/appManifest/deploy.ts"]
   package__ankhorage_contracts -.-> module_src_appManifest_deploy_ts
   module_src_appManifest_deploy_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --> module_src_deploy_ts
-  module_src_appManifest_generatedApis_ts["src/appManifest/generatedApis.ts"]
-  package__ankhorage_contracts -.-> module_src_appManifest_generatedApis_ts
-  module_src_appManifest_generatedApis_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_infra_ts["src/appManifest/infra.ts"]
   package__ankhorage_contracts -.-> module_src_appManifest_infra_ts
+  module_src_appManifest_infra_ts --> module_src_appManifest_apis_ts
   module_src_appManifest_infra_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_infra_ts --> module_src_auth_ts
   module_src_appManifest_infra_ts --> module_src_types_ts
@@ -54,9 +60,11 @@ graph TD
   package__ankhorage_contracts -.-> module_src_cli_index_ts
   module_src_data_apis_ts["src/data/apis.ts"]
   package__ankhorage_contracts -.-> module_src_data_apis_ts
+  module_src_data_apis_ts --> module_src_data_endpoints_ts
+  module_src_data_apis_ts --> module_src_data_ids_ts
   module_src_data_apis_ts --> module_src_data_refs_ts
+  module_src_data_apis_ts --> module_src_data_schemas_ts
   module_src_data_apis_ts --> module_src_data_values_ts
-  module_src_data_apis_ts --> module_src_db_ts
   module_src_data_diagnostics_ts["src/data/diagnostics.ts"]
   package__ankhorage_contracts -.-> module_src_data_diagnostics_ts
   module_src_data_diagnostics_ts --> module_src_data_ids_ts

--- a/paradox/diagrams/export-graph.mmd
+++ b/paradox/diagrams/export-graph.mmd
@@ -1,9 +1,10 @@
 graph LR
   module_src_appManifest_ts["src/appManifest.ts"]
+  module_src_appManifest_apis_ts["src/appManifest/apis.ts"]
   module_src_appManifest_bindings_ts["src/appManifest/bindings.ts"]
+  module_src_appManifest_data_ts["src/appManifest/data.ts"]
   module_src_appManifest_dataSources_ts["src/appManifest/dataSources.ts"]
   module_src_appManifest_deploy_ts["src/appManifest/deploy.ts"]
-  module_src_appManifest_generatedApis_ts["src/appManifest/generatedApis.ts"]
   module_src_appManifest_infra_ts["src/appManifest/infra.ts"]
   module_src_appManifest_media_ts["src/appManifest/media.ts"]
   module_src_appManifest_screens_ts["src/appManifest/screens.ts"]
@@ -69,20 +70,24 @@ graph LR
   module_src_cli_index_ts --> export_AnkhPackageMetadata
   export_AnkhProviderReference["AnkhProviderReference"]
   module_src_cli_index_ts --> export_AnkhProviderReference
-  export_ApiDataSourceBaseConfig["ApiDataSourceBaseConfig"]
-  module_src_data_sources_ts --> export_ApiDataSourceBaseConfig
-  export_ApiDataSourceBaseConfig -.-> export_ApiOrigin
-  export_ApiDataSourceBaseConfig -.-> export_ApiProtocol
-  export_ApiDataSourceBaseConfig -.-> export_CredentialRef
-  export_ApiDataSourceBaseConfig -.-> export_DataContractValue
-  export_ApiDataSourceBaseConfig -.-> export_DataEndpointConfig
-  export_ApiDataSourceBaseConfig -.-> export_DataSchema
-  export_ApiDataSourceConfig["ApiDataSourceConfig"]
-  module_src_data_sources_ts --> export_ApiDataSourceConfig
+  export_ApiBaseDefinition["ApiBaseDefinition"]
+  module_src_data_apis_ts --> export_ApiBaseDefinition
+  export_ApiBaseDefinition -.-> export_ApiOrigin
+  export_ApiBaseDefinition -.-> export_ApiProtocol
+  export_ApiBaseDefinition -.-> export_CredentialRef
+  export_ApiBaseDefinition -.-> export_DataContractValue
+  export_ApiBaseDefinition -.-> export_DataEndpointConfig
+  export_ApiBaseDefinition -.-> export_DataSchema
+  export_ApiDefinition["ApiDefinition"]
+  module_src_data_apis_ts --> export_ApiDefinition
+  export_ApiDefinitionList["ApiDefinitionList"]
+  module_src_data_apis_ts --> export_ApiDefinitionList
+  export_ApiId["ApiId"]
+  module_src_data_ids_ts --> export_ApiId
   export_ApiOrigin["ApiOrigin"]
-  module_src_data_sources_ts --> export_ApiOrigin
+  module_src_data_apis_ts --> export_ApiOrigin
   export_ApiProtocol["ApiProtocol"]
-  module_src_data_sources_ts --> export_ApiProtocol
+  module_src_data_apis_ts --> export_ApiProtocol
   export_APP_CATEGORIES["APP_CATEGORIES"]
   module_src_types_ts --> export_APP_CATEGORIES
   export_APP_DEPLOY_ENVIRONMENT_IDS["APP_DEPLOY_ENVIRONMENT_IDS"]
@@ -120,8 +125,7 @@ graph LR
   export_AppManifest -.-> export_AppDeployManifest
   export_AppManifest -.-> export_AppSettings
   export_AppManifest -.-> export_ComponentDataBinding
-  export_AppManifest -.-> export_DataSourceConfig
-  export_AppManifest -.-> export_GeneratedApiDefinition
+  export_AppManifest -.-> export_DatabaseDataSourceConfig
   export_AppManifest -.-> export_InfraManifest
   export_AppManifest -.-> export_MediaManifest
   export_AppManifest -.-> export_NavigatorSpec
@@ -490,13 +494,6 @@ graph LR
   module_src_data_schemas_ts --> export_DataSchemaSlot
   export_DataSchemaSlot -.-> export_DataSchema
   export_DataSchemaSlot -.-> export_DataSchemaRef
-  export_DataSourceBaseConfig["DataSourceBaseConfig"]
-  module_src_data_sources_ts --> export_DataSourceBaseConfig
-  export_DataSourceBaseConfig -.-> export_CredentialRef
-  export_DataSourceBaseConfig -.-> export_DataContractValue
-  export_DataSourceBaseConfig -.-> export_DataEndpointConfig
-  export_DataSourceBaseConfig -.-> export_DataSchema
-  export_DataSourceBaseConfig -.-> export_DataSourceKind
   export_DataSourceConfig["DataSourceConfig"]
   module_src_data_sources_ts --> export_DataSourceConfig
   export_DataSourceDiagnostic["DataSourceDiagnostic"]
@@ -618,19 +615,20 @@ graph LR
   export_EventBinding -.-> export_EventBindingTarget
   export_EventBindingTarget["EventBindingTarget"]
   module_src_bindings_ts --> export_EventBindingTarget
-  export_ExternalGraphQlApiDataSourceConfig["ExternalGraphQlApiDataSourceConfig"]
-  module_src_data_sources_ts --> export_ExternalGraphQlApiDataSourceConfig
-  export_ExternalGraphQlApiDataSourceConfig -.-> export_CredentialRef
-  export_ExternalGraphQlApiDataSourceConfig -.-> export_DataContractValue
-  export_ExternalGraphQlApiDataSourceConfig -.-> export_DataEndpointConfig
-  export_ExternalGraphQlApiDataSourceConfig -.-> export_DataSchema
-  export_ExternalRestApiDataSourceConfig["ExternalRestApiDataSourceConfig"]
-  module_src_data_sources_ts --> export_ExternalRestApiDataSourceConfig
-  export_ExternalRestApiDataSourceConfig -.-> export_CredentialRef
-  export_ExternalRestApiDataSourceConfig -.-> export_DataContractValue
-  export_ExternalRestApiDataSourceConfig -.-> export_DataEndpointConfig
-  export_ExternalRestApiDataSourceConfig -.-> export_DataSchema
-  export_ExternalRestApiDataSourceConfig -.-> export_OpenApiDocumentRef
+  export_ExternalGraphQlApiDefinition["ExternalGraphQlApiDefinition"]
+  module_src_data_apis_ts --> export_ExternalGraphQlApiDefinition
+  export_ExternalGraphQlApiDefinition -.-> export_CredentialRef
+  export_ExternalGraphQlApiDefinition -.-> export_DataContractValue
+  export_ExternalGraphQlApiDefinition -.-> export_DataEndpointConfig
+  export_ExternalGraphQlApiDefinition -.-> export_DataSchema
+  export_ExternalGraphQlApiDefinition -.-> export_GraphQlIntrospectionConfig
+  export_ExternalRestApiDefinition["ExternalRestApiDefinition"]
+  module_src_data_apis_ts --> export_ExternalRestApiDefinition
+  export_ExternalRestApiDefinition -.-> export_CredentialRef
+  export_ExternalRestApiDefinition -.-> export_DataContractValue
+  export_ExternalRestApiDefinition -.-> export_DataEndpointConfig
+  export_ExternalRestApiDefinition -.-> export_DataSchema
+  export_ExternalRestApiDefinition -.-> export_OpenApiDocumentRef
   export_FilterAction["FilterAction"]
   module_src_types_ts --> export_FilterAction
   export_findForbiddenInlineSecretFields["findForbiddenInlineSecretFields"]
@@ -641,41 +639,8 @@ graph LR
   module_src_types_ts --> export_FormSubmitEventDto
   export_FormSubmitValues["FormSubmitValues"]
   module_src_types_ts --> export_FormSubmitValues
-  export_GENERATED_API_CRUD_OPERATIONS["GENERATED_API_CRUD_OPERATIONS"]
-  module_src_data_apis_ts --> export_GENERATED_API_CRUD_OPERATIONS
-  export_GeneratedApiAuthRequirement["GeneratedApiAuthRequirement"]
-  module_src_data_apis_ts --> export_GeneratedApiAuthRequirement
-  export_GeneratedApiAuthRequirement -.-> export_DataContractValue
-  export_GeneratedApiCrudOperation["GeneratedApiCrudOperation"]
-  module_src_data_apis_ts --> export_GeneratedApiCrudOperation
-  export_GeneratedApiDefinition["GeneratedApiDefinition"]
-  module_src_data_apis_ts --> export_GeneratedApiDefinition
-  export_GeneratedApiDefinition -.-> export_DatabaseAdapterRef
-  export_GeneratedApiDefinition -.-> export_DataContractValue
-  export_GeneratedApiDefinition -.-> export_GeneratedApiAuthRequirement
-  export_GeneratedApiDefinition -.-> export_GeneratedApiResourceDefinition
-  export_GeneratedApiId["GeneratedApiId"]
-  module_src_data_apis_ts --> export_GeneratedApiId
-  export_GeneratedApiOperationPolicyRef["GeneratedApiOperationPolicyRef"]
-  module_src_data_apis_ts --> export_GeneratedApiOperationPolicyRef
-  export_GeneratedApiRegistry["GeneratedApiRegistry"]
-  module_src_data_apis_ts --> export_GeneratedApiRegistry
-  export_GeneratedApiResourceDefinition["GeneratedApiResourceDefinition"]
-  module_src_data_apis_ts --> export_GeneratedApiResourceDefinition
-  export_GeneratedApiResourceDefinition -.-> export_DataContractValue
-  export_GeneratedApiResourceDefinition -.-> export_DbCollectionDefinition
-  export_GeneratedApiResourceDefinition -.-> export_GeneratedApiOperationPolicyRef
-  export_GeneratedApiResourceId["GeneratedApiResourceId"]
-  module_src_data_apis_ts --> export_GeneratedApiResourceId
-  export_GeneratedApiSeedRecord["GeneratedApiSeedRecord"]
-  module_src_data_apis_ts --> export_GeneratedApiSeedRecord
-  export_GeneratedRestApiDataSourceConfig["GeneratedRestApiDataSourceConfig"]
-  module_src_data_sources_ts --> export_GeneratedRestApiDataSourceConfig
-  export_GeneratedRestApiDataSourceConfig -.-> export_CredentialRef
-  export_GeneratedRestApiDataSourceConfig -.-> export_DatabaseAdapterRef
-  export_GeneratedRestApiDataSourceConfig -.-> export_DataContractValue
-  export_GeneratedRestApiDataSourceConfig -.-> export_DataEndpointConfig
-  export_GeneratedRestApiDataSourceConfig -.-> export_DataSchema
+  export_GraphQlIntrospectionConfig["GraphQlIntrospectionConfig"]
+  module_src_data_apis_ts --> export_GraphQlIntrospectionConfig
   export_IconSpec["IconSpec"]
   module_src_types_ts --> export_IconSpec
   export_ImageAssetSource["ImageAssetSource"]
@@ -684,6 +649,7 @@ graph LR
   module_src_storage_ts --> export_ImageMetadata
   export_InfraManifest["InfraManifest"]
   module_src_types_ts --> export_InfraManifest
+  export_InfraManifest -.-> export_ApiDefinitionList
   export_InfraManifest -.-> export_AuthSpec
   export_InfraManifest -.-> export_DatabaseSpec
   export_InfraManifest -.-> export_DeploymentSpec
@@ -694,6 +660,12 @@ graph LR
   export_InfraSecretStoreSpec["InfraSecretStoreSpec"]
   module_src_secretManifest_ts --> export_InfraSecretStoreSpec
   export_InfraSecretStoreSpec -.-> export_SecretStoreProvider
+  export_InternalRestApiDefinition["InternalRestApiDefinition"]
+  module_src_data_apis_ts --> export_InternalRestApiDefinition
+  export_InternalRestApiDefinition -.-> export_CredentialRef
+  export_InternalRestApiDefinition -.-> export_DataContractValue
+  export_InternalRestApiDefinition -.-> export_DataEndpointConfig
+  export_InternalRestApiDefinition -.-> export_DataSchema
   export_isAppDeployManifest["isAppDeployManifest"]
   module_src_appManifest_deploy_ts --> export_isAppDeployManifest
   export_isAppManifest["isAppManifest"]
@@ -780,7 +752,7 @@ graph LR
   export_normalizeSecretScope -.-> export_SecretScope
   export_normalizeSecretScope -.-> export_SecretStoreResult
   export_OpenApiDocumentRef["OpenApiDocumentRef"]
-  module_src_data_sources_ts --> export_OpenApiDocumentRef
+  module_src_data_apis_ts --> export_OpenApiDocumentRef
   export_OperationId["OperationId"]
   module_src_data_ids_ts --> export_OperationId
   export_OperationScreenDataLoaderDefinition["OperationScreenDataLoaderDefinition"]

--- a/paradox/diagrams/module-relationships.mmd
+++ b/paradox/diagrams/module-relationships.mmd
@@ -1,9 +1,10 @@
 graph LR
   module_src_appManifest_ts["src/appManifest.ts"]
+  module_src_appManifest_apis_ts["src/appManifest/apis.ts"]
   module_src_appManifest_bindings_ts["src/appManifest/bindings.ts"]
+  module_src_appManifest_data_ts["src/appManifest/data.ts"]
   module_src_appManifest_dataSources_ts["src/appManifest/dataSources.ts"]
   module_src_appManifest_deploy_ts["src/appManifest/deploy.ts"]
-  module_src_appManifest_generatedApis_ts["src/appManifest/generatedApis.ts"]
   module_src_appManifest_infra_ts["src/appManifest/infra.ts"]
   module_src_appManifest_media_ts["src/appManifest/media.ts"]
   module_src_appManifest_screens_ts["src/appManifest/screens.ts"]
@@ -37,17 +38,21 @@ graph LR
   module_src_appManifest_ts --> module_src_appManifest_bindings_ts
   module_src_appManifest_ts --> module_src_appManifest_dataSources_ts
   module_src_appManifest_ts --> module_src_appManifest_deploy_ts
-  module_src_appManifest_ts --> module_src_appManifest_generatedApis_ts
   module_src_appManifest_ts --> module_src_appManifest_infra_ts
   module_src_appManifest_ts --> module_src_appManifest_media_ts
   module_src_appManifest_ts --> module_src_appManifest_screens_ts
   module_src_appManifest_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_ts --> module_src_types_ts
+  module_src_appManifest_apis_ts --> module_src_appManifest_data_ts
+  module_src_appManifest_apis_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_apis_ts --> module_src_data_index_ts
   module_src_appManifest_bindings_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_data_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_dataSources_ts --> module_src_appManifest_data_ts
   module_src_appManifest_dataSources_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --> module_src_deploy_ts
-  module_src_appManifest_generatedApis_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_infra_ts --> module_src_appManifest_apis_ts
   module_src_appManifest_infra_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_infra_ts --> module_src_auth_ts
   module_src_appManifest_infra_ts --> module_src_types_ts
@@ -60,9 +65,11 @@ graph LR
   module_src_auth_ts --> module_src_secrets_ts
   module_src_auth_ts --> module_src_types_ts
   module_src_bindings_ts --> module_src_data_index_ts
+  module_src_data_apis_ts --> module_src_data_endpoints_ts
+  module_src_data_apis_ts --> module_src_data_ids_ts
   module_src_data_apis_ts --> module_src_data_refs_ts
+  module_src_data_apis_ts --> module_src_data_schemas_ts
   module_src_data_apis_ts --> module_src_data_values_ts
-  module_src_data_apis_ts --> module_src_db_ts
   module_src_data_diagnostics_ts --> module_src_data_ids_ts
   module_src_data_endpoints_ts --> module_src_data_ids_ts
   module_src_data_endpoints_ts --> module_src_data_operations_ts

--- a/paradox/exports.json
+++ b/paradox/exports.json
@@ -44,7 +44,7 @@
     "modulePath": "src/data/ids.ts",
     "sourceLocation": {
       "filePath": "src/data/ids.ts",
-      "line": 6,
+      "line": 7,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -347,7 +347,7 @@
     "modulePath": "src/requirements.ts",
     "sourceLocation": {
       "filePath": "src/requirements.ts",
-      "line": 24,
+      "line": 25,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -433,15 +433,15 @@
     "structuredRows": []
   },
   {
-    "name": "ApiDataSourceBaseConfig",
+    "name": "ApiBaseDefinition",
     "description": null,
     "isReadme": false,
     "examples": [],
     "kind": "type",
-    "modulePath": "src/data/sources.ts",
+    "modulePath": "src/data/apis.ts",
     "sourceLocation": {
-      "filePath": "src/data/sources.ts",
-      "line": 22,
+      "filePath": "src/data/apis.ts",
+      "line": 10,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -472,7 +472,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -480,13 +480,6 @@
         "name": "id",
         "kind": "property",
         "type": "string",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "kind",
-        "kind": "property",
-        "type": "\"api\"",
         "required": true,
         "description": null
       },
@@ -521,7 +514,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -529,15 +522,51 @@
     "structuredRows": []
   },
   {
-    "name": "ApiDataSourceConfig",
+    "name": "ApiDefinition",
     "description": null,
     "isReadme": false,
     "examples": [],
     "kind": "unknown",
-    "modulePath": "src/data/sources.ts",
+    "modulePath": "src/data/apis.ts",
     "sourceLocation": {
-      "filePath": "src/data/sources.ts",
-      "line": 58,
+      "filePath": "src/data/apis.ts",
+      "line": 60,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "ApiDefinitionList",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/data/apis.ts",
+    "sourceLocation": {
+      "filePath": "src/data/apis.ts",
+      "line": 65,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "ApiId",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/data/ids.ts",
+    "sourceLocation": {
+      "filePath": "src/data/ids.ts",
+      "line": 1,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -552,10 +581,10 @@
     "isReadme": false,
     "examples": [],
     "kind": "unknown",
-    "modulePath": "src/data/sources.ts",
+    "modulePath": "src/data/apis.ts",
     "sourceLocation": {
-      "filePath": "src/data/sources.ts",
-      "line": 8,
+      "filePath": "src/data/apis.ts",
+      "line": 7,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -570,10 +599,10 @@
     "isReadme": false,
     "examples": [],
     "kind": "unknown",
-    "modulePath": "src/data/sources.ts",
+    "modulePath": "src/data/apis.ts",
     "sourceLocation": {
-      "filePath": "src/data/sources.ts",
-      "line": 9,
+      "filePath": "src/data/apis.ts",
+      "line": 8,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -938,8 +967,7 @@
       "AppDeployManifest",
       "AppSettings",
       "ComponentDataBinding",
-      "DataSourceConfig",
-      "GeneratedApiDefinition",
+      "DatabaseDataSourceConfig",
       "InfraManifest",
       "MediaManifest",
       "NavigatorSpec",
@@ -966,14 +994,14 @@
       {
         "name": "dataBindings",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/bindings\").ComponentDataBinding>> | undefined",
+        "type": "Readonly<Record<string, import(\"./src/bindings\").ComponentDataBinding>> | undefined",
         "required": false,
         "description": null
       },
       {
         "name": "dataSources",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSourceConfig>> | undefined",
+        "type": "Readonly<Record<string, import(\"./src/index\").DatabaseDataSourceConfig>> | undefined",
         "required": false,
         "description": null
       },
@@ -981,13 +1009,6 @@
         "name": "deploy",
         "kind": "property",
         "type": "AppDeployManifest | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "generatedApis",
-        "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").GeneratedApiDefinition>> | undefined",
         "required": false,
         "description": null
       },
@@ -1059,7 +1080,7 @@
     "modulePath": "src/appManifest.ts",
     "sourceLocation": {
       "filePath": "src/appManifest.ts",
-      "line": 17,
+      "line": 16,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1077,20 +1098,13 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 381,
+      "line": 382,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
     "relatedSymbols": [],
     "signatures": [],
     "members": [
-      {
-        "name": "apiBaseUrl",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
       {
         "name": "localization",
         "kind": "property",
@@ -2643,7 +2657,7 @@
       {
         "name": "createStrategy",
         "kind": "property",
-        "type": "\"app\" | \"api\" | \"trigger\" | undefined",
+        "type": "\"app\" | \"trigger\" | \"api\" | undefined",
         "required": false,
         "description": null
       },
@@ -3520,7 +3534,7 @@
     "signatures": [],
     "members": [
       {
-        "name": "dataSourceId",
+        "name": "apiId",
         "kind": "property",
         "type": "string",
         "required": true,
@@ -3900,7 +3914,7 @@
     "modulePath": "src/requirements.ts",
     "sourceLocation": {
       "filePath": "src/requirements.ts",
-      "line": 39,
+      "line": 40,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3984,7 +3998,7 @@
     "modulePath": "src/data/ids.ts",
     "sourceLocation": {
       "filePath": "src/data/ids.ts",
-      "line": 5,
+      "line": 6,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -4157,7 +4171,7 @@
     "modulePath": "src/data/sources.ts",
     "sourceLocation": {
       "filePath": "src/data/sources.ts",
-      "line": 63,
+      "line": 9,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -4194,7 +4208,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -4229,7 +4243,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -5204,87 +5218,6 @@
     "structuredRows": []
   },
   {
-    "name": "DataSourceBaseConfig",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "type",
-    "modulePath": "src/data/sources.ts",
-    "sourceLocation": {
-      "filePath": "src/data/sources.ts",
-      "line": 11,
-      "column": 1
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": [
-      "CredentialRef",
-      "DataContractValue",
-      "DataEndpointConfig",
-      "DataSchema",
-      "DataSourceKind"
-    ],
-    "signatures": [],
-    "members": [
-      {
-        "name": "credential",
-        "kind": "property",
-        "type": "CredentialRef | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "description",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "endpoints",
-        "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "id",
-        "kind": "property",
-        "type": "string",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "kind",
-        "kind": "property",
-        "type": "DataSourceKind",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "metadata",
-        "kind": "property",
-        "type": "DataContractValue | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "name",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "schemas",
-        "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
-        "required": false,
-        "description": null
-      }
-    ],
-    "structuredRows": []
-  },
-  {
     "name": "DataSourceConfig",
     "description": null,
     "isReadme": false,
@@ -5293,7 +5226,7 @@
     "modulePath": "src/data/sources.ts",
     "sourceLocation": {
       "filePath": "src/data/sources.ts",
-      "line": 68,
+      "line": 21,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -5311,13 +5244,20 @@
     "modulePath": "src/data/diagnostics.ts",
     "sourceLocation": {
       "filePath": "src/data/diagnostics.ts",
-      "line": 21,
+      "line": 22,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
     "relatedSymbols": ["DataDiagnosticCode", "DataDiagnosticSeverity"],
     "signatures": [],
     "members": [
+      {
+        "name": "apiId",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
       {
         "name": "code",
         "kind": "property",
@@ -5386,7 +5326,7 @@
     "modulePath": "src/data/diagnostics.ts",
     "sourceLocation": {
       "filePath": "src/data/diagnostics.ts",
-      "line": 32,
+      "line": 34,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -5404,7 +5344,7 @@
     "modulePath": "src/data/ids.ts",
     "sourceLocation": {
       "filePath": "src/data/ids.ts",
-      "line": 1,
+      "line": 2,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -5440,7 +5380,7 @@
     "modulePath": "src/data/sources.ts",
     "sourceLocation": {
       "filePath": "src/data/sources.ts",
-      "line": 70,
+      "line": 22,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6655,7 +6595,7 @@
     "modulePath": "src/data/ids.ts",
     "sourceLocation": {
       "filePath": "src/data/ids.ts",
-      "line": 2,
+      "line": 3,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6723,19 +6663,25 @@
     "structuredRows": []
   },
   {
-    "name": "ExternalGraphQlApiDataSourceConfig",
+    "name": "ExternalGraphQlApiDefinition",
     "description": null,
     "isReadme": false,
     "examples": [],
     "kind": "type",
-    "modulePath": "src/data/sources.ts",
+    "modulePath": "src/data/apis.ts",
     "sourceLocation": {
-      "filePath": "src/data/sources.ts",
-      "line": 41,
+      "filePath": "src/data/apis.ts",
+      "line": 40,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
-    "relatedSymbols": ["CredentialRef", "DataContractValue", "DataEndpointConfig", "DataSchema"],
+    "relatedSymbols": [
+      "CredentialRef",
+      "DataContractValue",
+      "DataEndpointConfig",
+      "DataSchema",
+      "GraphQlIntrospectionConfig"
+    ],
     "signatures": [],
     "members": [
       {
@@ -6755,7 +6701,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -6776,15 +6722,8 @@
       {
         "name": "introspection",
         "kind": "property",
-        "type": "{ readonly enabled: boolean; readonly schemaVersion?: string; } | undefined",
+        "type": "GraphQlIntrospectionConfig | undefined",
         "required": false,
-        "description": null
-      },
-      {
-        "name": "kind",
-        "kind": "property",
-        "type": "\"api\"",
-        "required": true,
         "description": null
       },
       {
@@ -6818,7 +6757,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -6826,15 +6765,15 @@
     "structuredRows": []
   },
   {
-    "name": "ExternalRestApiDataSourceConfig",
+    "name": "ExternalRestApiDefinition",
     "description": null,
     "isReadme": false,
     "examples": [],
     "kind": "type",
-    "modulePath": "src/data/sources.ts",
+    "modulePath": "src/data/apis.ts",
     "sourceLocation": {
-      "filePath": "src/data/sources.ts",
-      "line": 34,
+      "filePath": "src/data/apis.ts",
+      "line": 28,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6871,7 +6810,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -6879,13 +6818,6 @@
         "name": "id",
         "kind": "property",
         "type": "string",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "kind",
-        "kind": "property",
-        "type": "\"api\"",
         "required": true,
         "description": null
       },
@@ -6927,7 +6859,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -7054,25 +6986,7 @@
     "structuredRows": []
   },
   {
-    "name": "GENERATED_API_CRUD_OPERATIONS",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "value",
-    "modulePath": "src/data/apis.ts",
-    "sourceLocation": {
-      "filePath": "src/data/apis.ts",
-      "line": 5,
-      "column": 14
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": [],
-    "signatures": [],
-    "members": [],
-    "structuredRows": []
-  },
-  {
-    "name": "GeneratedApiAuthRequirement",
+    "name": "GraphQlIntrospectionConfig",
     "description": null,
     "isReadme": false,
     "examples": [],
@@ -7080,184 +6994,7 @@
     "modulePath": "src/data/apis.ts",
     "sourceLocation": {
       "filePath": "src/data/apis.ts",
-      "line": 18,
-      "column": 1
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": ["DataContractValue"],
-    "signatures": [],
-    "members": [
-      {
-        "name": "metadata",
-        "kind": "property",
-        "type": "DataContractValue | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "permissions",
-        "kind": "property",
-        "type": "readonly string[] | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "policy",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "required",
-        "kind": "property",
-        "type": "boolean | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "roles",
-        "kind": "property",
-        "type": "readonly string[] | undefined",
-        "required": false,
-        "description": null
-      }
-    ],
-    "structuredRows": []
-  },
-  {
-    "name": "GeneratedApiCrudOperation",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "unknown",
-    "modulePath": "src/data/apis.ts",
-    "sourceLocation": {
-      "filePath": "src/data/apis.ts",
-      "line": 12,
-      "column": 1
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": [],
-    "signatures": [],
-    "members": [],
-    "structuredRows": []
-  },
-  {
-    "name": "GeneratedApiDefinition",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "type",
-    "modulePath": "src/data/apis.ts",
-    "sourceLocation": {
-      "filePath": "src/data/apis.ts",
-      "line": 50,
-      "column": 1
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": [
-      "DatabaseAdapterRef",
-      "DataContractValue",
-      "GeneratedApiAuthRequirement",
-      "GeneratedApiResourceDefinition"
-    ],
-    "signatures": [],
-    "members": [
-      {
-        "name": "auth",
-        "kind": "property",
-        "type": "GeneratedApiAuthRequirement | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "basePath",
-        "kind": "property",
-        "type": "string",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "database",
-        "kind": "property",
-        "type": "DatabaseAdapterRef",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "description",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "id",
-        "kind": "property",
-        "type": "string",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "metadata",
-        "kind": "property",
-        "type": "DataContractValue | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "name",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "protocol",
-        "kind": "property",
-        "type": "\"rest\"",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "resources",
-        "kind": "property",
-        "type": "readonly GeneratedApiResourceDefinition[]",
-        "required": true,
-        "description": null
-      }
-    ],
-    "structuredRows": []
-  },
-  {
-    "name": "GeneratedApiId",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "unknown",
-    "modulePath": "src/data/apis.ts",
-    "sourceLocation": {
-      "filePath": "src/data/apis.ts",
-      "line": 14,
-      "column": 1
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": [],
-    "signatures": [],
-    "members": [],
-    "structuredRows": []
-  },
-  {
-    "name": "GeneratedApiOperationPolicyRef",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "type",
-    "modulePath": "src/data/apis.ts",
-    "sourceLocation": {
-      "filePath": "src/data/apis.ts",
-      "line": 26,
+      "line": 35,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7265,265 +7002,16 @@
     "signatures": [],
     "members": [
       {
-        "name": "id",
+        "name": "enabled",
         "kind": "property",
-        "type": "string",
+        "type": "boolean",
         "required": true,
         "description": null
       },
       {
-        "name": "operation",
-        "kind": "property",
-        "type": "\"list\" | \"read\" | \"create\" | \"update\" | \"delete\" | undefined",
-        "required": false,
-        "description": null
-      }
-    ],
-    "structuredRows": []
-  },
-  {
-    "name": "GeneratedApiRegistry",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "unknown",
-    "modulePath": "src/data/apis.ts",
-    "sourceLocation": {
-      "filePath": "src/data/apis.ts",
-      "line": 62,
-      "column": 1
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": [],
-    "signatures": [],
-    "members": [],
-    "structuredRows": []
-  },
-  {
-    "name": "GeneratedApiResourceDefinition",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "type",
-    "modulePath": "src/data/apis.ts",
-    "sourceLocation": {
-      "filePath": "src/data/apis.ts",
-      "line": 31,
-      "column": 1
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": [
-      "DataContractValue",
-      "DbCollectionDefinition",
-      "GeneratedApiOperationPolicyRef"
-    ],
-    "signatures": [],
-    "members": [
-      {
-        "name": "collection",
-        "kind": "property",
-        "type": "DbCollectionDefinition",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "description",
+        "name": "schemaVersion",
         "kind": "property",
         "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "id",
-        "kind": "property",
-        "type": "string",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "metadata",
-        "kind": "property",
-        "type": "DataContractValue | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "name",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "operations",
-        "kind": "property",
-        "type": "readonly (\"list\" | \"read\" | \"create\" | \"update\" | \"delete\")[]",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "path",
-        "kind": "property",
-        "type": "string",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "policies",
-        "kind": "property",
-        "type": "readonly GeneratedApiOperationPolicyRef[] | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "seed",
-        "kind": "property",
-        "type": "readonly Readonly<Record<string, DataContractValue>>[] | undefined",
-        "required": false,
-        "description": null
-      }
-    ],
-    "structuredRows": []
-  },
-  {
-    "name": "GeneratedApiResourceId",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "unknown",
-    "modulePath": "src/data/apis.ts",
-    "sourceLocation": {
-      "filePath": "src/data/apis.ts",
-      "line": 15,
-      "column": 1
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": [],
-    "signatures": [],
-    "members": [],
-    "structuredRows": []
-  },
-  {
-    "name": "GeneratedApiSeedRecord",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "unknown",
-    "modulePath": "src/data/apis.ts",
-    "sourceLocation": {
-      "filePath": "src/data/apis.ts",
-      "line": 16,
-      "column": 1
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": [],
-    "signatures": [],
-    "members": [],
-    "structuredRows": []
-  },
-  {
-    "name": "GeneratedRestApiDataSourceConfig",
-    "description": null,
-    "isReadme": false,
-    "examples": [],
-    "kind": "type",
-    "modulePath": "src/data/sources.ts",
-    "sourceLocation": {
-      "filePath": "src/data/sources.ts",
-      "line": 51,
-      "column": 1
-    },
-    "exportPaths": ["src/index.ts"],
-    "relatedSymbols": [
-      "CredentialRef",
-      "DatabaseAdapterRef",
-      "DataContractValue",
-      "DataEndpointConfig",
-      "DataSchema"
-    ],
-    "signatures": [],
-    "members": [
-      {
-        "name": "adapter",
-        "kind": "property",
-        "type": "DatabaseAdapterRef",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "credential",
-        "kind": "property",
-        "type": "CredentialRef | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "description",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "endpoints",
-        "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "generatedApiId",
-        "kind": "property",
-        "type": "string",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "id",
-        "kind": "property",
-        "type": "string",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "kind",
-        "kind": "property",
-        "type": "\"api\"",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "metadata",
-        "kind": "property",
-        "type": "DataContractValue | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "name",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "origin",
-        "kind": "property",
-        "type": "\"generated\"",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "protocol",
-        "kind": "property",
-        "type": "\"rest\"",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "schemas",
-        "kind": "property",
-        "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -7649,6 +7137,7 @@
     },
     "exportPaths": ["src/index.ts"],
     "relatedSymbols": [
+      "ApiDefinitionList",
       "AuthSpec",
       "DatabaseSpec",
       "DeploymentSpec",
@@ -7659,6 +7148,13 @@
     ],
     "signatures": [],
     "members": [
+      {
+        "name": "apis",
+        "kind": "property",
+        "type": "ApiDefinitionList | undefined",
+        "required": false,
+        "description": null
+      },
       {
         "name": "auth",
         "kind": "property",
@@ -7752,6 +7248,95 @@
     "structuredRows": []
   },
   {
+    "name": "InternalRestApiDefinition",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/data/apis.ts",
+    "sourceLocation": {
+      "filePath": "src/data/apis.ts",
+      "line": 54,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["CredentialRef", "DataContractValue", "DataEndpointConfig", "DataSchema"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "basePath",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "credential",
+        "kind": "property",
+        "type": "CredentialRef | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "description",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "endpoints",
+        "kind": "property",
+        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "id",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "metadata",
+        "kind": "property",
+        "type": "DataContractValue | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "name",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "origin",
+        "kind": "property",
+        "type": "\"internal\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "protocol",
+        "kind": "property",
+        "type": "\"rest\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "schemas",
+        "kind": "property",
+        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
     "name": "isAppDeployManifest",
     "description": null,
     "isReadme": false,
@@ -7792,7 +7377,7 @@
     "modulePath": "src/appManifest.ts",
     "sourceLocation": {
       "filePath": "src/appManifest.ts",
-      "line": 52,
+      "line": 50,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8697,10 +8282,10 @@
     "isReadme": false,
     "examples": [],
     "kind": "type",
-    "modulePath": "src/data/sources.ts",
+    "modulePath": "src/data/apis.ts",
     "sourceLocation": {
-      "filePath": "src/data/sources.ts",
-      "line": 28,
+      "filePath": "src/data/apis.ts",
+      "line": 22,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8740,7 +8325,7 @@
     "modulePath": "src/data/ids.ts",
     "sourceLocation": {
       "filePath": "src/data/ids.ts",
-      "line": 3,
+      "line": 4,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8805,7 +8390,7 @@
     "modulePath": "src/appManifest.ts",
     "sourceLocation": {
       "filePath": "src/appManifest.ts",
-      "line": 45,
+      "line": 43,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9170,7 +8755,7 @@
     "modulePath": "src/data/ids.ts",
     "sourceLocation": {
       "filePath": "src/data/ids.ts",
-      "line": 4,
+      "line": 5,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9188,7 +8773,7 @@
     "modulePath": "src/requirements.ts",
     "sourceLocation": {
       "filePath": "src/requirements.ts",
-      "line": 30,
+      "line": 31,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9198,7 +8783,7 @@
       {
         "name": "capability",
         "kind": "property",
-        "type": "\"notifications\" | \"clipboard\" | \"barcodeScanner\" | \"cameraPreview\" | \"mediaPicker\" | \"filePicker\" | \"location\"",
+        "type": "\"notifications\" | \"clipboard\" | \"barcodeScanner\" | \"cameraPreview\" | \"ebookReader\" | \"mediaPicker\" | \"filePicker\" | \"location\"",
         "required": true,
         "description": null
       }
@@ -9232,7 +8817,7 @@
     "modulePath": "src/requirements.ts",
     "sourceLocation": {
       "filePath": "src/requirements.ts",
-      "line": 26,
+      "line": 27,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9258,7 +8843,7 @@
     "modulePath": "src/requirements.ts",
     "sourceLocation": {
       "filePath": "src/requirements.ts",
-      "line": 34,
+      "line": 35,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9301,7 +8886,7 @@
       {
         "name": "dataLoaders",
         "kind": "property",
-        "type": "readonly import(\"/Users/a_rtiphishl_e/git/contracts/src/bindings\").OperationScreenDataLoaderDefinition[] | undefined",
+        "type": "readonly import(\"./src/bindings\").OperationScreenDataLoaderDefinition[] | undefined",
         "required": false,
         "description": null
       },

--- a/paradox/exports.md
+++ b/paradox/exports.md
@@ -16,7 +16,7 @@ Source: `src/types.ts:31:1`
 
 Kind: `unknown`
 Module: `src/data/ids.ts`
-Source: `src/data/ids.ts:6:1`
+Source: `src/data/ids.ts:7:1`
 
 ## AdapterKind
 
@@ -113,7 +113,7 @@ Source: `src/requirements.ts:1:14`
 
 Kind: `unknown`
 Module: `src/requirements.ts`
-Source: `src/requirements.ts:24:1`
+Source: `src/requirements.ts:25:1`
 
 ## AnkhoragePermissionName
 
@@ -141,44 +141,55 @@ Kind: `unknown`
 Module: `src/cli/index.ts`
 Source: `src/cli/index.ts:3:1`
 
-## ApiDataSourceBaseConfig
+## ApiBaseDefinition
 
 Kind: `type`
-Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:22:1`
+Module: `src/data/apis.ts`
+Source: `src/data/apis.ts:10:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                                                       | Required | Description |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| credential  | property | `CredentialRef \| undefined`                                                                               | no       |             |
-| description | property | `string \| undefined`                                                                                      | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                                                   | yes      |             |
-| kind        | property | `"api"`                                                                                                    | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                                                           | no       |             |
-| name        | property | `string \| undefined`                                                                                      | no       |             |
-| origin      | property | `ApiOrigin`                                                                                                | yes      |             |
-| protocol    | property | `ApiProtocol`                                                                                              | yes      |             |
-| schemas     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                      | Required | Description |
+| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
+| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
+| description | property | `string \| undefined`                                                     | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
+| id          | property | `string`                                                                  | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
+| name        | property | `string \| undefined`                                                     | no       |             |
+| origin      | property | `ApiOrigin`                                                               | yes      |             |
+| protocol    | property | `ApiProtocol`                                                             | yes      |             |
+| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
 
-## ApiDataSourceConfig
+## ApiDefinition
 
 Kind: `unknown`
-Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:58:1`
+Module: `src/data/apis.ts`
+Source: `src/data/apis.ts:60:1`
+
+## ApiDefinitionList
+
+Kind: `unknown`
+Module: `src/data/apis.ts`
+Source: `src/data/apis.ts:65:1`
+
+## ApiId
+
+Kind: `unknown`
+Module: `src/data/ids.ts`
+Source: `src/data/ids.ts:1:1`
 
 ## ApiOrigin
 
 Kind: `unknown`
-Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:8:1`
+Module: `src/data/apis.ts`
+Source: `src/data/apis.ts:7:1`
 
 ## ApiProtocol
 
 Kind: `unknown`
-Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:9:1`
+Module: `src/data/apis.ts`
+Source: `src/data/apis.ts:8:1`
 
 ## APP_CATEGORIES
 
@@ -310,10 +321,9 @@ Source: `src/types.ts:389:1`
 | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------- |
 | activeThemeId   | property | `string`                                                                                                                       | yes      |             |
 | activeThemeMode | property | `"dark" \| "light" \| undefined`                                                                                               | no       |             |
-| dataBindings    | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/bindings").ComponentDataBinding>> \| undefined`        | no       |             |
-| dataSources     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSourceConfig>> \| undefined`               | no       |             |
+| dataBindings    | property | `Readonly<Record<string, import("./src/bindings").ComponentDataBinding>> \| undefined`                                         | no       |             |
+| dataSources     | property | `Readonly<Record<string, import("./src/index").DatabaseDataSourceConfig>> \| undefined`                                        | no       |             |
 | deploy          | property | `AppDeployManifest \| undefined`                                                                                               | no       |             |
-| generatedApis   | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").GeneratedApiDefinition>> \| undefined`         | no       |             |
 | infra           | property | `InfraManifest`                                                                                                                | yes      |             |
 | media           | property | `MediaManifest \| undefined`                                                                                                   | no       |             |
 | metadata        | property | `{ name: string; slug: string; version: string; category: AppCategory; themeId: string; created?: string; updated?: string; }` | yes      |             |
@@ -327,19 +337,18 @@ Source: `src/types.ts:389:1`
 
 Kind: `unknown`
 Module: `src/appManifest.ts`
-Source: `src/appManifest.ts:17:1`
+Source: `src/appManifest.ts:16:1`
 
 ## AppSettings
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:381:1`
+Source: `src/types.ts:382:1`
 
 ### Members
 
 | Name         | Kind     | Type                                            | Required | Description |
 | ------------ | -------- | ----------------------------------------------- | -------- | ----------- |
-| apiBaseUrl   | property | `string \| undefined`                           | no       |             |
 | localization | property | `{ defaultLocale: string; locales: string[]; }` | yes      |             |
 
 ## AUTH_IDENTIFIER_KINDS
@@ -830,7 +839,7 @@ Source: `src/types.ts:346:1`
 
 | Name           | Kind     | Type                                       | Required | Description |
 | -------------- | -------- | ------------------------------------------ | -------- | ----------- |
-| createStrategy | property | `"app" \| "api" \| "trigger" \| undefined` | no       |             |
+| createStrategy | property | `"app" \| "trigger" \| "api" \| undefined` | no       |             |
 | fields         | property | `AuthProfileField[]`                       | yes      |             |
 | primaryKey     | property | `"authUserId" \| undefined`                | no       |             |
 | table          | property | `string \| undefined`                      | no       |             |
@@ -1115,11 +1124,11 @@ Source: `src/bindings.ts:20:1`
 
 ### Members
 
-| Name         | Kind     | Type                  | Required | Description |
-| ------------ | -------- | --------------------- | -------- | ----------- |
-| dataSourceId | property | `string`              | yes      |             |
-| endpointId   | property | `string \| undefined` | no       |             |
-| operationId  | property | `string`              | yes      |             |
+| Name        | Kind     | Type                  | Required | Description |
+| ----------- | -------- | --------------------- | -------- | ----------- |
+| apiId       | property | `string`              | yes      |             |
+| endpointId  | property | `string \| undefined` | no       |             |
+| operationId | property | `string`              | yes      |             |
 
 ## BindingValue
 
@@ -1247,7 +1256,7 @@ Source: `src/bindings.ts:3:1`
 
 Kind: `type`
 Module: `src/requirements.ts`
-Source: `src/requirements.ts:39:1`
+Source: `src/requirements.ts:40:1`
 
 ### Members
 
@@ -1279,7 +1288,7 @@ Source: `src/types.ts:55:1`
 
 Kind: `unknown`
 Module: `src/data/ids.ts`
-Source: `src/data/ids.ts:5:1`
+Source: `src/data/ids.ts:6:1`
 
 ## CredentialKind
 
@@ -1334,21 +1343,21 @@ Source: `src/data/refs.ts:23:1`
 
 Kind: `type`
 Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:63:1`
+Source: `src/data/sources.ts:9:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                                                       | Required | Description |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| adapter     | property | `DatabaseAdapterRef`                                                                                       | yes      |             |
-| credential  | property | `CredentialRef \| undefined`                                                                               | no       |             |
-| description | property | `string \| undefined`                                                                                      | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                                                   | yes      |             |
-| kind        | property | `"database"`                                                                                               | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                                                           | no       |             |
-| name        | property | `string \| undefined`                                                                                      | no       |             |
-| schemas     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                      | Required | Description |
+| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
+| adapter     | property | `DatabaseAdapterRef`                                                      | yes      |             |
+| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
+| description | property | `string \| undefined`                                                     | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
+| id          | property | `string`                                                                  | yes      |             |
+| kind        | property | `"database"`                                                              | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
+| name        | property | `string \| undefined`                                                     | no       |             |
+| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
 
 ## DatabaseProvider
 
@@ -1628,41 +1637,23 @@ Source: `src/data/schemas.ts:43:1`
 | schema    | property | `DataSchema \| undefined`    | no       |             |
 | schemaRef | property | `DataSchemaRef \| undefined` | no       |             |
 
-## DataSourceBaseConfig
-
-Kind: `type`
-Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:11:1`
-
-### Members
-
-| Name        | Kind     | Type                                                                                                       | Required | Description |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| credential  | property | `CredentialRef \| undefined`                                                                               | no       |             |
-| description | property | `string \| undefined`                                                                                      | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                                                   | yes      |             |
-| kind        | property | `DataSourceKind`                                                                                           | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                                                           | no       |             |
-| name        | property | `string \| undefined`                                                                                      | no       |             |
-| schemas     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
-
 ## DataSourceConfig
 
 Kind: `unknown`
 Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:68:1`
+Source: `src/data/sources.ts:21:1`
 
 ## DataSourceDiagnostic
 
 Kind: `type`
 Module: `src/data/diagnostics.ts`
-Source: `src/data/diagnostics.ts:21:1`
+Source: `src/data/diagnostics.ts:22:1`
 
 ### Members
 
 | Name         | Kind     | Type                     | Required | Description |
 | ------------ | -------- | ------------------------ | -------- | ----------- |
+| apiId        | property | `string \| undefined`    | no       |             |
 | code         | property | `DataDiagnosticCode`     | yes      |             |
 | dataSourceId | property | `string \| undefined`    | no       |             |
 | endpointId   | property | `string \| undefined`    | no       |             |
@@ -1676,13 +1667,13 @@ Source: `src/data/diagnostics.ts:21:1`
 
 Kind: `unknown`
 Module: `src/data/diagnostics.ts`
-Source: `src/data/diagnostics.ts:32:1`
+Source: `src/data/diagnostics.ts:34:1`
 
 ## DataSourceId
 
 Kind: `unknown`
 Module: `src/data/ids.ts`
-Source: `src/data/ids.ts:1:1`
+Source: `src/data/ids.ts:2:1`
 
 ## DataSourceKind
 
@@ -1694,7 +1685,7 @@ Source: `src/data/sources.ts:7:1`
 
 Kind: `unknown`
 Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:70:1`
+Source: `src/data/sources.ts:22:1`
 
 ## DbAdapter
 
@@ -2095,7 +2086,7 @@ Source: `src/types.ts:179:1`
 
 Kind: `unknown`
 Module: `src/data/ids.ts`
-Source: `src/data/ids.ts:2:1`
+Source: `src/data/ids.ts:3:1`
 
 ## EventBinding
 
@@ -2117,51 +2108,49 @@ Kind: `unknown`
 Module: `src/bindings.ts`
 Source: `src/bindings.ts:114:1`
 
-## ExternalGraphQlApiDataSourceConfig
+## ExternalGraphQlApiDefinition
 
 Kind: `type`
-Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:41:1`
+Module: `src/data/apis.ts`
+Source: `src/data/apis.ts:40:1`
 
 ### Members
 
-| Name          | Kind     | Type                                                                                                       | Required | Description |
-| ------------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| credential    | property | `CredentialRef \| undefined`                                                                               | no       |             |
-| description   | property | `string \| undefined`                                                                                      | no       |             |
-| endpoints     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
-| endpointUrl   | property | `string`                                                                                                   | yes      |             |
-| id            | property | `string`                                                                                                   | yes      |             |
-| introspection | property | `{ readonly enabled: boolean; readonly schemaVersion?: string; } \| undefined`                             | no       |             |
-| kind          | property | `"api"`                                                                                                    | yes      |             |
-| metadata      | property | `DataContractValue \| undefined`                                                                           | no       |             |
-| name          | property | `string \| undefined`                                                                                      | no       |             |
-| origin        | property | `"external"`                                                                                               | yes      |             |
-| protocol      | property | `"graphql"`                                                                                                | yes      |             |
-| schemas       | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
+| Name          | Kind     | Type                                                                      | Required | Description |
+| ------------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
+| credential    | property | `CredentialRef \| undefined`                                              | no       |             |
+| description   | property | `string \| undefined`                                                     | no       |             |
+| endpoints     | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
+| endpointUrl   | property | `string`                                                                  | yes      |             |
+| id            | property | `string`                                                                  | yes      |             |
+| introspection | property | `GraphQlIntrospectionConfig \| undefined`                                 | no       |             |
+| metadata      | property | `DataContractValue \| undefined`                                          | no       |             |
+| name          | property | `string \| undefined`                                                     | no       |             |
+| origin        | property | `"external"`                                                              | yes      |             |
+| protocol      | property | `"graphql"`                                                               | yes      |             |
+| schemas       | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
 
-## ExternalRestApiDataSourceConfig
+## ExternalRestApiDefinition
 
 Kind: `type`
-Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:34:1`
+Module: `src/data/apis.ts`
+Source: `src/data/apis.ts:28:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                                                       | Required | Description |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| baseUrl     | property | `string`                                                                                                   | yes      |             |
-| credential  | property | `CredentialRef \| undefined`                                                                               | no       |             |
-| description | property | `string \| undefined`                                                                                      | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                                                   | yes      |             |
-| kind        | property | `"api"`                                                                                                    | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                                                           | no       |             |
-| name        | property | `string \| undefined`                                                                                      | no       |             |
-| openApi     | property | `OpenApiDocumentRef \| undefined`                                                                          | no       |             |
-| origin      | property | `"external"`                                                                                               | yes      |             |
-| protocol    | property | `"rest"`                                                                                                   | yes      |             |
-| schemas     | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                      | Required | Description |
+| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
+| baseUrl     | property | `string`                                                                  | yes      |             |
+| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
+| description | property | `string \| undefined`                                                     | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
+| id          | property | `string`                                                                  | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
+| name        | property | `string \| undefined`                                                     | no       |             |
+| openApi     | property | `OpenApiDocumentRef \| undefined`                                         | no       |             |
+| origin      | property | `"external"`                                                              | yes      |             |
+| protocol    | property | `"rest"`                                                                  | yes      |             |
+| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
 
 ## FilterAction
 
@@ -2206,133 +2195,18 @@ Kind: `unknown`
 Module: `src/types.ts`
 Source: `src/types.ts:116:1`
 
-## GENERATED_API_CRUD_OPERATIONS
-
-Kind: `value`
-Module: `src/data/apis.ts`
-Source: `src/data/apis.ts:5:14`
-
-## GeneratedApiAuthRequirement
+## GraphQlIntrospectionConfig
 
 Kind: `type`
 Module: `src/data/apis.ts`
-Source: `src/data/apis.ts:18:1`
+Source: `src/data/apis.ts:35:1`
 
 ### Members
 
-| Name        | Kind     | Type                             | Required | Description |
-| ----------- | -------- | -------------------------------- | -------- | ----------- |
-| metadata    | property | `DataContractValue \| undefined` | no       |             |
-| permissions | property | `readonly string[] \| undefined` | no       |             |
-| policy      | property | `string \| undefined`            | no       |             |
-| required    | property | `boolean \| undefined`           | no       |             |
-| roles       | property | `readonly string[] \| undefined` | no       |             |
-
-## GeneratedApiCrudOperation
-
-Kind: `unknown`
-Module: `src/data/apis.ts`
-Source: `src/data/apis.ts:12:1`
-
-## GeneratedApiDefinition
-
-Kind: `type`
-Module: `src/data/apis.ts`
-Source: `src/data/apis.ts:50:1`
-
-### Members
-
-| Name        | Kind     | Type                                        | Required | Description |
-| ----------- | -------- | ------------------------------------------- | -------- | ----------- |
-| auth        | property | `GeneratedApiAuthRequirement \| undefined`  | no       |             |
-| basePath    | property | `string`                                    | yes      |             |
-| database    | property | `DatabaseAdapterRef`                        | yes      |             |
-| description | property | `string \| undefined`                       | no       |             |
-| id          | property | `string`                                    | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`            | no       |             |
-| name        | property | `string \| undefined`                       | no       |             |
-| protocol    | property | `"rest"`                                    | yes      |             |
-| resources   | property | `readonly GeneratedApiResourceDefinition[]` | yes      |             |
-
-## GeneratedApiId
-
-Kind: `unknown`
-Module: `src/data/apis.ts`
-Source: `src/data/apis.ts:14:1`
-
-## GeneratedApiOperationPolicyRef
-
-Kind: `type`
-Module: `src/data/apis.ts`
-Source: `src/data/apis.ts:26:1`
-
-### Members
-
-| Name      | Kind     | Type                                                                | Required | Description |
-| --------- | -------- | ------------------------------------------------------------------- | -------- | ----------- |
-| id        | property | `string`                                                            | yes      |             |
-| operation | property | `"list" \| "read" \| "create" \| "update" \| "delete" \| undefined` | no       |             |
-
-## GeneratedApiRegistry
-
-Kind: `unknown`
-Module: `src/data/apis.ts`
-Source: `src/data/apis.ts:62:1`
-
-## GeneratedApiResourceDefinition
-
-Kind: `type`
-Module: `src/data/apis.ts`
-Source: `src/data/apis.ts:31:1`
-
-### Members
-
-| Name        | Kind     | Type                                                                  | Required | Description |
-| ----------- | -------- | --------------------------------------------------------------------- | -------- | ----------- |
-| collection  | property | `DbCollectionDefinition`                                              | yes      |             |
-| description | property | `string \| undefined`                                                 | no       |             |
-| id          | property | `string`                                                              | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                      | no       |             |
-| name        | property | `string \| undefined`                                                 | no       |             |
-| operations  | property | `readonly ("list" \| "read" \| "create" \| "update" \| "delete")[]`   | yes      |             |
-| path        | property | `string`                                                              | yes      |             |
-| policies    | property | `readonly GeneratedApiOperationPolicyRef[] \| undefined`              | no       |             |
-| seed        | property | `readonly Readonly<Record<string, DataContractValue>>[] \| undefined` | no       |             |
-
-## GeneratedApiResourceId
-
-Kind: `unknown`
-Module: `src/data/apis.ts`
-Source: `src/data/apis.ts:15:1`
-
-## GeneratedApiSeedRecord
-
-Kind: `unknown`
-Module: `src/data/apis.ts`
-Source: `src/data/apis.ts:16:1`
-
-## GeneratedRestApiDataSourceConfig
-
-Kind: `type`
-Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:51:1`
-
-### Members
-
-| Name           | Kind     | Type                                                                                                       | Required | Description |
-| -------------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| adapter        | property | `DatabaseAdapterRef`                                                                                       | yes      |             |
-| credential     | property | `CredentialRef \| undefined`                                                                               | no       |             |
-| description    | property | `string \| undefined`                                                                                      | no       |             |
-| endpoints      | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataEndpointConfig>>`      | yes      |             |
-| generatedApiId | property | `string`                                                                                                   | yes      |             |
-| id             | property | `string`                                                                                                   | yes      |             |
-| kind           | property | `"api"`                                                                                                    | yes      |             |
-| metadata       | property | `DataContractValue \| undefined`                                                                           | no       |             |
-| name           | property | `string \| undefined`                                                                                      | no       |             |
-| origin         | property | `"generated"`                                                                                              | yes      |             |
-| protocol       | property | `"rest"`                                                                                                   | yes      |             |
-| schemas        | property | `Readonly<Record<string, import("/Users/a_rtiphishl_e/git/contracts/src/index").DataSchema>> \| undefined` | no       |             |
+| Name          | Kind     | Type                  | Required | Description |
+| ------------- | -------- | --------------------- | -------- | ----------- |
+| enabled       | property | `boolean`             | yes      |             |
+| schemaVersion | property | `string \| undefined` | no       |             |
 
 ## IconSpec
 
@@ -2379,6 +2253,7 @@ Source: `src/types.ts:370:1`
 
 | Name          | Kind     | Type                                   | Required | Description |
 | ------------- | -------- | -------------------------------------- | -------- | ----------- |
+| apis          | property | `ApiDefinitionList \| undefined`       | no       |             |
 | auth          | property | `AuthSpec \| undefined`                | no       |             |
 | database      | property | `DatabaseSpec \| undefined`            | no       |             |
 | deployment    | property | `DeploymentSpec \| undefined`          | no       |             |
@@ -2401,6 +2276,27 @@ Source: `src/secretManifest.ts:3:1`
 | -------- | -------- | --------------------- | -------- | ----------- |
 | provider | property | `SecretStoreProvider` | yes      |             |
 
+## InternalRestApiDefinition
+
+Kind: `type`
+Module: `src/data/apis.ts`
+Source: `src/data/apis.ts:54:1`
+
+### Members
+
+| Name        | Kind     | Type                                                                      | Required | Description |
+| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
+| basePath    | property | `string`                                                                  | yes      |             |
+| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
+| description | property | `string \| undefined`                                                     | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
+| id          | property | `string`                                                                  | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
+| name        | property | `string \| undefined`                                                     | no       |             |
+| origin      | property | `"internal"`                                                              | yes      |             |
+| protocol    | property | `"rest"`                                                                  | yes      |             |
+| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+
 ## isAppDeployManifest
 
 Kind: `function`
@@ -2417,7 +2313,7 @@ Source: `src/appManifest/deploy.ts:19:1`
 
 Kind: `function`
 Module: `src/appManifest.ts`
-Source: `src/appManifest.ts:52:1`
+Source: `src/appManifest.ts:50:1`
 
 ### Signatures
 
@@ -2723,8 +2619,8 @@ Source: `src/secrets.ts:129:1`
 ## OpenApiDocumentRef
 
 Kind: `type`
-Module: `src/data/sources.ts`
-Source: `src/data/sources.ts:28:1`
+Module: `src/data/apis.ts`
+Source: `src/data/apis.ts:22:1`
 
 ### Members
 
@@ -2738,7 +2634,7 @@ Source: `src/data/sources.ts:28:1`
 
 Kind: `unknown`
 Module: `src/data/ids.ts`
-Source: `src/data/ids.ts:3:1`
+Source: `src/data/ids.ts:4:1`
 
 ## OperationScreenDataLoaderDefinition
 
@@ -2759,7 +2655,7 @@ Source: `src/bindings.ts:97:1`
 
 Kind: `function`
 Module: `src/appManifest.ts`
-Source: `src/appManifest.ts:45:1`
+Source: `src/appManifest.ts:43:1`
 
 ### Signatures
 
@@ -2877,19 +2773,19 @@ Source: `src/runtimeCallbacks.ts:3:1`
 
 Kind: `unknown`
 Module: `src/data/ids.ts`
-Source: `src/data/ids.ts:4:1`
+Source: `src/data/ids.ts:5:1`
 
 ## ScreenCapabilityRequirement
 
 Kind: `type`
 Module: `src/requirements.ts`
-Source: `src/requirements.ts:30:1`
+Source: `src/requirements.ts:31:1`
 
 ### Members
 
-| Name       | Kind     | Type                                                                                                                   | Required | Description |
-| ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| capability | property | `"notifications" \| "clipboard" \| "barcodeScanner" \| "cameraPreview" \| "mediaPicker" \| "filePicker" \| "location"` | yes      |             |
+| Name       | Kind     | Type                                                                                                                                    | Required | Description |
+| ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| capability | property | `"notifications" \| "clipboard" \| "barcodeScanner" \| "cameraPreview" \| "ebookReader" \| "mediaPicker" \| "filePicker" \| "location"` | yes      |             |
 
 ## ScreenDataLoaderDefinition
 
@@ -2901,7 +2797,7 @@ Source: `src/bindings.ts:104:1`
 
 Kind: `type`
 Module: `src/requirements.ts`
-Source: `src/requirements.ts:26:1`
+Source: `src/requirements.ts:27:1`
 
 ### Members
 
@@ -2913,7 +2809,7 @@ Source: `src/requirements.ts:26:1`
 
 Kind: `type`
 Module: `src/requirements.ts`
-Source: `src/requirements.ts:34:1`
+Source: `src/requirements.ts:35:1`
 
 ### Members
 
@@ -2930,15 +2826,15 @@ Source: `src/types.ts:260:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                                                                    | Required | Description |
-| ----------- | -------- | ----------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| dataLoaders | property | `readonly import("/Users/a_rtiphishl_e/git/contracts/src/bindings").OperationScreenDataLoaderDefinition[] \| undefined` | no       |             |
-| description | property | `string \| undefined`                                                                                                   | no       |             |
-| id          | property | `string`                                                                                                                | yes      |             |
-| name        | property | `string`                                                                                                                | yes      |             |
-| requires    | property | `ScreenRequirements \| undefined`                                                                                       | no       |             |
-| root        | property | `UiNode`                                                                                                                | yes      |             |
-| title       | property | `string \| undefined`                                                                                                   | no       |             |
+| Name        | Kind     | Type                                                                                   | Required | Description |
+| ----------- | -------- | -------------------------------------------------------------------------------------- | -------- | ----------- |
+| dataLoaders | property | `readonly import("./src/bindings").OperationScreenDataLoaderDefinition[] \| undefined` | no       |             |
+| description | property | `string \| undefined`                                                                  | no       |             |
+| id          | property | `string`                                                                               | yes      |             |
+| name        | property | `string`                                                                               | yes      |             |
+| requires    | property | `ScreenRequirements \| undefined`                                                      | no       |             |
+| root        | property | `UiNode`                                                                               | yes      |             |
+| title       | property | `string \| undefined`                                                                  | no       |             |
 
 ## SearchAction
 

--- a/paradox/index.html
+++ b/paradox/index.html
@@ -202,31 +202,33 @@
               </button>
             </li>
             <li>
+              <button class="nav-button" type="button" data-target="src/appManifest/apis.ts">
+                src/appManifest/apis.ts
+                <small>10 functions</small>
+              </button>
+            </li>
+            <li>
               <button class="nav-button" type="button" data-target="src/appManifest/bindings.ts">
                 src/appManifest/bindings.ts
                 <small>14 functions</small>
               </button>
             </li>
             <li>
+              <button class="nav-button" type="button" data-target="src/appManifest/data.ts">
+                src/appManifest/data.ts
+                <small>16 functions</small>
+              </button>
+            </li>
+            <li>
               <button class="nav-button" type="button" data-target="src/appManifest/dataSources.ts">
                 src/appManifest/dataSources.ts
-                <small>17 functions</small>
+                <small>3 functions</small>
               </button>
             </li>
             <li>
               <button class="nav-button" type="button" data-target="src/appManifest/deploy.ts">
                 src/appManifest/deploy.ts
                 <small>10 functions</small>
-              </button>
-            </li>
-            <li>
-              <button
-                class="nav-button"
-                type="button"
-                data-target="src/appManifest/generatedApis.ts"
-              >
-                src/appManifest/generatedApis.ts
-                <small>12 functions</small>
               </button>
             </li>
             <li>
@@ -279,9 +281,9 @@
           <section class="panel">
             <h2>Package overview</h2>
             <div class="summary">
-              <div><strong>396</strong><span class="muted">public exports</span></div>
+              <div><strong>388</strong><span class="muted">public exports</span></div>
               <div><strong>0</strong><span class="muted">components</span></div>
-              <div><strong>35</strong><span class="muted">modules</span></div>
+              <div><strong>36</strong><span class="muted">modules</span></div>
               <div><strong>1</strong><span class="muted">entrypoints</span></div>
             </div>
             <h3>Entrypoints</h3>
@@ -294,14 +296,13 @@
             <h2>Modules</h2>
             <article
               class="item"
-              data-search="src/appManifest.ts src/appManifest/bindings.ts src/appManifest/dataSources.ts src/appManifest/deploy.ts src/appManifest/generatedApis.ts src/appManifest/infra.ts src/appManifest/media.ts src/appManifest/screens.ts src/appManifest/shared.ts src/types.ts AppManifestParseResult isAppManifest parseAppManifest"
+              data-search="src/appManifest.ts src/appManifest/bindings.ts src/appManifest/dataSources.ts src/appManifest/deploy.ts src/appManifest/infra.ts src/appManifest/media.ts src/appManifest/screens.ts src/appManifest/shared.ts src/types.ts AppManifestParseResult isAppManifest parseAppManifest"
             >
               <h3>src/appManifest.ts</h3>
               <p class="muted">Referenced module</p>
               <p>
                 <strong>Dependencies:</strong> <code>src/appManifest/bindings.ts</code>,
                 <code>src/appManifest/dataSources.ts</code>, <code>src/appManifest/deploy.ts</code>,
-                <code>src/appManifest/generatedApis.ts</code>,
                 <code>src/appManifest/infra.ts</code>, <code>src/appManifest/media.ts</code>,
                 <code>src/appManifest/screens.ts</code>, <code>src/appManifest/shared.ts</code>,
                 <code>src/types.ts</code>
@@ -310,6 +311,18 @@
                 <strong>Exports:</strong> <code>AppManifestParseResult</code>,
                 <code>isAppManifest</code>, <code>parseAppManifest</code>
               </p>
+            </article>
+            <article
+              class="item"
+              data-search="src/appManifest/apis.ts src/appManifest/data.ts src/appManifest/shared.ts src/data/index.ts isApiDefinitionList"
+            >
+              <h3>src/appManifest/apis.ts</h3>
+              <p class="muted">Referenced module</p>
+              <p>
+                <strong>Dependencies:</strong> <code>src/appManifest/data.ts</code>,
+                <code>src/appManifest/shared.ts</code>, <code>src/data/index.ts</code>
+              </p>
+              <p><strong>Exports:</strong> <code>isApiDefinitionList</code></p>
             </article>
             <article
               class="item"
@@ -326,11 +339,26 @@
             </article>
             <article
               class="item"
-              data-search="src/appManifest/dataSources.ts src/appManifest/shared.ts isDataSourceRegistry"
+              data-search="src/appManifest/data.ts src/appManifest/shared.ts isAdapterRef isCredentialRef isDataEndpointRegistry isDataSchemaRegistry"
+            >
+              <h3>src/appManifest/data.ts</h3>
+              <p class="muted">Referenced module</p>
+              <p><strong>Dependencies:</strong> <code>src/appManifest/shared.ts</code></p>
+              <p>
+                <strong>Exports:</strong> <code>isAdapterRef</code>, <code>isCredentialRef</code>,
+                <code>isDataEndpointRegistry</code>, <code>isDataSchemaRegistry</code>
+              </p>
+            </article>
+            <article
+              class="item"
+              data-search="src/appManifest/dataSources.ts src/appManifest/data.ts src/appManifest/shared.ts isDataSourceRegistry"
             >
               <h3>src/appManifest/dataSources.ts</h3>
               <p class="muted">Referenced module</p>
-              <p><strong>Dependencies:</strong> <code>src/appManifest/shared.ts</code></p>
+              <p>
+                <strong>Dependencies:</strong> <code>src/appManifest/data.ts</code>,
+                <code>src/appManifest/shared.ts</code>
+              </p>
               <p><strong>Exports:</strong> <code>isDataSourceRegistry</code></p>
             </article>
             <article
@@ -347,22 +375,14 @@
             </article>
             <article
               class="item"
-              data-search="src/appManifest/generatedApis.ts src/appManifest/shared.ts isGeneratedApiRegistry"
-            >
-              <h3>src/appManifest/generatedApis.ts</h3>
-              <p class="muted">Referenced module</p>
-              <p><strong>Dependencies:</strong> <code>src/appManifest/shared.ts</code></p>
-              <p><strong>Exports:</strong> <code>isGeneratedApiRegistry</code></p>
-            </article>
-            <article
-              class="item"
-              data-search="src/appManifest/infra.ts src/appManifest/shared.ts src/auth.ts src/types.ts isInfraManifest"
+              data-search="src/appManifest/infra.ts src/appManifest/apis.ts src/appManifest/shared.ts src/auth.ts src/types.ts isInfraManifest"
             >
               <h3>src/appManifest/infra.ts</h3>
               <p class="muted">Referenced module</p>
               <p>
-                <strong>Dependencies:</strong> <code>src/appManifest/shared.ts</code>,
-                <code>src/auth.ts</code>, <code>src/types.ts</code>
+                <strong>Dependencies:</strong> <code>src/appManifest/apis.ts</code>,
+                <code>src/appManifest/shared.ts</code>, <code>src/auth.ts</code>,
+                <code>src/types.ts</code>
               </p>
               <p><strong>Exports:</strong> <code>isInfraManifest</code></p>
             </article>
@@ -494,21 +514,21 @@
             </article>
             <article
               class="item"
-              data-search="src/data/apis.ts src/data/refs.ts src/data/values.ts src/db.ts GENERATED_API_CRUD_OPERATIONS GeneratedApiAuthRequirement GeneratedApiCrudOperation GeneratedApiDefinition GeneratedApiId GeneratedApiOperationPolicyRef GeneratedApiRegistry GeneratedApiResourceDefinition GeneratedApiResourceId GeneratedApiSeedRecord"
+              data-search="src/data/apis.ts src/data/endpoints.ts src/data/ids.ts src/data/refs.ts src/data/schemas.ts src/data/values.ts ApiBaseDefinition ApiDefinition ApiDefinitionList ApiOrigin ApiProtocol ExternalGraphQlApiDefinition ExternalRestApiDefinition GraphQlIntrospectionConfig InternalRestApiDefinition OpenApiDocumentRef"
             >
               <h3>src/data/apis.ts</h3>
               <p class="muted">Referenced module</p>
               <p>
-                <strong>Dependencies:</strong> <code>src/data/refs.ts</code>,
-                <code>src/data/values.ts</code>, <code>src/db.ts</code>
+                <strong>Dependencies:</strong> <code>src/data/endpoints.ts</code>,
+                <code>src/data/ids.ts</code>, <code>src/data/refs.ts</code>,
+                <code>src/data/schemas.ts</code>, <code>src/data/values.ts</code>
               </p>
               <p>
-                <strong>Exports:</strong> <code>GENERATED_API_CRUD_OPERATIONS</code>,
-                <code>GeneratedApiAuthRequirement</code>, <code>GeneratedApiCrudOperation</code>,
-                <code>GeneratedApiDefinition</code>, <code>GeneratedApiId</code>,
-                <code>GeneratedApiOperationPolicyRef</code>, <code>GeneratedApiRegistry</code>,
-                <code>GeneratedApiResourceDefinition</code>, <code>GeneratedApiResourceId</code>,
-                <code>GeneratedApiSeedRecord</code>
+                <strong>Exports:</strong> <code>ApiBaseDefinition</code>,
+                <code>ApiDefinition</code>, <code>ApiDefinitionList</code>, <code>ApiOrigin</code>,
+                <code>ApiProtocol</code>, <code>ExternalGraphQlApiDefinition</code>,
+                <code>ExternalRestApiDefinition</code>, <code>GraphQlIntrospectionConfig</code>,
+                <code>InternalRestApiDefinition</code>, <code>OpenApiDocumentRef</code>
               </p>
             </article>
             <article
@@ -542,53 +562,47 @@
             </article>
             <article
               class="item"
-              data-search="src/data/ids.ts AdapterId CredentialId DataSourceId EndpointId OperationId SchemaId"
+              data-search="src/data/ids.ts AdapterId ApiId CredentialId DataSourceId EndpointId OperationId SchemaId"
             >
               <h3>src/data/ids.ts</h3>
               <p class="muted">Referenced module</p>
               <p><strong>Dependencies:</strong> <span class="empty">None</span></p>
               <p>
-                <strong>Exports:</strong> <code>AdapterId</code>, <code>CredentialId</code>,
-                <code>DataSourceId</code>, <code>EndpointId</code>, <code>OperationId</code>,
-                <code>SchemaId</code>
+                <strong>Exports:</strong> <code>AdapterId</code>, <code>ApiId</code>,
+                <code>CredentialId</code>, <code>DataSourceId</code>, <code>EndpointId</code>,
+                <code>OperationId</code>, <code>SchemaId</code>
               </p>
             </article>
             <article
               class="item"
-              data-search="src/data/index.ts AdapterId AdapterKind AdapterRef ApiDataSourceBaseConfig ApiDataSourceConfig ApiOrigin ApiProtocol CredentialId CredentialKind CredentialRef DatabaseAdapterRef DatabaseDataSourceConfig DataContractValue DataDiagnosticCode DataDiagnosticSeverity DataEndpointConfig DataEndpointKind DataEndpointRegistry DataOperationConfig DataOperationIntent DataOperationMethod DataOperationPagination DataOperationParameter DataOperationParameterLocation DataOperationProtocol DataOperationRegistry DataOperationRequest DataOperationResponse DataPath DataSchema DataSchemaPrimitiveType DataSchemaProperty DataSchemaRef DataSchemaRegistry DataSchemaSlot DataSourceBaseConfig DataSourceConfig DataSourceDiagnostic DataSourceDiagnosticResult DataSourceId DataSourceKind DataSourceRegistry EndpointId ExternalGraphQlApiDataSourceConfig ExternalRestApiDataSourceConfig GENERATED_API_CRUD_OPERATIONS GeneratedApiAuthRequirement GeneratedApiCrudOperation GeneratedApiDefinition GeneratedApiId GeneratedApiOperationPolicyRef GeneratedApiRegistry GeneratedApiResourceDefinition GeneratedApiResourceId GeneratedApiSeedRecord GeneratedRestApiDataSourceConfig OpenApiDocumentRef OperationId SchemaId"
+              data-search="src/data/index.ts AdapterId AdapterKind AdapterRef ApiBaseDefinition ApiDefinition ApiDefinitionList ApiId ApiOrigin ApiProtocol CredentialId CredentialKind CredentialRef DatabaseAdapterRef DatabaseDataSourceConfig DataContractValue DataDiagnosticCode DataDiagnosticSeverity DataEndpointConfig DataEndpointKind DataEndpointRegistry DataOperationConfig DataOperationIntent DataOperationMethod DataOperationPagination DataOperationParameter DataOperationParameterLocation DataOperationProtocol DataOperationRegistry DataOperationRequest DataOperationResponse DataPath DataSchema DataSchemaPrimitiveType DataSchemaProperty DataSchemaRef DataSchemaRegistry DataSchemaSlot DataSourceConfig DataSourceDiagnostic DataSourceDiagnosticResult DataSourceId DataSourceKind DataSourceRegistry EndpointId ExternalGraphQlApiDefinition ExternalRestApiDefinition GraphQlIntrospectionConfig InternalRestApiDefinition OpenApiDocumentRef OperationId SchemaId"
             >
               <h3>src/data/index.ts</h3>
               <p class="muted">Referenced module</p>
               <p><strong>Dependencies:</strong> <span class="empty">None</span></p>
               <p>
                 <strong>Exports:</strong> <code>AdapterId</code>, <code>AdapterKind</code>,
-                <code>AdapterRef</code>, <code>ApiDataSourceBaseConfig</code>,
-                <code>ApiDataSourceConfig</code>, <code>ApiOrigin</code>, <code>ApiProtocol</code>,
-                <code>CredentialId</code>, <code>CredentialKind</code>, <code>CredentialRef</code>,
-                <code>DatabaseAdapterRef</code>, <code>DatabaseDataSourceConfig</code>,
-                <code>DataContractValue</code>, <code>DataDiagnosticCode</code>,
-                <code>DataDiagnosticSeverity</code>, <code>DataEndpointConfig</code>,
-                <code>DataEndpointKind</code>, <code>DataEndpointRegistry</code>,
-                <code>DataOperationConfig</code>, <code>DataOperationIntent</code>,
-                <code>DataOperationMethod</code>, <code>DataOperationPagination</code>,
-                <code>DataOperationParameter</code>, <code>DataOperationParameterLocation</code>,
-                <code>DataOperationProtocol</code>, <code>DataOperationRegistry</code>,
-                <code>DataOperationRequest</code>, <code>DataOperationResponse</code>,
-                <code>DataPath</code>, <code>DataSchema</code>,
+                <code>AdapterRef</code>, <code>ApiBaseDefinition</code>, <code>ApiDefinition</code>,
+                <code>ApiDefinitionList</code>, <code>ApiId</code>, <code>ApiOrigin</code>,
+                <code>ApiProtocol</code>, <code>CredentialId</code>, <code>CredentialKind</code>,
+                <code>CredentialRef</code>, <code>DatabaseAdapterRef</code>,
+                <code>DatabaseDataSourceConfig</code>, <code>DataContractValue</code>,
+                <code>DataDiagnosticCode</code>, <code>DataDiagnosticSeverity</code>,
+                <code>DataEndpointConfig</code>, <code>DataEndpointKind</code>,
+                <code>DataEndpointRegistry</code>, <code>DataOperationConfig</code>,
+                <code>DataOperationIntent</code>, <code>DataOperationMethod</code>,
+                <code>DataOperationPagination</code>, <code>DataOperationParameter</code>,
+                <code>DataOperationParameterLocation</code>, <code>DataOperationProtocol</code>,
+                <code>DataOperationRegistry</code>, <code>DataOperationRequest</code>,
+                <code>DataOperationResponse</code>, <code>DataPath</code>, <code>DataSchema</code>,
                 <code>DataSchemaPrimitiveType</code>, <code>DataSchemaProperty</code>,
                 <code>DataSchemaRef</code>, <code>DataSchemaRegistry</code>,
-                <code>DataSchemaSlot</code>, <code>DataSourceBaseConfig</code>,
-                <code>DataSourceConfig</code>, <code>DataSourceDiagnostic</code>,
-                <code>DataSourceDiagnosticResult</code>, <code>DataSourceId</code>,
-                <code>DataSourceKind</code>, <code>DataSourceRegistry</code>,
-                <code>EndpointId</code>, <code>ExternalGraphQlApiDataSourceConfig</code>,
-                <code>ExternalRestApiDataSourceConfig</code>,
-                <code>GENERATED_API_CRUD_OPERATIONS</code>,
-                <code>GeneratedApiAuthRequirement</code>, <code>GeneratedApiCrudOperation</code>,
-                <code>GeneratedApiDefinition</code>, <code>GeneratedApiId</code>,
-                <code>GeneratedApiOperationPolicyRef</code>, <code>GeneratedApiRegistry</code>,
-                <code>GeneratedApiResourceDefinition</code>, <code>GeneratedApiResourceId</code>,
-                <code>GeneratedApiSeedRecord</code>, <code>GeneratedRestApiDataSourceConfig</code>,
+                <code>DataSchemaSlot</code>, <code>DataSourceConfig</code>,
+                <code>DataSourceDiagnostic</code>, <code>DataSourceDiagnosticResult</code>,
+                <code>DataSourceId</code>, <code>DataSourceKind</code>,
+                <code>DataSourceRegistry</code>, <code>EndpointId</code>,
+                <code>ExternalGraphQlApiDefinition</code>, <code>ExternalRestApiDefinition</code>,
+                <code>GraphQlIntrospectionConfig</code>, <code>InternalRestApiDefinition</code>,
                 <code>OpenApiDocumentRef</code>, <code>OperationId</code>, <code>SchemaId</code>
               </p>
             </article>
@@ -647,7 +661,7 @@
             </article>
             <article
               class="item"
-              data-search="src/data/sources.ts src/data/endpoints.ts src/data/ids.ts src/data/refs.ts src/data/schemas.ts src/data/values.ts ApiDataSourceBaseConfig ApiDataSourceConfig ApiOrigin ApiProtocol DatabaseDataSourceConfig DataSourceBaseConfig DataSourceConfig DataSourceKind DataSourceRegistry ExternalGraphQlApiDataSourceConfig ExternalRestApiDataSourceConfig GeneratedRestApiDataSourceConfig OpenApiDocumentRef"
+              data-search="src/data/sources.ts src/data/endpoints.ts src/data/ids.ts src/data/refs.ts src/data/schemas.ts src/data/values.ts DatabaseDataSourceConfig DataSourceConfig DataSourceKind DataSourceRegistry"
             >
               <h3>src/data/sources.ts</h3>
               <p class="muted">Referenced module</p>
@@ -657,13 +671,9 @@
                 <code>src/data/schemas.ts</code>, <code>src/data/values.ts</code>
               </p>
               <p>
-                <strong>Exports:</strong> <code>ApiDataSourceBaseConfig</code>,
-                <code>ApiDataSourceConfig</code>, <code>ApiOrigin</code>, <code>ApiProtocol</code>,
-                <code>DatabaseDataSourceConfig</code>, <code>DataSourceBaseConfig</code>,
+                <strong>Exports:</strong> <code>DatabaseDataSourceConfig</code>,
                 <code>DataSourceConfig</code>, <code>DataSourceKind</code>,
-                <code>DataSourceRegistry</code>, <code>ExternalGraphQlApiDataSourceConfig</code>,
-                <code>ExternalRestApiDataSourceConfig</code>,
-                <code>GeneratedRestApiDataSourceConfig</code>, <code>OpenApiDocumentRef</code>
+                <code>DataSourceRegistry</code>
               </p>
             </article>
             <article class="item" data-search="src/data/values.ts DataContractValue DataPath">
@@ -714,7 +724,7 @@
             </article>
             <article
               class="item"
-              data-search="src/index.ts Action ActionType AdapterId AdapterKind AdapterRef AlertAction AnkhCapabilityId AnkhCommandCategory AnkhCommandDescriptor AnkhCommandProviderManifest ANKHORAGE_CAPABILITY_NAMES ANKHORAGE_PERMISSION_NAMES AnkhorageCapabilityName AnkhoragePermissionName AnkhPackageMetadata AnkhProviderReference ApiDataSourceBaseConfig ApiDataSourceConfig ApiOrigin ApiProtocol APP_CATEGORIES APP_DEPLOY_ENVIRONMENT_IDS APP_DEPLOY_TARGET_IDS AppCategory AppDeployAndroidTargetConfig AppDeployEnvironmentId AppDeployIosTargetConfig AppDeployManifest AppDeployProviderSelection AppDeployTargetId AppDeployTargets AppDeployWebTargetConfig AppManifest AppManifestParseResult AppSettings AUTH_IDENTIFIER_KINDS AUTH_OAUTH_CANCELLATION_REASONS AUTH_OAUTH_ERROR_CODES AUTH_OAUTH_ERROR_STAGES AUTH_OAUTH_PROVIDER_IDS AUTH_OAUTH_SETUP_CALLBACK_ROLES AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS AUTH_OAUTH_TRANSPORT_ERROR_CODES AUTH_OAUTH_TRANSPORT_IDS AUTH_PROFILE_CREATE_STRATEGIES AUTH_PROFILE_FIELDS AUTH_PROFILE_PRIMARY_KEY_STRATEGIES AUTH_PROFILE_UPDATE_STRATEGIES AUTH_PROVIDERS AUTH_SCOPES AUTH_SIGN_IN_IDENTIFIERS AUTH_SIGN_UP_FIELDS AUTH_SIGN_UP_POLICIES AuthAdapter AuthAdapterCapabilities AuthAdapterError AuthFlowConfig AuthIdentifier AuthIdentifierKind AuthOAuthAdapter AuthOAuthAuthorizationRequest AuthOAuthAuthorizationResponse AuthOAuthCancellationReason AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthConfig AuthOAuthError AuthOAuthErrorCode AuthOAuthErrorStage AuthOAuthProviderConfig AuthOAuthProviderId AuthOAuthSetupCallbackRequirement AuthOAuthSetupCallbackRole AuthOAuthSetupCapabilities AuthOAuthSetupFieldPersistence AuthOAuthSetupFieldRequirement AuthOAuthSetupFieldSensitivity AuthOAuthSetupPlan AuthOAuthSetupRequirement AuthOAuthStartResult AuthOAuthTransportCancellationReason AuthOAuthTransportError AuthOAuthTransportErrorCode AuthOAuthTransportId AuthProfileCreateStrategy AuthProfileField AuthProfilePrimaryKeyStrategy AuthProfileSpec AuthProfileUpdateStrategy AuthProvider AuthProviderConfig AuthResult AuthScope AuthSession AuthSignInConfig AuthSignInIdentifier AuthSignInSpec AuthSignUpConfig AuthSignUpField AuthSignUpPolicy AuthSignUpSpec AuthSpec AuthUser AUTHZ_ENGINES AUTHZ_KINDS AuthzEngine AuthzKind AuthzSpec BindingCondition BindingConditionOperator BindingDataPath BindingFallback BindingInputMap BindingInputValue BindingLifecycleBehavior BindingLifecycleState BindingOperationRef BindingValue BindingValueExpression BindingValueSource BindingValueTransform ButtonPressEventDto CollectionItemPressEventDto CollectionItemPressPayload CompleteOAuthAuthorizationInput ComponentDataBinding ComponentDataBindingRegistry ComponentEventDto ComponentEventDtoKind ComponentEventPayloadValue ComponentInstanceId ComponentRequirements ComponentTypeId ConsoleAction CredentialId CredentialKind CredentialRef DATABASE_PROVIDERS DATABASE_TIERS DatabaseAdapterRef DatabaseDataSourceConfig DatabaseProvider DatabaseSpec DatabaseTier DataContractValue DataDiagnosticCode DataDiagnosticSeverity DataEndpointConfig DataEndpointKind DataEndpointRegistry DataOperationConfig DataOperationIntent DataOperationMethod DataOperationPagination DataOperationParameter DataOperationParameterLocation DataOperationProtocol DataOperationRegistry DataOperationRequest DataOperationResponse DataPath DataSchema DataSchemaPrimitiveType DataSchemaProperty DataSchemaRef DataSchemaRegistry DataSchemaSlot DataSourceBaseConfig DataSourceConfig DataSourceDiagnostic DataSourceDiagnosticResult DataSourceId DataSourceKind DataSourceRegistry DbAdapter DbAdapterCapabilities DbAdapterError DbAdminAdapter DbAdminAdapterCapabilities DbAdminResult DbChangeEvent DbChangeKind DbChangeListener DbCollectionDefinition DbCollectionReference DbCollectionSubscriptionInput DbDeleteInput DbFieldDefinition DbFieldType DbFilter DbFilterOperator DbFindByIdInput DbInsertInput DbPage DbRealtimeAdapter DbRecord DbRecordSubscriptionInput DbResult DbSelectInput DbSort DbSortDirection DbSubscription DbSuccess DbTableInput DbUpdateInput DEFAULT_AUTH_FLOW DEPLOYMENT_TARGETS DeploymentSpec DeploymentTarget EndpointId EventBinding EventBindingTarget ExternalGraphQlApiDataSourceConfig ExternalRestApiDataSourceConfig FilterAction findForbiddenInlineSecretFields FORBIDDEN_INLINE_SECRET_FIELDS FormSubmitEventDto FormSubmitValues GENERATED_API_CRUD_OPERATIONS GeneratedApiAuthRequirement GeneratedApiCrudOperation GeneratedApiDefinition GeneratedApiId GeneratedApiOperationPolicyRef GeneratedApiRegistry GeneratedApiResourceDefinition GeneratedApiResourceId GeneratedApiSeedRecord GeneratedRestApiDataSourceConfig IconSpec ImageAssetSource ImageMetadata InfraManifest InfraSecretStoreSpec isAppDeployManifest isAppManifest isMediaAssetReference KnownAuthOAuthProviderId KnownAuthOAuthTransportId KnownAuthProfileField KnownAuthProvider KnownAuthSignUpField KnownComponentEventDto KnownDatabaseProvider KnownDeploymentTarget KnownSecretStoreProvider KnownStateProvider ManifestValue MEDIA_ASSET_KINDS MediaAsset MediaAssetKind MediaAssetMetadata MediaAssetReference MediaAssetRegistry MediaAssetSource MediaBundledSource MediaManifest MediaStorageAdapter MediaStorageSource MediaUrlSource NavigateAction NAVIGATOR_TYPES NavigatorSpec NavigatorType NetworkingSpec normalizeSecretRef normalizeSecretScope OpenApiDocumentRef OperationId OperationScreenDataLoaderDefinition parseAppManifest PasswordResetInput PropBinding resolveAuthFlow RouteDefinition RuntimeCallback RuntimeCallbackArgs RuntimeCallbackMap RuntimeNodePropsResolver RuntimeResolveNodePropsArgs SchemaId ScreenCapabilityRequirement ScreenDataLoaderDefinition ScreenPermissionRequirement ScreenRequirements ScreenSpec SearchAction SECRET_STORE_ERROR_CODES SECRET_STORE_PROVIDERS SecretCreateInput SecretGetMetadataInput SecretListInput SecretMetadata SecretPayload SecretRef SecretRemoveInput SecretReplaceInput SecretResolveInput SecretScope SecretStoreAdapter SecretStoreError SecretStoreErrorCode SecretStoreOkResult SecretStoreProvider SecretStoreResult SetLanguageAction SignInInput SignOutInput SignUpInput SplashScreenAssetSpec SplashScreenModeSpec SplashScreenResizeMode SplashScreenSpec StartOAuthAuthorizationInput STATE_PERSISTENCE_MODES STATE_PROVIDERS StateAdapter StateAdapterCapabilities StateAdapterError StateListener StatePath StatePersistenceMode StatePrimitive StateProvider StateResult StateSnapshot StateSpec StateSubscription StateSuccess StateValue STORAGE_PROVIDERS StorageAdapter StorageAdapterError StorageAssetReference StorageImageAssetSource StorageListAdapter StorageListInput StorageListResult StorageObjectMetadata StorageOkResult StorageProvider StoragePublicUrlInput StoragePublicUrlResult StorageRemoveInput StorageResolveAdapter StorageResolvedAccess StorageResolvedAsset StorageResolveInput StorageResolveResult StorageResult StorageSpec StorageUploadInput StorageUploadResult ThemeConfig ThemeGlobalTokenOverrides ThemeModeConfig ThemeNumericTokenOverrides ThemeRecipeFieldOverrides ThemeRecipeOverrides ThemeRecipeOverrideValue ThemeStringTokenOverrides ThemeTypographyHeadingOverrides ThemeTypographyTokenOverrides ToggleDarkModeAction UiBindableEventMeta UiBindableEventPayloadMeta UiBindablePropMeta UiBindableValueFieldMeta UiBindableValueMeta UiBindableValueType UiComponentBindingMeta UiComponentBlueprint UiComponentBlueprintIcon UiComponentCategory UiComponentEventMeta UiComponentEventPayloadFieldMeta UiComponentEventPayloadFieldType UiComponentEventPayloadKind UiComponentI18nFieldMeta UiComponentI18nMeta UiComponentMeta UiComponentMetaRegistry UiComponentPackageManifest UiComponentPropArrayItemSchema UiComponentPropSchema UiComponentPropType UiComponentPropValue UiComponentSlotMeta UiNode UiNodeRepeatSpec UrlImageAssetSource validateSecretPayload VerifyOtpInput"
+              data-search="src/index.ts Action ActionType AdapterId AdapterKind AdapterRef AlertAction AnkhCapabilityId AnkhCommandCategory AnkhCommandDescriptor AnkhCommandProviderManifest ANKHORAGE_CAPABILITY_NAMES ANKHORAGE_PERMISSION_NAMES AnkhorageCapabilityName AnkhoragePermissionName AnkhPackageMetadata AnkhProviderReference ApiBaseDefinition ApiDefinition ApiDefinitionList ApiId ApiOrigin ApiProtocol APP_CATEGORIES APP_DEPLOY_ENVIRONMENT_IDS APP_DEPLOY_TARGET_IDS AppCategory AppDeployAndroidTargetConfig AppDeployEnvironmentId AppDeployIosTargetConfig AppDeployManifest AppDeployProviderSelection AppDeployTargetId AppDeployTargets AppDeployWebTargetConfig AppManifest AppManifestParseResult AppSettings AUTH_IDENTIFIER_KINDS AUTH_OAUTH_CANCELLATION_REASONS AUTH_OAUTH_ERROR_CODES AUTH_OAUTH_ERROR_STAGES AUTH_OAUTH_PROVIDER_IDS AUTH_OAUTH_SETUP_CALLBACK_ROLES AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS AUTH_OAUTH_TRANSPORT_ERROR_CODES AUTH_OAUTH_TRANSPORT_IDS AUTH_PROFILE_CREATE_STRATEGIES AUTH_PROFILE_FIELDS AUTH_PROFILE_PRIMARY_KEY_STRATEGIES AUTH_PROFILE_UPDATE_STRATEGIES AUTH_PROVIDERS AUTH_SCOPES AUTH_SIGN_IN_IDENTIFIERS AUTH_SIGN_UP_FIELDS AUTH_SIGN_UP_POLICIES AuthAdapter AuthAdapterCapabilities AuthAdapterError AuthFlowConfig AuthIdentifier AuthIdentifierKind AuthOAuthAdapter AuthOAuthAuthorizationRequest AuthOAuthAuthorizationResponse AuthOAuthCancellationReason AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthConfig AuthOAuthError AuthOAuthErrorCode AuthOAuthErrorStage AuthOAuthProviderConfig AuthOAuthProviderId AuthOAuthSetupCallbackRequirement AuthOAuthSetupCallbackRole AuthOAuthSetupCapabilities AuthOAuthSetupFieldPersistence AuthOAuthSetupFieldRequirement AuthOAuthSetupFieldSensitivity AuthOAuthSetupPlan AuthOAuthSetupRequirement AuthOAuthStartResult AuthOAuthTransportCancellationReason AuthOAuthTransportError AuthOAuthTransportErrorCode AuthOAuthTransportId AuthProfileCreateStrategy AuthProfileField AuthProfilePrimaryKeyStrategy AuthProfileSpec AuthProfileUpdateStrategy AuthProvider AuthProviderConfig AuthResult AuthScope AuthSession AuthSignInConfig AuthSignInIdentifier AuthSignInSpec AuthSignUpConfig AuthSignUpField AuthSignUpPolicy AuthSignUpSpec AuthSpec AuthUser AUTHZ_ENGINES AUTHZ_KINDS AuthzEngine AuthzKind AuthzSpec BindingCondition BindingConditionOperator BindingDataPath BindingFallback BindingInputMap BindingInputValue BindingLifecycleBehavior BindingLifecycleState BindingOperationRef BindingValue BindingValueExpression BindingValueSource BindingValueTransform ButtonPressEventDto CollectionItemPressEventDto CollectionItemPressPayload CompleteOAuthAuthorizationInput ComponentDataBinding ComponentDataBindingRegistry ComponentEventDto ComponentEventDtoKind ComponentEventPayloadValue ComponentInstanceId ComponentRequirements ComponentTypeId ConsoleAction CredentialId CredentialKind CredentialRef DATABASE_PROVIDERS DATABASE_TIERS DatabaseAdapterRef DatabaseDataSourceConfig DatabaseProvider DatabaseSpec DatabaseTier DataContractValue DataDiagnosticCode DataDiagnosticSeverity DataEndpointConfig DataEndpointKind DataEndpointRegistry DataOperationConfig DataOperationIntent DataOperationMethod DataOperationPagination DataOperationParameter DataOperationParameterLocation DataOperationProtocol DataOperationRegistry DataOperationRequest DataOperationResponse DataPath DataSchema DataSchemaPrimitiveType DataSchemaProperty DataSchemaRef DataSchemaRegistry DataSchemaSlot DataSourceConfig DataSourceDiagnostic DataSourceDiagnosticResult DataSourceId DataSourceKind DataSourceRegistry DbAdapter DbAdapterCapabilities DbAdapterError DbAdminAdapter DbAdminAdapterCapabilities DbAdminResult DbChangeEvent DbChangeKind DbChangeListener DbCollectionDefinition DbCollectionReference DbCollectionSubscriptionInput DbDeleteInput DbFieldDefinition DbFieldType DbFilter DbFilterOperator DbFindByIdInput DbInsertInput DbPage DbRealtimeAdapter DbRecord DbRecordSubscriptionInput DbResult DbSelectInput DbSort DbSortDirection DbSubscription DbSuccess DbTableInput DbUpdateInput DEFAULT_AUTH_FLOW DEPLOYMENT_TARGETS DeploymentSpec DeploymentTarget EndpointId EventBinding EventBindingTarget ExternalGraphQlApiDefinition ExternalRestApiDefinition FilterAction findForbiddenInlineSecretFields FORBIDDEN_INLINE_SECRET_FIELDS FormSubmitEventDto FormSubmitValues GraphQlIntrospectionConfig IconSpec ImageAssetSource ImageMetadata InfraManifest InfraSecretStoreSpec InternalRestApiDefinition isAppDeployManifest isAppManifest isMediaAssetReference KnownAuthOAuthProviderId KnownAuthOAuthTransportId KnownAuthProfileField KnownAuthProvider KnownAuthSignUpField KnownComponentEventDto KnownDatabaseProvider KnownDeploymentTarget KnownSecretStoreProvider KnownStateProvider ManifestValue MEDIA_ASSET_KINDS MediaAsset MediaAssetKind MediaAssetMetadata MediaAssetReference MediaAssetRegistry MediaAssetSource MediaBundledSource MediaManifest MediaStorageAdapter MediaStorageSource MediaUrlSource NavigateAction NAVIGATOR_TYPES NavigatorSpec NavigatorType NetworkingSpec normalizeSecretRef normalizeSecretScope OpenApiDocumentRef OperationId OperationScreenDataLoaderDefinition parseAppManifest PasswordResetInput PropBinding resolveAuthFlow RouteDefinition RuntimeCallback RuntimeCallbackArgs RuntimeCallbackMap RuntimeNodePropsResolver RuntimeResolveNodePropsArgs SchemaId ScreenCapabilityRequirement ScreenDataLoaderDefinition ScreenPermissionRequirement ScreenRequirements ScreenSpec SearchAction SECRET_STORE_ERROR_CODES SECRET_STORE_PROVIDERS SecretCreateInput SecretGetMetadataInput SecretListInput SecretMetadata SecretPayload SecretRef SecretRemoveInput SecretReplaceInput SecretResolveInput SecretScope SecretStoreAdapter SecretStoreError SecretStoreErrorCode SecretStoreOkResult SecretStoreProvider SecretStoreResult SetLanguageAction SignInInput SignOutInput SignUpInput SplashScreenAssetSpec SplashScreenModeSpec SplashScreenResizeMode SplashScreenSpec StartOAuthAuthorizationInput STATE_PERSISTENCE_MODES STATE_PROVIDERS StateAdapter StateAdapterCapabilities StateAdapterError StateListener StatePath StatePersistenceMode StatePrimitive StateProvider StateResult StateSnapshot StateSpec StateSubscription StateSuccess StateValue STORAGE_PROVIDERS StorageAdapter StorageAdapterError StorageAssetReference StorageImageAssetSource StorageListAdapter StorageListInput StorageListResult StorageObjectMetadata StorageOkResult StorageProvider StoragePublicUrlInput StoragePublicUrlResult StorageRemoveInput StorageResolveAdapter StorageResolvedAccess StorageResolvedAsset StorageResolveInput StorageResolveResult StorageResult StorageSpec StorageUploadInput StorageUploadResult ThemeConfig ThemeGlobalTokenOverrides ThemeModeConfig ThemeNumericTokenOverrides ThemeRecipeFieldOverrides ThemeRecipeOverrides ThemeRecipeOverrideValue ThemeStringTokenOverrides ThemeTypographyHeadingOverrides ThemeTypographyTokenOverrides ToggleDarkModeAction UiBindableEventMeta UiBindableEventPayloadMeta UiBindablePropMeta UiBindableValueFieldMeta UiBindableValueMeta UiBindableValueType UiComponentBindingMeta UiComponentBlueprint UiComponentBlueprintIcon UiComponentCategory UiComponentEventMeta UiComponentEventPayloadFieldMeta UiComponentEventPayloadFieldType UiComponentEventPayloadKind UiComponentI18nFieldMeta UiComponentI18nMeta UiComponentMeta UiComponentMetaRegistry UiComponentPackageManifest UiComponentPropArrayItemSchema UiComponentPropSchema UiComponentPropType UiComponentPropValue UiComponentSlotMeta UiNode UiNodeRepeatSpec UrlImageAssetSource validateSecretPayload VerifyOtpInput"
             >
               <h3>src/index.ts</h3>
               <p class="muted">Configured entrypoint</p>
@@ -727,19 +737,19 @@
                 <code>AnkhCommandProviderManifest</code>, <code>ANKHORAGE_CAPABILITY_NAMES</code>,
                 <code>ANKHORAGE_PERMISSION_NAMES</code>, <code>AnkhorageCapabilityName</code>,
                 <code>AnkhoragePermissionName</code>, <code>AnkhPackageMetadata</code>,
-                <code>AnkhProviderReference</code>, <code>ApiDataSourceBaseConfig</code>,
-                <code>ApiDataSourceConfig</code>, <code>ApiOrigin</code>, <code>ApiProtocol</code>,
-                <code>APP_CATEGORIES</code>, <code>APP_DEPLOY_ENVIRONMENT_IDS</code>,
-                <code>APP_DEPLOY_TARGET_IDS</code>, <code>AppCategory</code>,
-                <code>AppDeployAndroidTargetConfig</code>, <code>AppDeployEnvironmentId</code>,
-                <code>AppDeployIosTargetConfig</code>, <code>AppDeployManifest</code>,
-                <code>AppDeployProviderSelection</code>, <code>AppDeployTargetId</code>,
-                <code>AppDeployTargets</code>, <code>AppDeployWebTargetConfig</code>,
-                <code>AppManifest</code>, <code>AppManifestParseResult</code>,
-                <code>AppSettings</code>, <code>AUTH_IDENTIFIER_KINDS</code>,
-                <code>AUTH_OAUTH_CANCELLATION_REASONS</code>, <code>AUTH_OAUTH_ERROR_CODES</code>,
-                <code>AUTH_OAUTH_ERROR_STAGES</code>, <code>AUTH_OAUTH_PROVIDER_IDS</code>,
-                <code>AUTH_OAUTH_SETUP_CALLBACK_ROLES</code>,
+                <code>AnkhProviderReference</code>, <code>ApiBaseDefinition</code>,
+                <code>ApiDefinition</code>, <code>ApiDefinitionList</code>, <code>ApiId</code>,
+                <code>ApiOrigin</code>, <code>ApiProtocol</code>, <code>APP_CATEGORIES</code>,
+                <code>APP_DEPLOY_ENVIRONMENT_IDS</code>, <code>APP_DEPLOY_TARGET_IDS</code>,
+                <code>AppCategory</code>, <code>AppDeployAndroidTargetConfig</code>,
+                <code>AppDeployEnvironmentId</code>, <code>AppDeployIosTargetConfig</code>,
+                <code>AppDeployManifest</code>, <code>AppDeployProviderSelection</code>,
+                <code>AppDeployTargetId</code>, <code>AppDeployTargets</code>,
+                <code>AppDeployWebTargetConfig</code>, <code>AppManifest</code>,
+                <code>AppManifestParseResult</code>, <code>AppSettings</code>,
+                <code>AUTH_IDENTIFIER_KINDS</code>, <code>AUTH_OAUTH_CANCELLATION_REASONS</code>,
+                <code>AUTH_OAUTH_ERROR_CODES</code>, <code>AUTH_OAUTH_ERROR_STAGES</code>,
+                <code>AUTH_OAUTH_PROVIDER_IDS</code>, <code>AUTH_OAUTH_SETUP_CALLBACK_ROLES</code>,
                 <code>AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS</code>,
                 <code>AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES</code>,
                 <code>AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS</code>,
@@ -804,14 +814,13 @@
                 <code>DataPath</code>, <code>DataSchema</code>,
                 <code>DataSchemaPrimitiveType</code>, <code>DataSchemaProperty</code>,
                 <code>DataSchemaRef</code>, <code>DataSchemaRegistry</code>,
-                <code>DataSchemaSlot</code>, <code>DataSourceBaseConfig</code>,
-                <code>DataSourceConfig</code>, <code>DataSourceDiagnostic</code>,
-                <code>DataSourceDiagnosticResult</code>, <code>DataSourceId</code>,
-                <code>DataSourceKind</code>, <code>DataSourceRegistry</code>,
-                <code>DbAdapter</code>, <code>DbAdapterCapabilities</code>,
-                <code>DbAdapterError</code>, <code>DbAdminAdapter</code>,
-                <code>DbAdminAdapterCapabilities</code>, <code>DbAdminResult</code>,
-                <code>DbChangeEvent</code>, <code>DbChangeKind</code>,
+                <code>DataSchemaSlot</code>, <code>DataSourceConfig</code>,
+                <code>DataSourceDiagnostic</code>, <code>DataSourceDiagnosticResult</code>,
+                <code>DataSourceId</code>, <code>DataSourceKind</code>,
+                <code>DataSourceRegistry</code>, <code>DbAdapter</code>,
+                <code>DbAdapterCapabilities</code>, <code>DbAdapterError</code>,
+                <code>DbAdminAdapter</code>, <code>DbAdminAdapterCapabilities</code>,
+                <code>DbAdminResult</code>, <code>DbChangeEvent</code>, <code>DbChangeKind</code>,
                 <code>DbChangeListener</code>, <code>DbCollectionDefinition</code>,
                 <code>DbCollectionReference</code>, <code>DbCollectionSubscriptionInput</code>,
                 <code>DbDeleteInput</code>, <code>DbFieldDefinition</code>,
@@ -824,26 +833,21 @@
                 <code>DbUpdateInput</code>, <code>DEFAULT_AUTH_FLOW</code>,
                 <code>DEPLOYMENT_TARGETS</code>, <code>DeploymentSpec</code>,
                 <code>DeploymentTarget</code>, <code>EndpointId</code>, <code>EventBinding</code>,
-                <code>EventBindingTarget</code>, <code>ExternalGraphQlApiDataSourceConfig</code>,
-                <code>ExternalRestApiDataSourceConfig</code>, <code>FilterAction</code>,
+                <code>EventBindingTarget</code>, <code>ExternalGraphQlApiDefinition</code>,
+                <code>ExternalRestApiDefinition</code>, <code>FilterAction</code>,
                 <code>findForbiddenInlineSecretFields</code>,
                 <code>FORBIDDEN_INLINE_SECRET_FIELDS</code>, <code>FormSubmitEventDto</code>,
-                <code>FormSubmitValues</code>, <code>GENERATED_API_CRUD_OPERATIONS</code>,
-                <code>GeneratedApiAuthRequirement</code>, <code>GeneratedApiCrudOperation</code>,
-                <code>GeneratedApiDefinition</code>, <code>GeneratedApiId</code>,
-                <code>GeneratedApiOperationPolicyRef</code>, <code>GeneratedApiRegistry</code>,
-                <code>GeneratedApiResourceDefinition</code>, <code>GeneratedApiResourceId</code>,
-                <code>GeneratedApiSeedRecord</code>, <code>GeneratedRestApiDataSourceConfig</code>,
+                <code>FormSubmitValues</code>, <code>GraphQlIntrospectionConfig</code>,
                 <code>IconSpec</code>, <code>ImageAssetSource</code>, <code>ImageMetadata</code>,
                 <code>InfraManifest</code>, <code>InfraSecretStoreSpec</code>,
-                <code>isAppDeployManifest</code>, <code>isAppManifest</code>,
-                <code>isMediaAssetReference</code>, <code>KnownAuthOAuthProviderId</code>,
-                <code>KnownAuthOAuthTransportId</code>, <code>KnownAuthProfileField</code>,
-                <code>KnownAuthProvider</code>, <code>KnownAuthSignUpField</code>,
-                <code>KnownComponentEventDto</code>, <code>KnownDatabaseProvider</code>,
-                <code>KnownDeploymentTarget</code>, <code>KnownSecretStoreProvider</code>,
-                <code>KnownStateProvider</code>, <code>ManifestValue</code>,
-                <code>MEDIA_ASSET_KINDS</code>, <code>MediaAsset</code>,
+                <code>InternalRestApiDefinition</code>, <code>isAppDeployManifest</code>,
+                <code>isAppManifest</code>, <code>isMediaAssetReference</code>,
+                <code>KnownAuthOAuthProviderId</code>, <code>KnownAuthOAuthTransportId</code>,
+                <code>KnownAuthProfileField</code>, <code>KnownAuthProvider</code>,
+                <code>KnownAuthSignUpField</code>, <code>KnownComponentEventDto</code>,
+                <code>KnownDatabaseProvider</code>, <code>KnownDeploymentTarget</code>,
+                <code>KnownSecretStoreProvider</code>, <code>KnownStateProvider</code>,
+                <code>ManifestValue</code>, <code>MEDIA_ASSET_KINDS</code>, <code>MediaAsset</code>,
                 <code>MediaAssetKind</code>, <code>MediaAssetMetadata</code>,
                 <code>MediaAssetReference</code>, <code>MediaAssetRegistry</code>,
                 <code>MediaAssetSource</code>, <code>MediaBundledSource</code>,
@@ -1137,7 +1141,7 @@
                 data-search="AppManifestParseResult unknown src/appManifest.ts "
               >
                 <h4>AppManifestParseResult</h4>
-                <p class="muted">unknown • <code>src/appManifest.ts:17:1</code></p>
+                <p class="muted">unknown • <code>src/appManifest.ts:16:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1148,7 +1152,7 @@
                 data-search="isAppManifest function src/appManifest.ts  (value: unknown) =&gt; boolean"
               >
                 <h4>isAppManifest</h4>
-                <p class="muted">function • <code>src/appManifest.ts:52:1</code></p>
+                <p class="muted">function • <code>src/appManifest.ts:50:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1182,7 +1186,7 @@
                 data-search="parseAppManifest function src/appManifest.ts  AppManifestParseResult (value: unknown) =&gt; AppManifestParseResult"
               >
                 <h4>parseAppManifest</h4>
-                <p class="muted">function • <code>src/appManifest.ts:45:1</code></p>
+                <p class="muted">function • <code>src/appManifest.ts:43:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -3601,7 +3605,7 @@
                   </thead>
                   <tbody>
                     <tr>
-                      <td><code>dataSourceId</code></td>
+                      <td><code>apiId</code></td>
                       <td>property</td>
                       <td><code>string</code></td>
                       <td>yes</td>
@@ -4230,28 +4234,22 @@
               <h3>src/data/apis.ts</h3>
               <article
                 class="item"
-                id="symbol-generated-api-crud-operations"
-                data-search="GENERATED_API_CRUD_OPERATIONS value src/data/apis.ts "
+                id="symbol-apibasedefinition"
+                data-search="ApiBaseDefinition type src/data/apis.ts  ApiOrigin ApiProtocol CredentialRef DataContractValue DataEndpointConfig DataSchema"
               >
-                <h4>GENERATED_API_CRUD_OPERATIONS</h4>
-                <p class="muted">value • <code>src/data/apis.ts:5:14</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
-                id="symbol-generatedapiauthrequirement"
-                data-search="GeneratedApiAuthRequirement type src/data/apis.ts  DataContractValue"
-              >
-                <h4>GeneratedApiAuthRequirement</h4>
-                <p class="muted">type • <code>src/data/apis.ts:18:1</code></p>
+                <h4>ApiBaseDefinition</h4>
+                <p class="muted">type • <code>src/data/apis.ts:10:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
                   <strong>Related symbols:</strong>
                   <ul class="chips">
+                    <li class="chip">ApiOrigin</li>
+                    <li class="chip">ApiProtocol</li>
+                    <li class="chip">CredentialRef</li>
                     <li class="chip">DataContractValue</li>
+                    <li class="chip">DataEndpointConfig</li>
+                    <li class="chip">DataSchema</li>
                   </ul>
                 </div>
 
@@ -4267,103 +4265,10 @@
                   </thead>
                   <tbody>
                     <tr>
-                      <td><code>metadata</code></td>
+                      <td><code>credential</code></td>
                       <td>property</td>
-                      <td><code>DataContractValue | undefined</code></td>
+                      <td><code>CredentialRef | undefined</code></td>
                       <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>permissions</code></td>
-                      <td>property</td>
-                      <td><code>readonly string[] | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>policy</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>required</code></td>
-                      <td>property</td>
-                      <td><code>boolean | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>roles</code></td>
-                      <td>property</td>
-                      <td><code>readonly string[] | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </article>
-              <article
-                class="item"
-                id="symbol-generatedapicrudoperation"
-                data-search="GeneratedApiCrudOperation unknown src/data/apis.ts "
-              >
-                <h4>GeneratedApiCrudOperation</h4>
-                <p class="muted">unknown • <code>src/data/apis.ts:12:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
-                id="symbol-generatedapidefinition"
-                data-search="GeneratedApiDefinition type src/data/apis.ts  DatabaseAdapterRef DataContractValue GeneratedApiAuthRequirement GeneratedApiResourceDefinition"
-              >
-                <h4>GeneratedApiDefinition</h4>
-                <p class="muted">type • <code>src/data/apis.ts:50:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div>
-                  <strong>Related symbols:</strong>
-                  <ul class="chips">
-                    <li class="chip">DatabaseAdapterRef</li>
-                    <li class="chip">DataContractValue</li>
-                    <li class="chip">GeneratedApiAuthRequirement</li>
-                    <li class="chip">GeneratedApiResourceDefinition</li>
-                  </ul>
-                </div>
-
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Member</th>
-                      <th>Kind</th>
-                      <th>Type</th>
-                      <th>Required</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>auth</code></td>
-                      <td>property</td>
-                      <td><code>GeneratedApiAuthRequirement | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>basePath</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>database</code></td>
-                      <td>property</td>
-                      <td><code>DatabaseAdapterRef</code></td>
-                      <td>yes</td>
                       <td></td>
                     </tr>
                     <tr>
@@ -4371,6 +4276,18 @@
                       <td>property</td>
                       <td><code>string | undefined</code></td>
                       <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>endpoints</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >Readonly&lt;Record&lt;string,
+                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                        >
+                      </td>
+                      <td>yes</td>
                       <td></td>
                     </tr>
                     <tr>
@@ -4392,6 +4309,299 @@
                       <td>property</td>
                       <td><code>string | undefined</code></td>
                       <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>origin</code></td>
+                      <td>property</td>
+                      <td><code>ApiOrigin</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>protocol</code></td>
+                      <td>property</td>
+                      <td><code>ApiProtocol</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>schemas</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >Readonly&lt;Record&lt;string,
+                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                        >
+                      </td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-apidefinition"
+                data-search="ApiDefinition unknown src/data/apis.ts "
+              >
+                <h4>ApiDefinition</h4>
+                <p class="muted">unknown • <code>src/data/apis.ts:60:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-apidefinitionlist"
+                data-search="ApiDefinitionList unknown src/data/apis.ts "
+              >
+                <h4>ApiDefinitionList</h4>
+                <p class="muted">unknown • <code>src/data/apis.ts:65:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-apiorigin"
+                data-search="ApiOrigin unknown src/data/apis.ts "
+              >
+                <h4>ApiOrigin</h4>
+                <p class="muted">unknown • <code>src/data/apis.ts:7:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-apiprotocol"
+                data-search="ApiProtocol unknown src/data/apis.ts "
+              >
+                <h4>ApiProtocol</h4>
+                <p class="muted">unknown • <code>src/data/apis.ts:8:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-externalgraphqlapidefinition"
+                data-search="ExternalGraphQlApiDefinition type src/data/apis.ts  CredentialRef DataContractValue DataEndpointConfig DataSchema GraphQlIntrospectionConfig"
+              >
+                <h4>ExternalGraphQlApiDefinition</h4>
+                <p class="muted">type • <code>src/data/apis.ts:40:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">CredentialRef</li>
+                    <li class="chip">DataContractValue</li>
+                    <li class="chip">DataEndpointConfig</li>
+                    <li class="chip">DataSchema</li>
+                    <li class="chip">GraphQlIntrospectionConfig</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>credential</code></td>
+                      <td>property</td>
+                      <td><code>CredentialRef | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>description</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>endpoints</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >Readonly&lt;Record&lt;string,
+                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                        >
+                      </td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>endpointUrl</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>id</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>introspection</code></td>
+                      <td>property</td>
+                      <td><code>GraphQlIntrospectionConfig | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>metadata</code></td>
+                      <td>property</td>
+                      <td><code>DataContractValue | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>name</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>origin</code></td>
+                      <td>property</td>
+                      <td><code>&quot;external&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>protocol</code></td>
+                      <td>property</td>
+                      <td><code>&quot;graphql&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>schemas</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >Readonly&lt;Record&lt;string,
+                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                        >
+                      </td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-externalrestapidefinition"
+                data-search="ExternalRestApiDefinition type src/data/apis.ts  CredentialRef DataContractValue DataEndpointConfig DataSchema OpenApiDocumentRef"
+              >
+                <h4>ExternalRestApiDefinition</h4>
+                <p class="muted">type • <code>src/data/apis.ts:28:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">CredentialRef</li>
+                    <li class="chip">DataContractValue</li>
+                    <li class="chip">DataEndpointConfig</li>
+                    <li class="chip">DataSchema</li>
+                    <li class="chip">OpenApiDocumentRef</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>baseUrl</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>credential</code></td>
+                      <td>property</td>
+                      <td><code>CredentialRef | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>description</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>endpoints</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >Readonly&lt;Record&lt;string,
+                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                        >
+                      </td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>id</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>metadata</code></td>
+                      <td>property</td>
+                      <td><code>DataContractValue | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>name</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>openApi</code></td>
+                      <td>property</td>
+                      <td><code>OpenApiDocumentRef | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>origin</code></td>
+                      <td>property</td>
+                      <td><code>&quot;external&quot;</code></td>
+                      <td>yes</td>
                       <td></td>
                     </tr>
                     <tr>
@@ -4402,10 +4612,15 @@
                       <td></td>
                     </tr>
                     <tr>
-                      <td><code>resources</code></td>
+                      <td><code>schemas</code></td>
                       <td>property</td>
-                      <td><code>readonly GeneratedApiResourceDefinition[]</code></td>
-                      <td>yes</td>
+                      <td>
+                        <code
+                          >Readonly&lt;Record&lt;string,
+                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                        >
+                      </td>
+                      <td>no</td>
                       <td></td>
                     </tr>
                   </tbody>
@@ -4413,22 +4628,11 @@
               </article>
               <article
                 class="item"
-                id="symbol-generatedapiid"
-                data-search="GeneratedApiId unknown src/data/apis.ts "
+                id="symbol-graphqlintrospectionconfig"
+                data-search="GraphQlIntrospectionConfig type src/data/apis.ts "
               >
-                <h4>GeneratedApiId</h4>
-                <p class="muted">unknown • <code>src/data/apis.ts:14:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
-                id="symbol-generatedapioperationpolicyref"
-                data-search="GeneratedApiOperationPolicyRef type src/data/apis.ts "
-              >
-                <h4>GeneratedApiOperationPolicyRef</h4>
-                <p class="muted">type • <code>src/data/apis.ts:26:1</code></p>
+                <h4>GraphQlIntrospectionConfig</h4>
+                <p class="muted">type • <code>src/data/apis.ts:35:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -4445,21 +4649,16 @@
                   </thead>
                   <tbody>
                     <tr>
-                      <td><code>id</code></td>
+                      <td><code>enabled</code></td>
                       <td>property</td>
-                      <td><code>string</code></td>
+                      <td><code>boolean</code></td>
                       <td>yes</td>
                       <td></td>
                     </tr>
                     <tr>
-                      <td><code>operation</code></td>
+                      <td><code>schemaVersion</code></td>
                       <td>property</td>
-                      <td>
-                        <code
-                          >&quot;list&quot; | &quot;read&quot; | &quot;create&quot; |
-                          &quot;update&quot; | &quot;delete&quot; | undefined</code
-                        >
-                      </td>
+                      <td><code>string | undefined</code></td>
                       <td>no</td>
                       <td></td>
                     </tr>
@@ -4468,30 +4667,20 @@
               </article>
               <article
                 class="item"
-                id="symbol-generatedapiregistry"
-                data-search="GeneratedApiRegistry unknown src/data/apis.ts "
+                id="symbol-internalrestapidefinition"
+                data-search="InternalRestApiDefinition type src/data/apis.ts  CredentialRef DataContractValue DataEndpointConfig DataSchema"
               >
-                <h4>GeneratedApiRegistry</h4>
-                <p class="muted">unknown • <code>src/data/apis.ts:62:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
-                id="symbol-generatedapiresourcedefinition"
-                data-search="GeneratedApiResourceDefinition type src/data/apis.ts  DataContractValue DbCollectionDefinition GeneratedApiOperationPolicyRef"
-              >
-                <h4>GeneratedApiResourceDefinition</h4>
-                <p class="muted">type • <code>src/data/apis.ts:31:1</code></p>
+                <h4>InternalRestApiDefinition</h4>
+                <p class="muted">type • <code>src/data/apis.ts:54:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
                   <strong>Related symbols:</strong>
                   <ul class="chips">
+                    <li class="chip">CredentialRef</li>
                     <li class="chip">DataContractValue</li>
-                    <li class="chip">DbCollectionDefinition</li>
-                    <li class="chip">GeneratedApiOperationPolicyRef</li>
+                    <li class="chip">DataEndpointConfig</li>
+                    <li class="chip">DataSchema</li>
                   </ul>
                 </div>
 
@@ -4507,10 +4696,17 @@
                   </thead>
                   <tbody>
                     <tr>
-                      <td><code>collection</code></td>
+                      <td><code>basePath</code></td>
                       <td>property</td>
-                      <td><code>DbCollectionDefinition</code></td>
+                      <td><code>string</code></td>
                       <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>credential</code></td>
+                      <td>property</td>
+                      <td><code>CredentialRef | undefined</code></td>
+                      <td>no</td>
                       <td></td>
                     </tr>
                     <tr>
@@ -4518,6 +4714,18 @@
                       <td>property</td>
                       <td><code>string | undefined</code></td>
                       <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>endpoints</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >Readonly&lt;Record&lt;string,
+                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                        >
+                      </td>
+                      <td>yes</td>
                       <td></td>
                     </tr>
                     <tr>
@@ -4542,38 +4750,26 @@
                       <td></td>
                     </tr>
                     <tr>
-                      <td><code>operations</code></td>
+                      <td><code>origin</code></td>
                       <td>property</td>
-                      <td>
-                        <code
-                          >readonly (&quot;list&quot; | &quot;read&quot; | &quot;create&quot; |
-                          &quot;update&quot; | &quot;delete&quot;)[]</code
-                        >
-                      </td>
+                      <td><code>&quot;internal&quot;</code></td>
                       <td>yes</td>
                       <td></td>
                     </tr>
                     <tr>
-                      <td><code>path</code></td>
+                      <td><code>protocol</code></td>
                       <td>property</td>
-                      <td><code>string</code></td>
+                      <td><code>&quot;rest&quot;</code></td>
                       <td>yes</td>
                       <td></td>
                     </tr>
                     <tr>
-                      <td><code>policies</code></td>
-                      <td>property</td>
-                      <td><code>readonly GeneratedApiOperationPolicyRef[] | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>seed</code></td>
+                      <td><code>schemas</code></td>
                       <td>property</td>
                       <td>
                         <code
-                          >readonly Readonly&lt;Record&lt;string, DataContractValue&gt;&gt;[] |
-                          undefined</code
+                          >Readonly&lt;Record&lt;string,
+                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -4584,25 +4780,49 @@
               </article>
               <article
                 class="item"
-                id="symbol-generatedapiresourceid"
-                data-search="GeneratedApiResourceId unknown src/data/apis.ts "
+                id="symbol-openapidocumentref"
+                data-search="OpenApiDocumentRef type src/data/apis.ts "
               >
-                <h4>GeneratedApiResourceId</h4>
-                <p class="muted">unknown • <code>src/data/apis.ts:15:1</code></p>
+                <h4>OpenApiDocumentRef</h4>
+                <p class="muted">type • <code>src/data/apis.ts:22:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
-                id="symbol-generatedapiseedrecord"
-                data-search="GeneratedApiSeedRecord unknown src/data/apis.ts "
-              >
-                <h4>GeneratedApiSeedRecord</h4>
-                <p class="muted">unknown • <code>src/data/apis.ts:16:1</code></p>
 
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>documentId</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>url</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>version</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
               </article>
             </section>
             <section>
@@ -4635,7 +4855,7 @@
                 data-search="DataSourceDiagnostic type src/data/diagnostics.ts  DataDiagnosticCode DataDiagnosticSeverity"
               >
                 <h4>DataSourceDiagnostic</h4>
-                <p class="muted">type • <code>src/data/diagnostics.ts:21:1</code></p>
+                <p class="muted">type • <code>src/data/diagnostics.ts:22:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -4657,6 +4877,13 @@
                     </tr>
                   </thead>
                   <tbody>
+                    <tr>
+                      <td><code>apiId</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
                     <tr>
                       <td><code>code</code></td>
                       <td>property</td>
@@ -4722,7 +4949,7 @@
                 data-search="DataSourceDiagnosticResult unknown src/data/diagnostics.ts "
               >
                 <h4>DataSourceDiagnosticResult</h4>
-                <p class="muted">unknown • <code>src/data/diagnostics.ts:32:1</code></p>
+                <p class="muted">unknown • <code>src/data/diagnostics.ts:34:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -4859,7 +5086,14 @@
                 data-search="AdapterId unknown src/data/ids.ts "
               >
                 <h4>AdapterId</h4>
-                <p class="muted">unknown • <code>src/data/ids.ts:6:1</code></p>
+                <p class="muted">unknown • <code>src/data/ids.ts:7:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article class="item" id="symbol-apiid" data-search="ApiId unknown src/data/ids.ts ">
+                <h4>ApiId</h4>
+                <p class="muted">unknown • <code>src/data/ids.ts:1:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -4870,7 +5104,7 @@
                 data-search="CredentialId unknown src/data/ids.ts "
               >
                 <h4>CredentialId</h4>
-                <p class="muted">unknown • <code>src/data/ids.ts:5:1</code></p>
+                <p class="muted">unknown • <code>src/data/ids.ts:6:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -4881,7 +5115,7 @@
                 data-search="DataSourceId unknown src/data/ids.ts "
               >
                 <h4>DataSourceId</h4>
-                <p class="muted">unknown • <code>src/data/ids.ts:1:1</code></p>
+                <p class="muted">unknown • <code>src/data/ids.ts:2:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -4892,7 +5126,7 @@
                 data-search="EndpointId unknown src/data/ids.ts "
               >
                 <h4>EndpointId</h4>
-                <p class="muted">unknown • <code>src/data/ids.ts:2:1</code></p>
+                <p class="muted">unknown • <code>src/data/ids.ts:3:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -4903,7 +5137,7 @@
                 data-search="OperationId unknown src/data/ids.ts "
               >
                 <h4>OperationId</h4>
-                <p class="muted">unknown • <code>src/data/ids.ts:3:1</code></p>
+                <p class="muted">unknown • <code>src/data/ids.ts:4:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -4914,7 +5148,7 @@
                 data-search="SchemaId unknown src/data/ids.ts "
               >
                 <h4>SchemaId</h4>
-                <p class="muted">unknown • <code>src/data/ids.ts:4:1</code></p>
+                <p class="muted">unknown • <code>src/data/ids.ts:5:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -5901,160 +6135,11 @@
               <h3>src/data/sources.ts</h3>
               <article
                 class="item"
-                id="symbol-apidatasourcebaseconfig"
-                data-search="ApiDataSourceBaseConfig type src/data/sources.ts  ApiOrigin ApiProtocol CredentialRef DataContractValue DataEndpointConfig DataSchema"
-              >
-                <h4>ApiDataSourceBaseConfig</h4>
-                <p class="muted">type • <code>src/data/sources.ts:22:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div>
-                  <strong>Related symbols:</strong>
-                  <ul class="chips">
-                    <li class="chip">ApiOrigin</li>
-                    <li class="chip">ApiProtocol</li>
-                    <li class="chip">CredentialRef</li>
-                    <li class="chip">DataContractValue</li>
-                    <li class="chip">DataEndpointConfig</li>
-                    <li class="chip">DataSchema</li>
-                  </ul>
-                </div>
-
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Member</th>
-                      <th>Kind</th>
-                      <th>Type</th>
-                      <th>Required</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>credential</code></td>
-                      <td>property</td>
-                      <td><code>CredentialRef | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>description</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>endpoints</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
-                        >
-                      </td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>id</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>kind</code></td>
-                      <td>property</td>
-                      <td><code>&quot;api&quot;</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>metadata</code></td>
-                      <td>property</td>
-                      <td><code>DataContractValue | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>name</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>origin</code></td>
-                      <td>property</td>
-                      <td><code>ApiOrigin</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>protocol</code></td>
-                      <td>property</td>
-                      <td><code>ApiProtocol</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>schemas</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
-                          | undefined</code
-                        >
-                      </td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </article>
-              <article
-                class="item"
-                id="symbol-apidatasourceconfig"
-                data-search="ApiDataSourceConfig unknown src/data/sources.ts "
-              >
-                <h4>ApiDataSourceConfig</h4>
-                <p class="muted">unknown • <code>src/data/sources.ts:58:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
-                id="symbol-apiorigin"
-                data-search="ApiOrigin unknown src/data/sources.ts "
-              >
-                <h4>ApiOrigin</h4>
-                <p class="muted">unknown • <code>src/data/sources.ts:8:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
-                id="symbol-apiprotocol"
-                data-search="ApiProtocol unknown src/data/sources.ts "
-              >
-                <h4>ApiProtocol</h4>
-                <p class="muted">unknown • <code>src/data/sources.ts:9:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
                 id="symbol-databasedatasourceconfig"
                 data-search="DatabaseDataSourceConfig type src/data/sources.ts  CredentialRef DatabaseAdapterRef DataContractValue DataEndpointConfig DataSchema"
               >
                 <h4>DatabaseDataSourceConfig</h4>
-                <p class="muted">type • <code>src/data/sources.ts:63:1</code></p>
+                <p class="muted">type • <code>src/data/sources.ts:9:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -6106,7 +6191,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -6146,109 +6231,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
-                          | undefined</code
-                        >
-                      </td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </article>
-              <article
-                class="item"
-                id="symbol-datasourcebaseconfig"
-                data-search="DataSourceBaseConfig type src/data/sources.ts  CredentialRef DataContractValue DataEndpointConfig DataSchema DataSourceKind"
-              >
-                <h4>DataSourceBaseConfig</h4>
-                <p class="muted">type • <code>src/data/sources.ts:11:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div>
-                  <strong>Related symbols:</strong>
-                  <ul class="chips">
-                    <li class="chip">CredentialRef</li>
-                    <li class="chip">DataContractValue</li>
-                    <li class="chip">DataEndpointConfig</li>
-                    <li class="chip">DataSchema</li>
-                    <li class="chip">DataSourceKind</li>
-                  </ul>
-                </div>
-
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Member</th>
-                      <th>Kind</th>
-                      <th>Type</th>
-                      <th>Required</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>credential</code></td>
-                      <td>property</td>
-                      <td><code>CredentialRef | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>description</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>endpoints</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
-                        >
-                      </td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>id</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>kind</code></td>
-                      <td>property</td>
-                      <td><code>DataSourceKind</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>metadata</code></td>
-                      <td>property</td>
-                      <td><code>DataContractValue | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>name</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>schemas</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
-                          | undefined</code
+                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -6263,7 +6246,7 @@
                 data-search="DataSourceConfig unknown src/data/sources.ts "
               >
                 <h4>DataSourceConfig</h4>
-                <p class="muted">unknown • <code>src/data/sources.ts:68:1</code></p>
+                <p class="muted">unknown • <code>src/data/sources.ts:21:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -6285,447 +6268,10 @@
                 data-search="DataSourceRegistry unknown src/data/sources.ts "
               >
                 <h4>DataSourceRegistry</h4>
-                <p class="muted">unknown • <code>src/data/sources.ts:70:1</code></p>
+                <p class="muted">unknown • <code>src/data/sources.ts:22:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
-                id="symbol-externalgraphqlapidatasourceconfig"
-                data-search="ExternalGraphQlApiDataSourceConfig type src/data/sources.ts  CredentialRef DataContractValue DataEndpointConfig DataSchema"
-              >
-                <h4>ExternalGraphQlApiDataSourceConfig</h4>
-                <p class="muted">type • <code>src/data/sources.ts:41:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div>
-                  <strong>Related symbols:</strong>
-                  <ul class="chips">
-                    <li class="chip">CredentialRef</li>
-                    <li class="chip">DataContractValue</li>
-                    <li class="chip">DataEndpointConfig</li>
-                    <li class="chip">DataSchema</li>
-                  </ul>
-                </div>
-
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Member</th>
-                      <th>Kind</th>
-                      <th>Type</th>
-                      <th>Required</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>credential</code></td>
-                      <td>property</td>
-                      <td><code>CredentialRef | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>description</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>endpoints</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
-                        >
-                      </td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>endpointUrl</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>id</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>introspection</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >{ readonly enabled: boolean; readonly schemaVersion?: string; } |
-                          undefined</code
-                        >
-                      </td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>kind</code></td>
-                      <td>property</td>
-                      <td><code>&quot;api&quot;</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>metadata</code></td>
-                      <td>property</td>
-                      <td><code>DataContractValue | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>name</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>origin</code></td>
-                      <td>property</td>
-                      <td><code>&quot;external&quot;</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>protocol</code></td>
-                      <td>property</td>
-                      <td><code>&quot;graphql&quot;</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>schemas</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
-                          | undefined</code
-                        >
-                      </td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </article>
-              <article
-                class="item"
-                id="symbol-externalrestapidatasourceconfig"
-                data-search="ExternalRestApiDataSourceConfig type src/data/sources.ts  CredentialRef DataContractValue DataEndpointConfig DataSchema OpenApiDocumentRef"
-              >
-                <h4>ExternalRestApiDataSourceConfig</h4>
-                <p class="muted">type • <code>src/data/sources.ts:34:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div>
-                  <strong>Related symbols:</strong>
-                  <ul class="chips">
-                    <li class="chip">CredentialRef</li>
-                    <li class="chip">DataContractValue</li>
-                    <li class="chip">DataEndpointConfig</li>
-                    <li class="chip">DataSchema</li>
-                    <li class="chip">OpenApiDocumentRef</li>
-                  </ul>
-                </div>
-
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Member</th>
-                      <th>Kind</th>
-                      <th>Type</th>
-                      <th>Required</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>baseUrl</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>credential</code></td>
-                      <td>property</td>
-                      <td><code>CredentialRef | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>description</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>endpoints</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
-                        >
-                      </td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>id</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>kind</code></td>
-                      <td>property</td>
-                      <td><code>&quot;api&quot;</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>metadata</code></td>
-                      <td>property</td>
-                      <td><code>DataContractValue | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>name</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>openApi</code></td>
-                      <td>property</td>
-                      <td><code>OpenApiDocumentRef | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>origin</code></td>
-                      <td>property</td>
-                      <td><code>&quot;external&quot;</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>protocol</code></td>
-                      <td>property</td>
-                      <td><code>&quot;rest&quot;</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>schemas</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
-                          | undefined</code
-                        >
-                      </td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </article>
-              <article
-                class="item"
-                id="symbol-generatedrestapidatasourceconfig"
-                data-search="GeneratedRestApiDataSourceConfig type src/data/sources.ts  CredentialRef DatabaseAdapterRef DataContractValue DataEndpointConfig DataSchema"
-              >
-                <h4>GeneratedRestApiDataSourceConfig</h4>
-                <p class="muted">type • <code>src/data/sources.ts:51:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div>
-                  <strong>Related symbols:</strong>
-                  <ul class="chips">
-                    <li class="chip">CredentialRef</li>
-                    <li class="chip">DatabaseAdapterRef</li>
-                    <li class="chip">DataContractValue</li>
-                    <li class="chip">DataEndpointConfig</li>
-                    <li class="chip">DataSchema</li>
-                  </ul>
-                </div>
-
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Member</th>
-                      <th>Kind</th>
-                      <th>Type</th>
-                      <th>Required</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>adapter</code></td>
-                      <td>property</td>
-                      <td><code>DatabaseAdapterRef</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>credential</code></td>
-                      <td>property</td>
-                      <td><code>CredentialRef | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>description</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>endpoints</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataEndpointConfig&gt;&gt;</code
-                        >
-                      </td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>generatedApiId</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>id</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>kind</code></td>
-                      <td>property</td>
-                      <td><code>&quot;api&quot;</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>metadata</code></td>
-                      <td>property</td>
-                      <td><code>DataContractValue | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>name</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>origin</code></td>
-                      <td>property</td>
-                      <td><code>&quot;generated&quot;</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>protocol</code></td>
-                      <td>property</td>
-                      <td><code>&quot;rest&quot;</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>schemas</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSchema&gt;&gt;
-                          | undefined</code
-                        >
-                      </td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </article>
-              <article
-                class="item"
-                id="symbol-openapidocumentref"
-                data-search="OpenApiDocumentRef type src/data/sources.ts "
-              >
-                <h4>OpenApiDocumentRef</h4>
-                <p class="muted">type • <code>src/data/sources.ts:28:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Member</th>
-                      <th>Kind</th>
-                      <th>Type</th>
-                      <th>Required</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>documentId</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>url</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>version</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                  </tbody>
-                </table>
               </article>
             </section>
             <section>
@@ -8801,7 +8347,7 @@
                 data-search="AnkhorageCapabilityName unknown src/requirements.ts "
               >
                 <h4>AnkhorageCapabilityName</h4>
-                <p class="muted">unknown • <code>src/requirements.ts:24:1</code></p>
+                <p class="muted">unknown • <code>src/requirements.ts:25:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8823,7 +8369,7 @@
                 data-search="ComponentRequirements type src/requirements.ts  ScreenCapabilityRequirement ScreenPermissionRequirement"
               >
                 <h4>ComponentRequirements</h4>
-                <p class="muted">type • <code>src/requirements.ts:39:1</code></p>
+                <p class="muted">type • <code>src/requirements.ts:40:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -8868,7 +8414,7 @@
                 data-search="ScreenCapabilityRequirement type src/requirements.ts "
               >
                 <h4>ScreenCapabilityRequirement</h4>
-                <p class="muted">type • <code>src/requirements.ts:30:1</code></p>
+                <p class="muted">type • <code>src/requirements.ts:31:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8891,8 +8437,8 @@
                         <code
                           >&quot;notifications&quot; | &quot;clipboard&quot; |
                           &quot;barcodeScanner&quot; | &quot;cameraPreview&quot; |
-                          &quot;mediaPicker&quot; | &quot;filePicker&quot; |
-                          &quot;location&quot;</code
+                          &quot;ebookReader&quot; | &quot;mediaPicker&quot; | &quot;filePicker&quot;
+                          | &quot;location&quot;</code
                         >
                       </td>
                       <td>yes</td>
@@ -8907,7 +8453,7 @@
                 data-search="ScreenPermissionRequirement type src/requirements.ts "
               >
                 <h4>ScreenPermissionRequirement</h4>
-                <p class="muted">type • <code>src/requirements.ts:26:1</code></p>
+                <p class="muted">type • <code>src/requirements.ts:27:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8946,7 +8492,7 @@
                 data-search="ScreenRequirements type src/requirements.ts  ScreenCapabilityRequirement ScreenPermissionRequirement"
               >
                 <h4>ScreenRequirements</h4>
-                <p class="muted">type • <code>src/requirements.ts:34:1</code></p>
+                <p class="muted">type • <code>src/requirements.ts:35:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -11921,7 +11467,7 @@
               <article
                 class="item"
                 id="symbol-appmanifest"
-                data-search="AppManifest type src/types.ts  AppCategory AppDeployManifest AppSettings ComponentDataBinding DataSourceConfig GeneratedApiDefinition InfraManifest MediaManifest NavigatorSpec ScreenSpec SplashScreenSpec ThemeConfig"
+                data-search="AppManifest type src/types.ts  AppCategory AppDeployManifest AppSettings ComponentDataBinding DatabaseDataSourceConfig InfraManifest MediaManifest NavigatorSpec ScreenSpec SplashScreenSpec ThemeConfig"
               >
                 <h4>AppManifest</h4>
                 <p class="muted">type • <code>src/types.ts:389:1</code></p>
@@ -11934,8 +11480,7 @@
                     <li class="chip">AppDeployManifest</li>
                     <li class="chip">AppSettings</li>
                     <li class="chip">ComponentDataBinding</li>
-                    <li class="chip">DataSourceConfig</li>
-                    <li class="chip">GeneratedApiDefinition</li>
+                    <li class="chip">DatabaseDataSourceConfig</li>
                     <li class="chip">InfraManifest</li>
                     <li class="chip">MediaManifest</li>
                     <li class="chip">NavigatorSpec</li>
@@ -11976,8 +11521,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/bindings&quot;).ComponentDataBinding&gt;&gt;
-                          | undefined</code
+                          import(&quot;./src/bindings&quot;).ComponentDataBinding&gt;&gt; |
+                          undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -11989,8 +11534,8 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).DataSourceConfig&gt;&gt;
-                          | undefined</code
+                          import(&quot;./src/index&quot;).DatabaseDataSourceConfig&gt;&gt; |
+                          undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -12000,19 +11545,6 @@
                       <td><code>deploy</code></td>
                       <td>property</td>
                       <td><code>AppDeployManifest | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>generatedApis</code></td>
-                      <td>property</td>
-                      <td>
-                        <code
-                          >Readonly&lt;Record&lt;string,
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/index&quot;).GeneratedApiDefinition&gt;&gt;
-                          | undefined</code
-                        >
-                      </td>
                       <td>no</td>
                       <td></td>
                     </tr>
@@ -12086,7 +11618,7 @@
                 data-search="AppSettings type src/types.ts "
               >
                 <h4>AppSettings</h4>
-                <p class="muted">type • <code>src/types.ts:381:1</code></p>
+                <p class="muted">type • <code>src/types.ts:382:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12102,13 +11634,6 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <tr>
-                      <td><code>apiBaseUrl</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
                     <tr>
                       <td><code>localization</code></td>
                       <td>property</td>
@@ -12272,7 +11797,7 @@
                       <td>property</td>
                       <td>
                         <code
-                          >&quot;app&quot; | &quot;api&quot; | &quot;trigger&quot; | undefined</code
+                          >&quot;app&quot; | &quot;trigger&quot; | &quot;api&quot; | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -13073,7 +12598,7 @@
               <article
                 class="item"
                 id="symbol-inframanifest"
-                data-search="InfraManifest type src/types.ts  AuthSpec DatabaseSpec DeploymentSpec InfraSecretStoreSpec NetworkingSpec StateSpec StorageSpec"
+                data-search="InfraManifest type src/types.ts  ApiDefinitionList AuthSpec DatabaseSpec DeploymentSpec InfraSecretStoreSpec NetworkingSpec StateSpec StorageSpec"
               >
                 <h4>InfraManifest</h4>
                 <p class="muted">type • <code>src/types.ts:370:1</code></p>
@@ -13082,6 +12607,7 @@
                 <div>
                   <strong>Related symbols:</strong>
                   <ul class="chips">
+                    <li class="chip">ApiDefinitionList</li>
                     <li class="chip">AuthSpec</li>
                     <li class="chip">DatabaseSpec</li>
                     <li class="chip">DeploymentSpec</li>
@@ -13103,6 +12629,13 @@
                     </tr>
                   </thead>
                   <tbody>
+                    <tr>
+                      <td><code>apis</code></td>
+                      <td>property</td>
+                      <td><code>ApiDefinitionList | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
                     <tr>
                       <td><code>auth</code></td>
                       <td>property</td>
@@ -13532,8 +13065,8 @@
                       <td>
                         <code
                           >readonly
-                          import(&quot;/Users/a_rtiphishl_e/git/contracts/src/bindings&quot;).OperationScreenDataLoaderDefinition[]
-                          | undefined</code
+                          import(&quot;./src/bindings&quot;).OperationScreenDataLoaderDefinition[] |
+                          undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -15396,27 +14929,33 @@
                 module_src_appManifest_ts --&gt; module_src_appManifest_bindings_ts
                 module_src_appManifest_ts --&gt; module_src_appManifest_dataSources_ts
                 module_src_appManifest_ts --&gt; module_src_appManifest_deploy_ts
-                module_src_appManifest_ts --&gt; module_src_appManifest_generatedApis_ts
                 module_src_appManifest_ts --&gt; module_src_appManifest_infra_ts
                 module_src_appManifest_ts --&gt; module_src_appManifest_media_ts
                 module_src_appManifest_ts --&gt; module_src_appManifest_screens_ts
                 module_src_appManifest_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_ts --&gt; module_src_types_ts
+                module_src_appManifest_apis_ts[&quot;src/appManifest/apis.ts&quot;]
+                package__ankhorage_contracts -.-&gt; module_src_appManifest_apis_ts
+                module_src_appManifest_apis_ts --&gt; module_src_appManifest_data_ts
+                module_src_appManifest_apis_ts --&gt; module_src_appManifest_shared_ts
+                module_src_appManifest_apis_ts --&gt; module_src_data_index_ts
                 module_src_appManifest_bindings_ts[&quot;src/appManifest/bindings.ts&quot;]
                 package__ankhorage_contracts -.-&gt; module_src_appManifest_bindings_ts
                 module_src_appManifest_bindings_ts --&gt; module_src_appManifest_shared_ts
+                module_src_appManifest_data_ts[&quot;src/appManifest/data.ts&quot;]
+                package__ankhorage_contracts -.-&gt; module_src_appManifest_data_ts
+                module_src_appManifest_data_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_dataSources_ts[&quot;src/appManifest/dataSources.ts&quot;]
                 package__ankhorage_contracts -.-&gt; module_src_appManifest_dataSources_ts
+                module_src_appManifest_dataSources_ts --&gt; module_src_appManifest_data_ts
                 module_src_appManifest_dataSources_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_deploy_ts[&quot;src/appManifest/deploy.ts&quot;]
                 package__ankhorage_contracts -.-&gt; module_src_appManifest_deploy_ts
                 module_src_appManifest_deploy_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_deploy_ts --&gt; module_src_deploy_ts
-                module_src_appManifest_generatedApis_ts[&quot;src/appManifest/generatedApis.ts&quot;]
-                package__ankhorage_contracts -.-&gt; module_src_appManifest_generatedApis_ts
-                module_src_appManifest_generatedApis_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
                 package__ankhorage_contracts -.-&gt; module_src_appManifest_infra_ts
+                module_src_appManifest_infra_ts --&gt; module_src_appManifest_apis_ts
                 module_src_appManifest_infra_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_infra_ts --&gt; module_src_auth_ts
                 module_src_appManifest_infra_ts --&gt; module_src_types_ts
@@ -15440,8 +14979,10 @@
                 package__ankhorage_contracts -.-&gt; module_src_cli_index_ts
                 module_src_data_apis_ts[&quot;src/data/apis.ts&quot;] package__ankhorage_contracts
                 -.-&gt; module_src_data_apis_ts module_src_data_apis_ts --&gt;
-                module_src_data_refs_ts module_src_data_apis_ts --&gt; module_src_data_values_ts
-                module_src_data_apis_ts --&gt; module_src_db_ts
+                module_src_data_endpoints_ts module_src_data_apis_ts --&gt; module_src_data_ids_ts
+                module_src_data_apis_ts --&gt; module_src_data_refs_ts module_src_data_apis_ts
+                --&gt; module_src_data_schemas_ts module_src_data_apis_ts --&gt;
+                module_src_data_values_ts
                 module_src_data_diagnostics_ts[&quot;src/data/diagnostics.ts&quot;]
                 package__ankhorage_contracts -.-&gt; module_src_data_diagnostics_ts
                 module_src_data_diagnostics_ts --&gt; module_src_data_ids_ts
@@ -15517,27 +15058,33 @@ graph TD
   module_src_appManifest_ts --&gt; module_src_appManifest_bindings_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_dataSources_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_deploy_ts
-  module_src_appManifest_ts --&gt; module_src_appManifest_generatedApis_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_infra_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_media_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_screens_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_ts --&gt; module_src_types_ts
+  module_src_appManifest_apis_ts[&quot;src/appManifest/apis.ts&quot;]
+  package__ankhorage_contracts -.-&gt; module_src_appManifest_apis_ts
+  module_src_appManifest_apis_ts --&gt; module_src_appManifest_data_ts
+  module_src_appManifest_apis_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_apis_ts --&gt; module_src_data_index_ts
   module_src_appManifest_bindings_ts[&quot;src/appManifest/bindings.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_appManifest_bindings_ts
   module_src_appManifest_bindings_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_data_ts[&quot;src/appManifest/data.ts&quot;]
+  package__ankhorage_contracts -.-&gt; module_src_appManifest_data_ts
+  module_src_appManifest_data_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_dataSources_ts[&quot;src/appManifest/dataSources.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_appManifest_dataSources_ts
+  module_src_appManifest_dataSources_ts --&gt; module_src_appManifest_data_ts
   module_src_appManifest_dataSources_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts[&quot;src/appManifest/deploy.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_appManifest_deploy_ts
   module_src_appManifest_deploy_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --&gt; module_src_deploy_ts
-  module_src_appManifest_generatedApis_ts[&quot;src/appManifest/generatedApis.ts&quot;]
-  package__ankhorage_contracts -.-&gt; module_src_appManifest_generatedApis_ts
-  module_src_appManifest_generatedApis_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_appManifest_infra_ts
+  module_src_appManifest_infra_ts --&gt; module_src_appManifest_apis_ts
   module_src_appManifest_infra_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_infra_ts --&gt; module_src_auth_ts
   module_src_appManifest_infra_ts --&gt; module_src_types_ts
@@ -15564,9 +15111,11 @@ graph TD
   package__ankhorage_contracts -.-&gt; module_src_cli_index_ts
   module_src_data_apis_ts[&quot;src/data/apis.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_data_apis_ts
+  module_src_data_apis_ts --&gt; module_src_data_endpoints_ts
+  module_src_data_apis_ts --&gt; module_src_data_ids_ts
   module_src_data_apis_ts --&gt; module_src_data_refs_ts
+  module_src_data_apis_ts --&gt; module_src_data_schemas_ts
   module_src_data_apis_ts --&gt; module_src_data_values_ts
-  module_src_data_apis_ts --&gt; module_src_db_ts
   module_src_data_diagnostics_ts[&quot;src/data/diagnostics.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_data_diagnostics_ts
   module_src_data_diagnostics_ts --&gt; module_src_data_ids_ts
@@ -15651,10 +15200,11 @@ graph TD
               <p class="muted"><code>diagrams/module-relationships.mmd</code></p>
               <div class="mermaid">
                 graph LR module_src_appManifest_ts[&quot;src/appManifest.ts&quot;]
+                module_src_appManifest_apis_ts[&quot;src/appManifest/apis.ts&quot;]
                 module_src_appManifest_bindings_ts[&quot;src/appManifest/bindings.ts&quot;]
+                module_src_appManifest_data_ts[&quot;src/appManifest/data.ts&quot;]
                 module_src_appManifest_dataSources_ts[&quot;src/appManifest/dataSources.ts&quot;]
                 module_src_appManifest_deploy_ts[&quot;src/appManifest/deploy.ts&quot;]
-                module_src_appManifest_generatedApis_ts[&quot;src/appManifest/generatedApis.ts&quot;]
                 module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
                 module_src_appManifest_media_ts[&quot;src/appManifest/media.ts&quot;]
                 module_src_appManifest_screens_ts[&quot;src/appManifest/screens.ts&quot;]
@@ -15688,17 +15238,21 @@ graph TD
                 module_src_appManifest_bindings_ts module_src_appManifest_ts --&gt;
                 module_src_appManifest_dataSources_ts module_src_appManifest_ts --&gt;
                 module_src_appManifest_deploy_ts module_src_appManifest_ts --&gt;
-                module_src_appManifest_generatedApis_ts module_src_appManifest_ts --&gt;
                 module_src_appManifest_infra_ts module_src_appManifest_ts --&gt;
                 module_src_appManifest_media_ts module_src_appManifest_ts --&gt;
                 module_src_appManifest_screens_ts module_src_appManifest_ts --&gt;
                 module_src_appManifest_shared_ts module_src_appManifest_ts --&gt;
-                module_src_types_ts module_src_appManifest_bindings_ts --&gt;
+                module_src_types_ts module_src_appManifest_apis_ts --&gt;
+                module_src_appManifest_data_ts module_src_appManifest_apis_ts --&gt;
+                module_src_appManifest_shared_ts module_src_appManifest_apis_ts --&gt;
+                module_src_data_index_ts module_src_appManifest_bindings_ts --&gt;
+                module_src_appManifest_shared_ts module_src_appManifest_data_ts --&gt;
                 module_src_appManifest_shared_ts module_src_appManifest_dataSources_ts --&gt;
+                module_src_appManifest_data_ts module_src_appManifest_dataSources_ts --&gt;
                 module_src_appManifest_shared_ts module_src_appManifest_deploy_ts --&gt;
                 module_src_appManifest_shared_ts module_src_appManifest_deploy_ts --&gt;
-                module_src_deploy_ts module_src_appManifest_generatedApis_ts --&gt;
-                module_src_appManifest_shared_ts module_src_appManifest_infra_ts --&gt;
+                module_src_deploy_ts module_src_appManifest_infra_ts --&gt;
+                module_src_appManifest_apis_ts module_src_appManifest_infra_ts --&gt;
                 module_src_appManifest_shared_ts module_src_appManifest_infra_ts --&gt;
                 module_src_auth_ts module_src_appManifest_infra_ts --&gt; module_src_types_ts
                 module_src_appManifest_media_ts --&gt; module_src_appManifest_shared_ts
@@ -15708,9 +15262,11 @@ graph TD
                 module_src_appManifest_screens_ts --&gt; module_src_types_ts module_src_auth_ts
                 --&gt; module_src_deploy_ts module_src_auth_ts --&gt; module_src_secrets_ts
                 module_src_auth_ts --&gt; module_src_types_ts module_src_bindings_ts --&gt;
-                module_src_data_index_ts module_src_data_apis_ts --&gt; module_src_data_refs_ts
-                module_src_data_apis_ts --&gt; module_src_data_values_ts module_src_data_apis_ts
-                --&gt; module_src_db_ts module_src_data_diagnostics_ts --&gt; module_src_data_ids_ts
+                module_src_data_index_ts module_src_data_apis_ts --&gt; module_src_data_endpoints_ts
+                module_src_data_apis_ts --&gt; module_src_data_ids_ts module_src_data_apis_ts --&gt;
+                module_src_data_refs_ts module_src_data_apis_ts --&gt; module_src_data_schemas_ts
+                module_src_data_apis_ts --&gt; module_src_data_values_ts
+                module_src_data_diagnostics_ts --&gt; module_src_data_ids_ts
                 module_src_data_endpoints_ts --&gt; module_src_data_ids_ts
                 module_src_data_endpoints_ts --&gt; module_src_data_operations_ts
                 module_src_data_endpoints_ts --&gt; module_src_data_refs_ts
@@ -15740,10 +15296,11 @@ graph TD
                 <pre>
 graph LR
   module_src_appManifest_ts[&quot;src/appManifest.ts&quot;]
+  module_src_appManifest_apis_ts[&quot;src/appManifest/apis.ts&quot;]
   module_src_appManifest_bindings_ts[&quot;src/appManifest/bindings.ts&quot;]
+  module_src_appManifest_data_ts[&quot;src/appManifest/data.ts&quot;]
   module_src_appManifest_dataSources_ts[&quot;src/appManifest/dataSources.ts&quot;]
   module_src_appManifest_deploy_ts[&quot;src/appManifest/deploy.ts&quot;]
-  module_src_appManifest_generatedApis_ts[&quot;src/appManifest/generatedApis.ts&quot;]
   module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
   module_src_appManifest_media_ts[&quot;src/appManifest/media.ts&quot;]
   module_src_appManifest_screens_ts[&quot;src/appManifest/screens.ts&quot;]
@@ -15777,17 +15334,21 @@ graph LR
   module_src_appManifest_ts --&gt; module_src_appManifest_bindings_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_dataSources_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_deploy_ts
-  module_src_appManifest_ts --&gt; module_src_appManifest_generatedApis_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_infra_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_media_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_screens_ts
   module_src_appManifest_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_ts --&gt; module_src_types_ts
+  module_src_appManifest_apis_ts --&gt; module_src_appManifest_data_ts
+  module_src_appManifest_apis_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_apis_ts --&gt; module_src_data_index_ts
   module_src_appManifest_bindings_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_data_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_dataSources_ts --&gt; module_src_appManifest_data_ts
   module_src_appManifest_dataSources_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --&gt; module_src_deploy_ts
-  module_src_appManifest_generatedApis_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_infra_ts --&gt; module_src_appManifest_apis_ts
   module_src_appManifest_infra_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_infra_ts --&gt; module_src_auth_ts
   module_src_appManifest_infra_ts --&gt; module_src_types_ts
@@ -15800,9 +15361,11 @@ graph LR
   module_src_auth_ts --&gt; module_src_secrets_ts
   module_src_auth_ts --&gt; module_src_types_ts
   module_src_bindings_ts --&gt; module_src_data_index_ts
+  module_src_data_apis_ts --&gt; module_src_data_endpoints_ts
+  module_src_data_apis_ts --&gt; module_src_data_ids_ts
   module_src_data_apis_ts --&gt; module_src_data_refs_ts
+  module_src_data_apis_ts --&gt; module_src_data_schemas_ts
   module_src_data_apis_ts --&gt; module_src_data_values_ts
-  module_src_data_apis_ts --&gt; module_src_db_ts
   module_src_data_diagnostics_ts --&gt; module_src_data_ids_ts
   module_src_data_endpoints_ts --&gt; module_src_data_ids_ts
   module_src_data_endpoints_ts --&gt; module_src_data_operations_ts
@@ -15841,10 +15404,11 @@ graph LR
               <p class="muted"><code>diagrams/export-graph.mmd</code></p>
               <div class="mermaid">
                 graph LR module_src_appManifest_ts[&quot;src/appManifest.ts&quot;]
+                module_src_appManifest_apis_ts[&quot;src/appManifest/apis.ts&quot;]
                 module_src_appManifest_bindings_ts[&quot;src/appManifest/bindings.ts&quot;]
+                module_src_appManifest_data_ts[&quot;src/appManifest/data.ts&quot;]
                 module_src_appManifest_dataSources_ts[&quot;src/appManifest/dataSources.ts&quot;]
                 module_src_appManifest_deploy_ts[&quot;src/appManifest/deploy.ts&quot;]
-                module_src_appManifest_generatedApis_ts[&quot;src/appManifest/generatedApis.ts&quot;]
                 module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
                 module_src_appManifest_media_ts[&quot;src/appManifest/media.ts&quot;]
                 module_src_appManifest_screens_ts[&quot;src/appManifest/screens.ts&quot;]
@@ -15904,21 +15468,20 @@ graph LR
                 --&gt; export_AnkhPackageMetadata
                 export_AnkhProviderReference[&quot;AnkhProviderReference&quot;]
                 module_src_cli_index_ts --&gt; export_AnkhProviderReference
-                export_ApiDataSourceBaseConfig[&quot;ApiDataSourceBaseConfig&quot;]
-                module_src_data_sources_ts --&gt; export_ApiDataSourceBaseConfig
-                export_ApiDataSourceBaseConfig -.-&gt; export_ApiOrigin
-                export_ApiDataSourceBaseConfig -.-&gt; export_ApiProtocol
-                export_ApiDataSourceBaseConfig -.-&gt; export_CredentialRef
-                export_ApiDataSourceBaseConfig -.-&gt; export_DataContractValue
-                export_ApiDataSourceBaseConfig -.-&gt; export_DataEndpointConfig
-                export_ApiDataSourceBaseConfig -.-&gt; export_DataSchema
-                export_ApiDataSourceConfig[&quot;ApiDataSourceConfig&quot;]
-                module_src_data_sources_ts --&gt; export_ApiDataSourceConfig
-                export_ApiOrigin[&quot;ApiOrigin&quot;] module_src_data_sources_ts --&gt;
-                export_ApiOrigin export_ApiProtocol[&quot;ApiProtocol&quot;]
-                module_src_data_sources_ts --&gt; export_ApiProtocol
-                export_APP_CATEGORIES[&quot;APP_CATEGORIES&quot;] module_src_types_ts --&gt;
-                export_APP_CATEGORIES
+                export_ApiBaseDefinition[&quot;ApiBaseDefinition&quot;] module_src_data_apis_ts
+                --&gt; export_ApiBaseDefinition export_ApiBaseDefinition -.-&gt; export_ApiOrigin
+                export_ApiBaseDefinition -.-&gt; export_ApiProtocol export_ApiBaseDefinition -.-&gt;
+                export_CredentialRef export_ApiBaseDefinition -.-&gt; export_DataContractValue
+                export_ApiBaseDefinition -.-&gt; export_DataEndpointConfig export_ApiBaseDefinition
+                -.-&gt; export_DataSchema export_ApiDefinition[&quot;ApiDefinition&quot;]
+                module_src_data_apis_ts --&gt; export_ApiDefinition
+                export_ApiDefinitionList[&quot;ApiDefinitionList&quot;] module_src_data_apis_ts
+                --&gt; export_ApiDefinitionList export_ApiId[&quot;ApiId&quot;]
+                module_src_data_ids_ts --&gt; export_ApiId export_ApiOrigin[&quot;ApiOrigin&quot;]
+                module_src_data_apis_ts --&gt; export_ApiOrigin
+                export_ApiProtocol[&quot;ApiProtocol&quot;] module_src_data_apis_ts --&gt;
+                export_ApiProtocol export_APP_CATEGORIES[&quot;APP_CATEGORIES&quot;]
+                module_src_types_ts --&gt; export_APP_CATEGORIES
                 export_APP_DEPLOY_ENVIRONMENT_IDS[&quot;APP_DEPLOY_ENVIRONMENT_IDS&quot;]
                 module_src_deploy_ts --&gt; export_APP_DEPLOY_ENVIRONMENT_IDS
                 export_APP_DEPLOY_TARGET_IDS[&quot;APP_DEPLOY_TARGET_IDS&quot;] module_src_deploy_ts
@@ -15949,11 +15512,10 @@ graph LR
                 export_AppManifest export_AppManifest -.-&gt; export_AppCategory export_AppManifest
                 -.-&gt; export_AppDeployManifest export_AppManifest -.-&gt; export_AppSettings
                 export_AppManifest -.-&gt; export_ComponentDataBinding export_AppManifest -.-&gt;
-                export_DataSourceConfig export_AppManifest -.-&gt; export_GeneratedApiDefinition
-                export_AppManifest -.-&gt; export_InfraManifest export_AppManifest -.-&gt;
-                export_MediaManifest export_AppManifest -.-&gt; export_NavigatorSpec
-                export_AppManifest -.-&gt; export_ScreenSpec export_AppManifest -.-&gt;
-                export_SplashScreenSpec export_AppManifest -.-&gt; export_ThemeConfig
+                export_DatabaseDataSourceConfig export_AppManifest -.-&gt; export_InfraManifest
+                export_AppManifest -.-&gt; export_MediaManifest export_AppManifest -.-&gt;
+                export_NavigatorSpec export_AppManifest -.-&gt; export_ScreenSpec export_AppManifest
+                -.-&gt; export_SplashScreenSpec export_AppManifest -.-&gt; export_ThemeConfig
                 export_AppManifestParseResult[&quot;AppManifestParseResult&quot;]
                 module_src_appManifest_ts --&gt; export_AppManifestParseResult
                 export_AppSettings[&quot;AppSettings&quot;] module_src_types_ts --&gt;
@@ -16268,12 +15830,6 @@ graph LR
                 export_DataSchemaSlot[&quot;DataSchemaSlot&quot;] module_src_data_schemas_ts --&gt;
                 export_DataSchemaSlot export_DataSchemaSlot -.-&gt; export_DataSchema
                 export_DataSchemaSlot -.-&gt; export_DataSchemaRef
-                export_DataSourceBaseConfig[&quot;DataSourceBaseConfig&quot;]
-                module_src_data_sources_ts --&gt; export_DataSourceBaseConfig
-                export_DataSourceBaseConfig -.-&gt; export_CredentialRef export_DataSourceBaseConfig
-                -.-&gt; export_DataContractValue export_DataSourceBaseConfig -.-&gt;
-                export_DataEndpointConfig export_DataSourceBaseConfig -.-&gt; export_DataSchema
-                export_DataSourceBaseConfig -.-&gt; export_DataSourceKind
                 export_DataSourceConfig[&quot;DataSourceConfig&quot;] module_src_data_sources_ts
                 --&gt; export_DataSourceConfig
                 export_DataSourceDiagnostic[&quot;DataSourceDiagnostic&quot;]
@@ -16363,19 +15919,20 @@ graph LR
                 export_EventBinding -.-&gt; export_BindingInputValue export_EventBinding -.-&gt;
                 export_EventBindingTarget export_EventBindingTarget[&quot;EventBindingTarget&quot;]
                 module_src_bindings_ts --&gt; export_EventBindingTarget
-                export_ExternalGraphQlApiDataSourceConfig[&quot;ExternalGraphQlApiDataSourceConfig&quot;]
-                module_src_data_sources_ts --&gt; export_ExternalGraphQlApiDataSourceConfig
-                export_ExternalGraphQlApiDataSourceConfig -.-&gt; export_CredentialRef
-                export_ExternalGraphQlApiDataSourceConfig -.-&gt; export_DataContractValue
-                export_ExternalGraphQlApiDataSourceConfig -.-&gt; export_DataEndpointConfig
-                export_ExternalGraphQlApiDataSourceConfig -.-&gt; export_DataSchema
-                export_ExternalRestApiDataSourceConfig[&quot;ExternalRestApiDataSourceConfig&quot;]
-                module_src_data_sources_ts --&gt; export_ExternalRestApiDataSourceConfig
-                export_ExternalRestApiDataSourceConfig -.-&gt; export_CredentialRef
-                export_ExternalRestApiDataSourceConfig -.-&gt; export_DataContractValue
-                export_ExternalRestApiDataSourceConfig -.-&gt; export_DataEndpointConfig
-                export_ExternalRestApiDataSourceConfig -.-&gt; export_DataSchema
-                export_ExternalRestApiDataSourceConfig -.-&gt; export_OpenApiDocumentRef
+                export_ExternalGraphQlApiDefinition[&quot;ExternalGraphQlApiDefinition&quot;]
+                module_src_data_apis_ts --&gt; export_ExternalGraphQlApiDefinition
+                export_ExternalGraphQlApiDefinition -.-&gt; export_CredentialRef
+                export_ExternalGraphQlApiDefinition -.-&gt; export_DataContractValue
+                export_ExternalGraphQlApiDefinition -.-&gt; export_DataEndpointConfig
+                export_ExternalGraphQlApiDefinition -.-&gt; export_DataSchema
+                export_ExternalGraphQlApiDefinition -.-&gt; export_GraphQlIntrospectionConfig
+                export_ExternalRestApiDefinition[&quot;ExternalRestApiDefinition&quot;]
+                module_src_data_apis_ts --&gt; export_ExternalRestApiDefinition
+                export_ExternalRestApiDefinition -.-&gt; export_CredentialRef
+                export_ExternalRestApiDefinition -.-&gt; export_DataContractValue
+                export_ExternalRestApiDefinition -.-&gt; export_DataEndpointConfig
+                export_ExternalRestApiDefinition -.-&gt; export_DataSchema
+                export_ExternalRestApiDefinition -.-&gt; export_OpenApiDocumentRef
                 export_FilterAction[&quot;FilterAction&quot;] module_src_types_ts --&gt;
                 export_FilterAction
                 export_findForbiddenInlineSecretFields[&quot;findForbiddenInlineSecretFields&quot;]
@@ -16385,54 +15942,28 @@ graph LR
                 export_FormSubmitEventDto[&quot;FormSubmitEventDto&quot;] module_src_types_ts --&gt;
                 export_FormSubmitEventDto export_FormSubmitValues[&quot;FormSubmitValues&quot;]
                 module_src_types_ts --&gt; export_FormSubmitValues
-                export_GENERATED_API_CRUD_OPERATIONS[&quot;GENERATED_API_CRUD_OPERATIONS&quot;]
-                module_src_data_apis_ts --&gt; export_GENERATED_API_CRUD_OPERATIONS
-                export_GeneratedApiAuthRequirement[&quot;GeneratedApiAuthRequirement&quot;]
-                module_src_data_apis_ts --&gt; export_GeneratedApiAuthRequirement
-                export_GeneratedApiAuthRequirement -.-&gt; export_DataContractValue
-                export_GeneratedApiCrudOperation[&quot;GeneratedApiCrudOperation&quot;]
-                module_src_data_apis_ts --&gt; export_GeneratedApiCrudOperation
-                export_GeneratedApiDefinition[&quot;GeneratedApiDefinition&quot;]
-                module_src_data_apis_ts --&gt; export_GeneratedApiDefinition
-                export_GeneratedApiDefinition -.-&gt; export_DatabaseAdapterRef
-                export_GeneratedApiDefinition -.-&gt; export_DataContractValue
-                export_GeneratedApiDefinition -.-&gt; export_GeneratedApiAuthRequirement
-                export_GeneratedApiDefinition -.-&gt; export_GeneratedApiResourceDefinition
-                export_GeneratedApiId[&quot;GeneratedApiId&quot;] module_src_data_apis_ts --&gt;
-                export_GeneratedApiId
-                export_GeneratedApiOperationPolicyRef[&quot;GeneratedApiOperationPolicyRef&quot;]
-                module_src_data_apis_ts --&gt; export_GeneratedApiOperationPolicyRef
-                export_GeneratedApiRegistry[&quot;GeneratedApiRegistry&quot;]
-                module_src_data_apis_ts --&gt; export_GeneratedApiRegistry
-                export_GeneratedApiResourceDefinition[&quot;GeneratedApiResourceDefinition&quot;]
-                module_src_data_apis_ts --&gt; export_GeneratedApiResourceDefinition
-                export_GeneratedApiResourceDefinition -.-&gt; export_DataContractValue
-                export_GeneratedApiResourceDefinition -.-&gt; export_DbCollectionDefinition
-                export_GeneratedApiResourceDefinition -.-&gt; export_GeneratedApiOperationPolicyRef
-                export_GeneratedApiResourceId[&quot;GeneratedApiResourceId&quot;]
-                module_src_data_apis_ts --&gt; export_GeneratedApiResourceId
-                export_GeneratedApiSeedRecord[&quot;GeneratedApiSeedRecord&quot;]
-                module_src_data_apis_ts --&gt; export_GeneratedApiSeedRecord
-                export_GeneratedRestApiDataSourceConfig[&quot;GeneratedRestApiDataSourceConfig&quot;]
-                module_src_data_sources_ts --&gt; export_GeneratedRestApiDataSourceConfig
-                export_GeneratedRestApiDataSourceConfig -.-&gt; export_CredentialRef
-                export_GeneratedRestApiDataSourceConfig -.-&gt; export_DatabaseAdapterRef
-                export_GeneratedRestApiDataSourceConfig -.-&gt; export_DataContractValue
-                export_GeneratedRestApiDataSourceConfig -.-&gt; export_DataEndpointConfig
-                export_GeneratedRestApiDataSourceConfig -.-&gt; export_DataSchema
+                export_GraphQlIntrospectionConfig[&quot;GraphQlIntrospectionConfig&quot;]
+                module_src_data_apis_ts --&gt; export_GraphQlIntrospectionConfig
                 export_IconSpec[&quot;IconSpec&quot;] module_src_types_ts --&gt; export_IconSpec
                 export_ImageAssetSource[&quot;ImageAssetSource&quot;] module_src_storage_ts --&gt;
                 export_ImageAssetSource export_ImageMetadata[&quot;ImageMetadata&quot;]
                 module_src_storage_ts --&gt; export_ImageMetadata
                 export_InfraManifest[&quot;InfraManifest&quot;] module_src_types_ts --&gt;
-                export_InfraManifest export_InfraManifest -.-&gt; export_AuthSpec
-                export_InfraManifest -.-&gt; export_DatabaseSpec export_InfraManifest -.-&gt;
-                export_DeploymentSpec export_InfraManifest -.-&gt; export_InfraSecretStoreSpec
-                export_InfraManifest -.-&gt; export_NetworkingSpec export_InfraManifest -.-&gt;
-                export_StateSpec export_InfraManifest -.-&gt; export_StorageSpec
+                export_InfraManifest export_InfraManifest -.-&gt; export_ApiDefinitionList
+                export_InfraManifest -.-&gt; export_AuthSpec export_InfraManifest -.-&gt;
+                export_DatabaseSpec export_InfraManifest -.-&gt; export_DeploymentSpec
+                export_InfraManifest -.-&gt; export_InfraSecretStoreSpec export_InfraManifest
+                -.-&gt; export_NetworkingSpec export_InfraManifest -.-&gt; export_StateSpec
+                export_InfraManifest -.-&gt; export_StorageSpec
                 export_InfraSecretStoreSpec[&quot;InfraSecretStoreSpec&quot;]
                 module_src_secretManifest_ts --&gt; export_InfraSecretStoreSpec
                 export_InfraSecretStoreSpec -.-&gt; export_SecretStoreProvider
+                export_InternalRestApiDefinition[&quot;InternalRestApiDefinition&quot;]
+                module_src_data_apis_ts --&gt; export_InternalRestApiDefinition
+                export_InternalRestApiDefinition -.-&gt; export_CredentialRef
+                export_InternalRestApiDefinition -.-&gt; export_DataContractValue
+                export_InternalRestApiDefinition -.-&gt; export_DataEndpointConfig
+                export_InternalRestApiDefinition -.-&gt; export_DataSchema
                 export_isAppDeployManifest[&quot;isAppDeployManifest&quot;]
                 module_src_appManifest_deploy_ts --&gt; export_isAppDeployManifest
                 export_isAppManifest[&quot;isAppManifest&quot;] module_src_appManifest_ts --&gt;
@@ -16503,7 +16034,7 @@ graph LR
                 export_normalizeSecretScope[&quot;normalizeSecretScope&quot;] module_src_secrets_ts
                 --&gt; export_normalizeSecretScope export_normalizeSecretScope -.-&gt;
                 export_SecretScope export_normalizeSecretScope -.-&gt; export_SecretStoreResult
-                export_OpenApiDocumentRef[&quot;OpenApiDocumentRef&quot;] module_src_data_sources_ts
+                export_OpenApiDocumentRef[&quot;OpenApiDocumentRef&quot;] module_src_data_apis_ts
                 --&gt; export_OpenApiDocumentRef export_OperationId[&quot;OperationId&quot;]
                 module_src_data_ids_ts --&gt; export_OperationId
                 export_OperationScreenDataLoaderDefinition[&quot;OperationScreenDataLoaderDefinition&quot;]
@@ -16819,10 +16350,11 @@ graph LR
                 <pre>
 graph LR
   module_src_appManifest_ts[&quot;src/appManifest.ts&quot;]
+  module_src_appManifest_apis_ts[&quot;src/appManifest/apis.ts&quot;]
   module_src_appManifest_bindings_ts[&quot;src/appManifest/bindings.ts&quot;]
+  module_src_appManifest_data_ts[&quot;src/appManifest/data.ts&quot;]
   module_src_appManifest_dataSources_ts[&quot;src/appManifest/dataSources.ts&quot;]
   module_src_appManifest_deploy_ts[&quot;src/appManifest/deploy.ts&quot;]
-  module_src_appManifest_generatedApis_ts[&quot;src/appManifest/generatedApis.ts&quot;]
   module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
   module_src_appManifest_media_ts[&quot;src/appManifest/media.ts&quot;]
   module_src_appManifest_screens_ts[&quot;src/appManifest/screens.ts&quot;]
@@ -16888,20 +16420,24 @@ graph LR
   module_src_cli_index_ts --&gt; export_AnkhPackageMetadata
   export_AnkhProviderReference[&quot;AnkhProviderReference&quot;]
   module_src_cli_index_ts --&gt; export_AnkhProviderReference
-  export_ApiDataSourceBaseConfig[&quot;ApiDataSourceBaseConfig&quot;]
-  module_src_data_sources_ts --&gt; export_ApiDataSourceBaseConfig
-  export_ApiDataSourceBaseConfig -.-&gt; export_ApiOrigin
-  export_ApiDataSourceBaseConfig -.-&gt; export_ApiProtocol
-  export_ApiDataSourceBaseConfig -.-&gt; export_CredentialRef
-  export_ApiDataSourceBaseConfig -.-&gt; export_DataContractValue
-  export_ApiDataSourceBaseConfig -.-&gt; export_DataEndpointConfig
-  export_ApiDataSourceBaseConfig -.-&gt; export_DataSchema
-  export_ApiDataSourceConfig[&quot;ApiDataSourceConfig&quot;]
-  module_src_data_sources_ts --&gt; export_ApiDataSourceConfig
+  export_ApiBaseDefinition[&quot;ApiBaseDefinition&quot;]
+  module_src_data_apis_ts --&gt; export_ApiBaseDefinition
+  export_ApiBaseDefinition -.-&gt; export_ApiOrigin
+  export_ApiBaseDefinition -.-&gt; export_ApiProtocol
+  export_ApiBaseDefinition -.-&gt; export_CredentialRef
+  export_ApiBaseDefinition -.-&gt; export_DataContractValue
+  export_ApiBaseDefinition -.-&gt; export_DataEndpointConfig
+  export_ApiBaseDefinition -.-&gt; export_DataSchema
+  export_ApiDefinition[&quot;ApiDefinition&quot;]
+  module_src_data_apis_ts --&gt; export_ApiDefinition
+  export_ApiDefinitionList[&quot;ApiDefinitionList&quot;]
+  module_src_data_apis_ts --&gt; export_ApiDefinitionList
+  export_ApiId[&quot;ApiId&quot;]
+  module_src_data_ids_ts --&gt; export_ApiId
   export_ApiOrigin[&quot;ApiOrigin&quot;]
-  module_src_data_sources_ts --&gt; export_ApiOrigin
+  module_src_data_apis_ts --&gt; export_ApiOrigin
   export_ApiProtocol[&quot;ApiProtocol&quot;]
-  module_src_data_sources_ts --&gt; export_ApiProtocol
+  module_src_data_apis_ts --&gt; export_ApiProtocol
   export_APP_CATEGORIES[&quot;APP_CATEGORIES&quot;]
   module_src_types_ts --&gt; export_APP_CATEGORIES
   export_APP_DEPLOY_ENVIRONMENT_IDS[&quot;APP_DEPLOY_ENVIRONMENT_IDS&quot;]
@@ -16939,8 +16475,7 @@ graph LR
   export_AppManifest -.-&gt; export_AppDeployManifest
   export_AppManifest -.-&gt; export_AppSettings
   export_AppManifest -.-&gt; export_ComponentDataBinding
-  export_AppManifest -.-&gt; export_DataSourceConfig
-  export_AppManifest -.-&gt; export_GeneratedApiDefinition
+  export_AppManifest -.-&gt; export_DatabaseDataSourceConfig
   export_AppManifest -.-&gt; export_InfraManifest
   export_AppManifest -.-&gt; export_MediaManifest
   export_AppManifest -.-&gt; export_NavigatorSpec
@@ -17309,13 +16844,6 @@ graph LR
   module_src_data_schemas_ts --&gt; export_DataSchemaSlot
   export_DataSchemaSlot -.-&gt; export_DataSchema
   export_DataSchemaSlot -.-&gt; export_DataSchemaRef
-  export_DataSourceBaseConfig[&quot;DataSourceBaseConfig&quot;]
-  module_src_data_sources_ts --&gt; export_DataSourceBaseConfig
-  export_DataSourceBaseConfig -.-&gt; export_CredentialRef
-  export_DataSourceBaseConfig -.-&gt; export_DataContractValue
-  export_DataSourceBaseConfig -.-&gt; export_DataEndpointConfig
-  export_DataSourceBaseConfig -.-&gt; export_DataSchema
-  export_DataSourceBaseConfig -.-&gt; export_DataSourceKind
   export_DataSourceConfig[&quot;DataSourceConfig&quot;]
   module_src_data_sources_ts --&gt; export_DataSourceConfig
   export_DataSourceDiagnostic[&quot;DataSourceDiagnostic&quot;]
@@ -17437,19 +16965,20 @@ graph LR
   export_EventBinding -.-&gt; export_EventBindingTarget
   export_EventBindingTarget[&quot;EventBindingTarget&quot;]
   module_src_bindings_ts --&gt; export_EventBindingTarget
-  export_ExternalGraphQlApiDataSourceConfig[&quot;ExternalGraphQlApiDataSourceConfig&quot;]
-  module_src_data_sources_ts --&gt; export_ExternalGraphQlApiDataSourceConfig
-  export_ExternalGraphQlApiDataSourceConfig -.-&gt; export_CredentialRef
-  export_ExternalGraphQlApiDataSourceConfig -.-&gt; export_DataContractValue
-  export_ExternalGraphQlApiDataSourceConfig -.-&gt; export_DataEndpointConfig
-  export_ExternalGraphQlApiDataSourceConfig -.-&gt; export_DataSchema
-  export_ExternalRestApiDataSourceConfig[&quot;ExternalRestApiDataSourceConfig&quot;]
-  module_src_data_sources_ts --&gt; export_ExternalRestApiDataSourceConfig
-  export_ExternalRestApiDataSourceConfig -.-&gt; export_CredentialRef
-  export_ExternalRestApiDataSourceConfig -.-&gt; export_DataContractValue
-  export_ExternalRestApiDataSourceConfig -.-&gt; export_DataEndpointConfig
-  export_ExternalRestApiDataSourceConfig -.-&gt; export_DataSchema
-  export_ExternalRestApiDataSourceConfig -.-&gt; export_OpenApiDocumentRef
+  export_ExternalGraphQlApiDefinition[&quot;ExternalGraphQlApiDefinition&quot;]
+  module_src_data_apis_ts --&gt; export_ExternalGraphQlApiDefinition
+  export_ExternalGraphQlApiDefinition -.-&gt; export_CredentialRef
+  export_ExternalGraphQlApiDefinition -.-&gt; export_DataContractValue
+  export_ExternalGraphQlApiDefinition -.-&gt; export_DataEndpointConfig
+  export_ExternalGraphQlApiDefinition -.-&gt; export_DataSchema
+  export_ExternalGraphQlApiDefinition -.-&gt; export_GraphQlIntrospectionConfig
+  export_ExternalRestApiDefinition[&quot;ExternalRestApiDefinition&quot;]
+  module_src_data_apis_ts --&gt; export_ExternalRestApiDefinition
+  export_ExternalRestApiDefinition -.-&gt; export_CredentialRef
+  export_ExternalRestApiDefinition -.-&gt; export_DataContractValue
+  export_ExternalRestApiDefinition -.-&gt; export_DataEndpointConfig
+  export_ExternalRestApiDefinition -.-&gt; export_DataSchema
+  export_ExternalRestApiDefinition -.-&gt; export_OpenApiDocumentRef
   export_FilterAction[&quot;FilterAction&quot;]
   module_src_types_ts --&gt; export_FilterAction
   export_findForbiddenInlineSecretFields[&quot;findForbiddenInlineSecretFields&quot;]
@@ -17460,41 +16989,8 @@ graph LR
   module_src_types_ts --&gt; export_FormSubmitEventDto
   export_FormSubmitValues[&quot;FormSubmitValues&quot;]
   module_src_types_ts --&gt; export_FormSubmitValues
-  export_GENERATED_API_CRUD_OPERATIONS[&quot;GENERATED_API_CRUD_OPERATIONS&quot;]
-  module_src_data_apis_ts --&gt; export_GENERATED_API_CRUD_OPERATIONS
-  export_GeneratedApiAuthRequirement[&quot;GeneratedApiAuthRequirement&quot;]
-  module_src_data_apis_ts --&gt; export_GeneratedApiAuthRequirement
-  export_GeneratedApiAuthRequirement -.-&gt; export_DataContractValue
-  export_GeneratedApiCrudOperation[&quot;GeneratedApiCrudOperation&quot;]
-  module_src_data_apis_ts --&gt; export_GeneratedApiCrudOperation
-  export_GeneratedApiDefinition[&quot;GeneratedApiDefinition&quot;]
-  module_src_data_apis_ts --&gt; export_GeneratedApiDefinition
-  export_GeneratedApiDefinition -.-&gt; export_DatabaseAdapterRef
-  export_GeneratedApiDefinition -.-&gt; export_DataContractValue
-  export_GeneratedApiDefinition -.-&gt; export_GeneratedApiAuthRequirement
-  export_GeneratedApiDefinition -.-&gt; export_GeneratedApiResourceDefinition
-  export_GeneratedApiId[&quot;GeneratedApiId&quot;]
-  module_src_data_apis_ts --&gt; export_GeneratedApiId
-  export_GeneratedApiOperationPolicyRef[&quot;GeneratedApiOperationPolicyRef&quot;]
-  module_src_data_apis_ts --&gt; export_GeneratedApiOperationPolicyRef
-  export_GeneratedApiRegistry[&quot;GeneratedApiRegistry&quot;]
-  module_src_data_apis_ts --&gt; export_GeneratedApiRegistry
-  export_GeneratedApiResourceDefinition[&quot;GeneratedApiResourceDefinition&quot;]
-  module_src_data_apis_ts --&gt; export_GeneratedApiResourceDefinition
-  export_GeneratedApiResourceDefinition -.-&gt; export_DataContractValue
-  export_GeneratedApiResourceDefinition -.-&gt; export_DbCollectionDefinition
-  export_GeneratedApiResourceDefinition -.-&gt; export_GeneratedApiOperationPolicyRef
-  export_GeneratedApiResourceId[&quot;GeneratedApiResourceId&quot;]
-  module_src_data_apis_ts --&gt; export_GeneratedApiResourceId
-  export_GeneratedApiSeedRecord[&quot;GeneratedApiSeedRecord&quot;]
-  module_src_data_apis_ts --&gt; export_GeneratedApiSeedRecord
-  export_GeneratedRestApiDataSourceConfig[&quot;GeneratedRestApiDataSourceConfig&quot;]
-  module_src_data_sources_ts --&gt; export_GeneratedRestApiDataSourceConfig
-  export_GeneratedRestApiDataSourceConfig -.-&gt; export_CredentialRef
-  export_GeneratedRestApiDataSourceConfig -.-&gt; export_DatabaseAdapterRef
-  export_GeneratedRestApiDataSourceConfig -.-&gt; export_DataContractValue
-  export_GeneratedRestApiDataSourceConfig -.-&gt; export_DataEndpointConfig
-  export_GeneratedRestApiDataSourceConfig -.-&gt; export_DataSchema
+  export_GraphQlIntrospectionConfig[&quot;GraphQlIntrospectionConfig&quot;]
+  module_src_data_apis_ts --&gt; export_GraphQlIntrospectionConfig
   export_IconSpec[&quot;IconSpec&quot;]
   module_src_types_ts --&gt; export_IconSpec
   export_ImageAssetSource[&quot;ImageAssetSource&quot;]
@@ -17503,6 +16999,7 @@ graph LR
   module_src_storage_ts --&gt; export_ImageMetadata
   export_InfraManifest[&quot;InfraManifest&quot;]
   module_src_types_ts --&gt; export_InfraManifest
+  export_InfraManifest -.-&gt; export_ApiDefinitionList
   export_InfraManifest -.-&gt; export_AuthSpec
   export_InfraManifest -.-&gt; export_DatabaseSpec
   export_InfraManifest -.-&gt; export_DeploymentSpec
@@ -17513,6 +17010,12 @@ graph LR
   export_InfraSecretStoreSpec[&quot;InfraSecretStoreSpec&quot;]
   module_src_secretManifest_ts --&gt; export_InfraSecretStoreSpec
   export_InfraSecretStoreSpec -.-&gt; export_SecretStoreProvider
+  export_InternalRestApiDefinition[&quot;InternalRestApiDefinition&quot;]
+  module_src_data_apis_ts --&gt; export_InternalRestApiDefinition
+  export_InternalRestApiDefinition -.-&gt; export_CredentialRef
+  export_InternalRestApiDefinition -.-&gt; export_DataContractValue
+  export_InternalRestApiDefinition -.-&gt; export_DataEndpointConfig
+  export_InternalRestApiDefinition -.-&gt; export_DataSchema
   export_isAppDeployManifest[&quot;isAppDeployManifest&quot;]
   module_src_appManifest_deploy_ts --&gt; export_isAppDeployManifest
   export_isAppManifest[&quot;isAppManifest&quot;]
@@ -17599,7 +17102,7 @@ graph LR
   export_normalizeSecretScope -.-&gt; export_SecretScope
   export_normalizeSecretScope -.-&gt; export_SecretStoreResult
   export_OpenApiDocumentRef[&quot;OpenApiDocumentRef&quot;]
-  module_src_data_sources_ts --&gt; export_OpenApiDocumentRef
+  module_src_data_apis_ts --&gt; export_OpenApiDocumentRef
   export_OperationId[&quot;OperationId&quot;]
   module_src_data_ids_ts --&gt; export_OperationId
   export_OperationScreenDataLoaderDefinition[&quot;OperationScreenDataLoaderDefinition&quot;]
@@ -17969,27 +17472,87 @@ graph LR
             <h2>src/appManifest.ts</h2>
             <article class="item" data-search="parseAppManifest src/appManifest.ts ">
               <h3>parseAppManifest</h3>
-              <p class="muted"><code>src/appManifest.ts:45:1</code></p>
+              <p class="muted"><code>src/appManifest.ts:43:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAppManifest src/appManifest.ts ">
               <h3>isAppManifest</h3>
-              <p class="muted"><code>src/appManifest.ts:52:1</code></p>
+              <p class="muted"><code>src/appManifest.ts:50:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="hasRequiredManifestKeys src/appManifest.ts ">
               <h3>hasRequiredManifestKeys</h3>
-              <p class="muted"><code>src/appManifest.ts:74:1</code></p>
+              <p class="muted"><code>src/appManifest.ts:72:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isActiveThemeMode src/appManifest.ts ">
               <h3>isActiveThemeMode</h3>
-              <p class="muted"><code>src/appManifest.ts:80:1</code></p>
+              <p class="muted"><code>src/appManifest.ts:78:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAppSettings src/appManifest.ts ">
               <h3>isAppSettings</h3>
-              <p class="muted"><code>src/appManifest.ts:84:1</code></p>
+              <p class="muted"><code>src/appManifest.ts:82:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+          </section>
+        </section>
+        <section
+          id="view-src-appmanifest-apis-ts"
+          class="view"
+          data-view="src/appManifest/apis.ts"
+          hidden
+        >
+          <section class="panel">
+            <h2>src/appManifest/apis.ts</h2>
+            <article class="item" data-search="isApiDefinitionList src/appManifest/apis.ts ">
+              <h3>isApiDefinitionList</h3>
+              <p class="muted"><code>src/appManifest/apis.ts:22:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isApiDefinition src/appManifest/apis.ts ">
+              <h3>isApiDefinition</h3>
+              <p class="muted"><code>src/appManifest/apis.ts:28:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isApiBaseDefinition src/appManifest/apis.ts ">
+              <h3>isApiBaseDefinition</h3>
+              <p class="muted"><code>src/appManifest/apis.ts:38:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isExternalRestApi src/appManifest/apis.ts ">
+              <h3>isExternalRestApi</h3>
+              <p class="muted"><code>src/appManifest/apis.ts:53:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isExternalGraphQlApi src/appManifest/apis.ts ">
+              <h3>isExternalGraphQlApi</h3>
+              <p class="muted"><code>src/appManifest/apis.ts:61:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isInternalRestApi src/appManifest/apis.ts ">
+              <h3>isInternalRestApi</h3>
+              <p class="muted"><code>src/appManifest/apis.ts:69:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isOpenApiDocumentRef src/appManifest/apis.ts ">
+              <h3>isOpenApiDocumentRef</h3>
+              <p class="muted"><code>src/appManifest/apis.ts:73:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isGraphQlIntrospection src/appManifest/apis.ts ">
+              <h3>isGraphQlIntrospection</h3>
+              <p class="muted"><code>src/appManifest/apis.ts:83:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isNonEmptyString src/appManifest/apis.ts ">
+              <h3>isNonEmptyString</h3>
+              <p class="muted"><code>src/appManifest/apis.ts:92:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="hasOnlyKeys src/appManifest/apis.ts ">
+              <h3>hasOnlyKeys</h3>
+              <p class="muted"><code>src/appManifest/apis.ts:96:1</code></p>
               <p class="empty">No description available.</p>
             </article>
           </section>
@@ -18087,6 +17650,102 @@ graph LR
           </section>
         </section>
         <section
+          id="view-src-appmanifest-data-ts"
+          class="view"
+          data-view="src/appManifest/data.ts"
+          hidden
+        >
+          <section class="panel">
+            <h2>src/appManifest/data.ts</h2>
+            <article class="item" data-search="isDataEndpointRegistry src/appManifest/data.ts ">
+              <h3>isDataEndpointRegistry</h3>
+              <p class="muted"><code>src/appManifest/data.ts:21:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isDataSchemaRegistry src/appManifest/data.ts ">
+              <h3>isDataSchemaRegistry</h3>
+              <p class="muted"><code>src/appManifest/data.ts:25:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isCredentialRef src/appManifest/data.ts ">
+              <h3>isCredentialRef</h3>
+              <p class="muted"><code>src/appManifest/data.ts:29:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isAdapterRef src/appManifest/data.ts ">
+              <h3>isAdapterRef</h3>
+              <p class="muted"><code>src/appManifest/data.ts:39:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isDataEndpointConfig src/appManifest/data.ts ">
+              <h3>isDataEndpointConfig</h3>
+              <p class="muted"><code>src/appManifest/data.ts:50:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isDataOperationConfig src/appManifest/data.ts ">
+              <h3>isDataOperationConfig</h3>
+              <p class="muted"><code>src/appManifest/data.ts:66:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isDataOperationRequest src/appManifest/data.ts ">
+              <h3>isDataOperationRequest</h3>
+              <p class="muted"><code>src/appManifest/data.ts:86:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isDataOperationParameter src/appManifest/data.ts ">
+              <h3>isDataOperationParameter</h3>
+              <p class="muted"><code>src/appManifest/data.ts:96:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isDataOperationResponse src/appManifest/data.ts ">
+              <h3>isDataOperationResponse</h3>
+              <p class="muted"><code>src/appManifest/data.ts:109:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isDataSchemaSlot src/appManifest/data.ts ">
+              <h3>isDataSchemaSlot</h3>
+              <p class="muted"><code>src/appManifest/data.ts:121:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isDataSchema src/appManifest/data.ts ">
+              <h3>isDataSchema</h3>
+              <p class="muted"><code>src/appManifest/data.ts:128:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isDataSchemaType src/appManifest/data.ts ">
+              <h3>isDataSchemaType</h3>
+              <p class="muted"><code>src/appManifest/data.ts:135:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isOptionalSchemaScalars src/appManifest/data.ts ">
+              <h3>isOptionalSchemaScalars</h3>
+              <p class="muted"><code>src/appManifest/data.ts:144:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isOptionalSchemaCollections src/appManifest/data.ts "
+            >
+              <h3>isOptionalSchemaCollections</h3>
+              <p class="muted"><code>src/appManifest/data.ts:158:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isOptionalSchemaComposition src/appManifest/data.ts "
+            >
+              <h3>isOptionalSchemaComposition</h3>
+              <p class="muted"><code>src/appManifest/data.ts:170:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isDataSchemaRef src/appManifest/data.ts ">
+              <h3>isDataSchemaRef</h3>
+              <p class="muted"><code>src/appManifest/data.ts:177:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+          </section>
+        </section>
+        <section
           id="view-src-appmanifest-datasources-ts"
           class="view"
           data-view="src/appManifest/dataSources.ts"
@@ -18099,20 +17758,7 @@ graph LR
               data-search="isDataSourceRegistry src/appManifest/dataSources.ts "
             >
               <h3>isDataSourceRegistry</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:3:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isDataSourceConfig src/appManifest/dataSources.ts ">
-              <h3>isDataSourceConfig</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:7:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="hasBaseDataSourceShape src/appManifest/dataSources.ts "
-            >
-              <h3>hasBaseDataSourceShape</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:15:1</code></p>
+              <p class="muted"><code>src/appManifest/dataSources.ts:21:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article
@@ -18120,102 +17766,12 @@ graph LR
               data-search="isDatabaseDataSource src/appManifest/dataSources.ts "
             >
               <h3>isDatabaseDataSource</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:29:1</code></p>
+              <p class="muted"><code>src/appManifest/dataSources.ts:28:1</code></p>
               <p class="empty">No description available.</p>
             </article>
-            <article
-              class="item"
-              data-search="isGeneratedDataSource src/appManifest/dataSources.ts "
-            >
-              <h3>isGeneratedDataSource</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:35:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isExternalDataSource src/appManifest/dataSources.ts "
-            >
-              <h3>isExternalDataSource</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:45:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isOpenApiDocumentRef src/appManifest/dataSources.ts "
-            >
-              <h3>isOpenApiDocumentRef</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:63:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isGraphQlIntrospection src/appManifest/dataSources.ts "
-            >
-              <h3>isGraphQlIntrospection</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:72:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isDataEndpointRegistry src/appManifest/dataSources.ts "
-            >
-              <h3>isDataEndpointRegistry</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:78:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isDataEndpointConfig src/appManifest/dataSources.ts "
-            >
-              <h3>isDataEndpointConfig</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:82:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isDataOperationConfig src/appManifest/dataSources.ts "
-            >
-              <h3>isDataOperationConfig</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:98:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isDataOperationRequest src/appManifest/dataSources.ts "
-            >
-              <h3>isDataOperationRequest</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:118:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isDataOperationParameter src/appManifest/dataSources.ts "
-            >
-              <h3>isDataOperationParameter</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:127:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isDataOperationResponse src/appManifest/dataSources.ts "
-            >
-              <h3>isDataOperationResponse</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:140:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isDataSchemaSlot src/appManifest/dataSources.ts ">
-              <h3>isDataSchemaSlot</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:152:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isCredentialRef src/appManifest/dataSources.ts ">
-              <h3>isCredentialRef</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:156:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isAdapterRef src/appManifest/dataSources.ts ">
-              <h3>isAdapterRef</h3>
-              <p class="muted"><code>src/appManifest/dataSources.ts:166:1</code></p>
+            <article class="item" data-search="hasOnlyKeys src/appManifest/dataSources.ts ">
+              <h3>hasOnlyKeys</h3>
+              <p class="muted"><code>src/appManifest/dataSources.ts:46:1</code></p>
               <p class="empty">No description available.</p>
             </article>
           </section>
@@ -18281,103 +17837,6 @@ graph LR
           </section>
         </section>
         <section
-          id="view-src-appmanifest-generatedapis-ts"
-          class="view"
-          data-view="src/appManifest/generatedApis.ts"
-          hidden
-        >
-          <section class="panel">
-            <h2>src/appManifest/generatedApis.ts</h2>
-            <article
-              class="item"
-              data-search="isGeneratedApiRegistry src/appManifest/generatedApis.ts "
-            >
-              <h3>isGeneratedApiRegistry</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:9:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isGeneratedApiDefinition src/appManifest/generatedApis.ts "
-            >
-              <h3>isGeneratedApiDefinition</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:13:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isDatabaseAdapterRef src/appManifest/generatedApis.ts "
-            >
-              <h3>isDatabaseAdapterRef</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:29:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isGeneratedApiAuthRequirement src/appManifest/generatedApis.ts "
-            >
-              <h3>isGeneratedApiAuthRequirement</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:33:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isGeneratedApiResourceDefinition src/appManifest/generatedApis.ts "
-            >
-              <h3>isGeneratedApiResourceDefinition</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:44:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isSeedRecords src/appManifest/generatedApis.ts ">
-              <h3>isSeedRecords</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:61:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isGeneratedApiCrudOperation src/appManifest/generatedApis.ts "
-            >
-              <h3>isGeneratedApiCrudOperation</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:68:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isGeneratedApiPolicyRef src/appManifest/generatedApis.ts "
-            >
-              <h3>isGeneratedApiPolicyRef</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:72:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isDbCollectionDefinition src/appManifest/generatedApis.ts "
-            >
-              <h3>isDbCollectionDefinition</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:80:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article
-              class="item"
-              data-search="isDbFieldDefinition src/appManifest/generatedApis.ts "
-            >
-              <h3>isDbFieldDefinition</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:91:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isDbDefaultValue src/appManifest/generatedApis.ts ">
-              <h3>isDbDefaultValue</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:103:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isAdapterRef src/appManifest/generatedApis.ts ">
-              <h3>isAdapterRef</h3>
-              <p class="muted"><code>src/appManifest/generatedApis.ts:113:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-          </section>
-        </section>
-        <section
           id="view-src-appmanifest-infra-ts"
           class="view"
           data-view="src/appManifest/infra.ts"
@@ -18387,77 +17846,77 @@ graph LR
             <h2>src/appManifest/infra.ts</h2>
             <article class="item" data-search="isInfraManifest src/appManifest/infra.ts ">
               <h3>isInfraManifest</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:36:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:37:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isDeploymentSpec src/appManifest/infra.ts ">
               <h3>isDeploymentSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:53:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:55:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isDatabaseSpec src/appManifest/infra.ts ">
               <h3>isDatabaseSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:59:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:61:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isStorageSpec src/appManifest/infra.ts ">
               <h3>isStorageSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:68:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:70:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isStateSpec src/appManifest/infra.ts ">
               <h3>isStateSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:77:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:79:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isNetworkingSpec src/appManifest/infra.ts ">
               <h3>isNetworkingSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:86:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:88:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthSpec src/appManifest/infra.ts ">
               <h3>isAuthSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:90:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:92:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthzSpec src/appManifest/infra.ts ">
               <h3>isAuthzSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:105:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:107:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthFlow src/appManifest/infra.ts ">
               <h3>isAuthFlow</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:115:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:117:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthSignInSpec src/appManifest/infra.ts ">
               <h3>isAuthSignInSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:128:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:130:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthSignUpSpec src/appManifest/infra.ts ">
               <h3>isAuthSignUpSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:138:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:140:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthOAuthConfig src/appManifest/infra.ts ">
               <h3>isAuthOAuthConfig</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:148:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:150:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthOAuthProviderConfig src/appManifest/infra.ts ">
               <h3>isAuthOAuthProviderConfig</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:158:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:160:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthProfileSpec src/appManifest/infra.ts ">
               <h3>isAuthProfileSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:172:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:174:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isIconSpec src/appManifest/infra.ts ">
               <h3>isIconSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:189:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:191:1</code></p>
               <p class="empty">No description available.</p>
             </article>
           </section>

--- a/paradox/paradox.json
+++ b/paradox/paradox.json
@@ -12,7 +12,7 @@
     {
       "id": "npm",
       "label": "npm",
-      "value": "v7.8.0",
+      "value": "v8.0.0",
       "color": "cb3837"
     },
     {
@@ -59,7 +59,10 @@
     }
   ],
   "usage": null,
+  "readmeUsageDescription": null,
   "readmeUsage": [],
+  "readmeCli": null,
+  "readmeConfig": null,
   "config": null,
   "entrypoints": ["src/index.ts"],
   "modules": [
@@ -70,7 +73,6 @@
         "src/appManifest/bindings.ts",
         "src/appManifest/dataSources.ts",
         "src/appManifest/deploy.ts",
-        "src/appManifest/generatedApis.ts",
         "src/appManifest/infra.ts",
         "src/appManifest/media.ts",
         "src/appManifest/screens.ts",
@@ -78,6 +80,12 @@
         "src/types.ts"
       ],
       "exports": ["AppManifestParseResult", "isAppManifest", "parseAppManifest"]
+    },
+    {
+      "path": "src/appManifest/apis.ts",
+      "isEntrypoint": false,
+      "dependencies": ["src/appManifest/data.ts", "src/appManifest/shared.ts", "src/data/index.ts"],
+      "exports": ["isApiDefinitionList"]
     },
     {
       "path": "src/appManifest/bindings.ts",
@@ -90,9 +98,20 @@
       ]
     },
     {
-      "path": "src/appManifest/dataSources.ts",
+      "path": "src/appManifest/data.ts",
       "isEntrypoint": false,
       "dependencies": ["src/appManifest/shared.ts"],
+      "exports": [
+        "isAdapterRef",
+        "isCredentialRef",
+        "isDataEndpointRegistry",
+        "isDataSchemaRegistry"
+      ]
+    },
+    {
+      "path": "src/appManifest/dataSources.ts",
+      "isEntrypoint": false,
+      "dependencies": ["src/appManifest/data.ts", "src/appManifest/shared.ts"],
       "exports": ["isDataSourceRegistry"]
     },
     {
@@ -102,15 +121,14 @@
       "exports": ["isAppDeployManifest"]
     },
     {
-      "path": "src/appManifest/generatedApis.ts",
-      "isEntrypoint": false,
-      "dependencies": ["src/appManifest/shared.ts"],
-      "exports": ["isGeneratedApiRegistry"]
-    },
-    {
       "path": "src/appManifest/infra.ts",
       "isEntrypoint": false,
-      "dependencies": ["src/appManifest/shared.ts", "src/auth.ts", "src/types.ts"],
+      "dependencies": [
+        "src/appManifest/apis.ts",
+        "src/appManifest/shared.ts",
+        "src/auth.ts",
+        "src/types.ts"
+      ],
       "exports": ["isInfraManifest"]
     },
     {
@@ -259,18 +277,24 @@
     {
       "path": "src/data/apis.ts",
       "isEntrypoint": false,
-      "dependencies": ["src/data/refs.ts", "src/data/values.ts", "src/db.ts"],
+      "dependencies": [
+        "src/data/endpoints.ts",
+        "src/data/ids.ts",
+        "src/data/refs.ts",
+        "src/data/schemas.ts",
+        "src/data/values.ts"
+      ],
       "exports": [
-        "GENERATED_API_CRUD_OPERATIONS",
-        "GeneratedApiAuthRequirement",
-        "GeneratedApiCrudOperation",
-        "GeneratedApiDefinition",
-        "GeneratedApiId",
-        "GeneratedApiOperationPolicyRef",
-        "GeneratedApiRegistry",
-        "GeneratedApiResourceDefinition",
-        "GeneratedApiResourceId",
-        "GeneratedApiSeedRecord"
+        "ApiBaseDefinition",
+        "ApiDefinition",
+        "ApiDefinitionList",
+        "ApiOrigin",
+        "ApiProtocol",
+        "ExternalGraphQlApiDefinition",
+        "ExternalRestApiDefinition",
+        "GraphQlIntrospectionConfig",
+        "InternalRestApiDefinition",
+        "OpenApiDocumentRef"
       ]
     },
     {
@@ -301,6 +325,7 @@
       "dependencies": [],
       "exports": [
         "AdapterId",
+        "ApiId",
         "CredentialId",
         "DataSourceId",
         "EndpointId",
@@ -316,8 +341,10 @@
         "AdapterId",
         "AdapterKind",
         "AdapterRef",
-        "ApiDataSourceBaseConfig",
-        "ApiDataSourceConfig",
+        "ApiBaseDefinition",
+        "ApiDefinition",
+        "ApiDefinitionList",
+        "ApiId",
         "ApiOrigin",
         "ApiProtocol",
         "CredentialId",
@@ -348,7 +375,6 @@
         "DataSchemaRef",
         "DataSchemaRegistry",
         "DataSchemaSlot",
-        "DataSourceBaseConfig",
         "DataSourceConfig",
         "DataSourceDiagnostic",
         "DataSourceDiagnosticResult",
@@ -356,19 +382,10 @@
         "DataSourceKind",
         "DataSourceRegistry",
         "EndpointId",
-        "ExternalGraphQlApiDataSourceConfig",
-        "ExternalRestApiDataSourceConfig",
-        "GENERATED_API_CRUD_OPERATIONS",
-        "GeneratedApiAuthRequirement",
-        "GeneratedApiCrudOperation",
-        "GeneratedApiDefinition",
-        "GeneratedApiId",
-        "GeneratedApiOperationPolicyRef",
-        "GeneratedApiRegistry",
-        "GeneratedApiResourceDefinition",
-        "GeneratedApiResourceId",
-        "GeneratedApiSeedRecord",
-        "GeneratedRestApiDataSourceConfig",
+        "ExternalGraphQlApiDefinition",
+        "ExternalRestApiDefinition",
+        "GraphQlIntrospectionConfig",
+        "InternalRestApiDefinition",
         "OpenApiDocumentRef",
         "OperationId",
         "SchemaId"
@@ -432,19 +449,10 @@
         "src/data/values.ts"
       ],
       "exports": [
-        "ApiDataSourceBaseConfig",
-        "ApiDataSourceConfig",
-        "ApiOrigin",
-        "ApiProtocol",
         "DatabaseDataSourceConfig",
-        "DataSourceBaseConfig",
         "DataSourceConfig",
         "DataSourceKind",
-        "DataSourceRegistry",
-        "ExternalGraphQlApiDataSourceConfig",
-        "ExternalRestApiDataSourceConfig",
-        "GeneratedRestApiDataSourceConfig",
-        "OpenApiDocumentRef"
+        "DataSourceRegistry"
       ]
     },
     {
@@ -530,8 +538,10 @@
         "AnkhoragePermissionName",
         "AnkhPackageMetadata",
         "AnkhProviderReference",
-        "ApiDataSourceBaseConfig",
-        "ApiDataSourceConfig",
+        "ApiBaseDefinition",
+        "ApiDefinition",
+        "ApiDefinitionList",
+        "ApiId",
         "ApiOrigin",
         "ApiProtocol",
         "APP_CATEGORIES",
@@ -683,7 +693,6 @@
         "DataSchemaRef",
         "DataSchemaRegistry",
         "DataSchemaSlot",
-        "DataSourceBaseConfig",
         "DataSourceConfig",
         "DataSourceDiagnostic",
         "DataSourceDiagnosticResult",
@@ -728,29 +737,20 @@
         "EndpointId",
         "EventBinding",
         "EventBindingTarget",
-        "ExternalGraphQlApiDataSourceConfig",
-        "ExternalRestApiDataSourceConfig",
+        "ExternalGraphQlApiDefinition",
+        "ExternalRestApiDefinition",
         "FilterAction",
         "findForbiddenInlineSecretFields",
         "FORBIDDEN_INLINE_SECRET_FIELDS",
         "FormSubmitEventDto",
         "FormSubmitValues",
-        "GENERATED_API_CRUD_OPERATIONS",
-        "GeneratedApiAuthRequirement",
-        "GeneratedApiCrudOperation",
-        "GeneratedApiDefinition",
-        "GeneratedApiId",
-        "GeneratedApiOperationPolicyRef",
-        "GeneratedApiRegistry",
-        "GeneratedApiResourceDefinition",
-        "GeneratedApiResourceId",
-        "GeneratedApiSeedRecord",
-        "GeneratedRestApiDataSourceConfig",
+        "GraphQlIntrospectionConfig",
         "IconSpec",
         "ImageAssetSource",
         "ImageMetadata",
         "InfraManifest",
         "InfraSecretStoreSpec",
+        "InternalRestApiDefinition",
         "isAppDeployManifest",
         "isAppManifest",
         "isMediaAssetReference",
@@ -1237,7 +1237,7 @@
       "modulePath": "src/data/ids.ts",
       "sourceLocation": {
         "filePath": "src/data/ids.ts",
-        "line": 6,
+        "line": 7,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1540,7 +1540,7 @@
       "modulePath": "src/requirements.ts",
       "sourceLocation": {
         "filePath": "src/requirements.ts",
-        "line": 24,
+        "line": 25,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1626,15 +1626,15 @@
       "structuredRows": []
     },
     {
-      "name": "ApiDataSourceBaseConfig",
+      "name": "ApiBaseDefinition",
       "description": null,
       "isReadme": false,
       "examples": [],
       "kind": "type",
-      "modulePath": "src/data/sources.ts",
+      "modulePath": "src/data/apis.ts",
       "sourceLocation": {
-        "filePath": "src/data/sources.ts",
-        "line": 22,
+        "filePath": "src/data/apis.ts",
+        "line": 10,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1665,7 +1665,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -1673,13 +1673,6 @@
           "name": "id",
           "kind": "property",
           "type": "string",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "kind",
-          "kind": "property",
-          "type": "\"api\"",
           "required": true,
           "description": null
         },
@@ -1714,7 +1707,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -1722,15 +1715,51 @@
       "structuredRows": []
     },
     {
-      "name": "ApiDataSourceConfig",
+      "name": "ApiDefinition",
       "description": null,
       "isReadme": false,
       "examples": [],
       "kind": "unknown",
-      "modulePath": "src/data/sources.ts",
+      "modulePath": "src/data/apis.ts",
       "sourceLocation": {
-        "filePath": "src/data/sources.ts",
-        "line": 58,
+        "filePath": "src/data/apis.ts",
+        "line": 60,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "ApiDefinitionList",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/data/apis.ts",
+      "sourceLocation": {
+        "filePath": "src/data/apis.ts",
+        "line": 65,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "ApiId",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/data/ids.ts",
+      "sourceLocation": {
+        "filePath": "src/data/ids.ts",
+        "line": 1,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1745,10 +1774,10 @@
       "isReadme": false,
       "examples": [],
       "kind": "unknown",
-      "modulePath": "src/data/sources.ts",
+      "modulePath": "src/data/apis.ts",
       "sourceLocation": {
-        "filePath": "src/data/sources.ts",
-        "line": 8,
+        "filePath": "src/data/apis.ts",
+        "line": 7,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1763,10 +1792,10 @@
       "isReadme": false,
       "examples": [],
       "kind": "unknown",
-      "modulePath": "src/data/sources.ts",
+      "modulePath": "src/data/apis.ts",
       "sourceLocation": {
-        "filePath": "src/data/sources.ts",
-        "line": 9,
+        "filePath": "src/data/apis.ts",
+        "line": 8,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2131,8 +2160,7 @@
         "AppDeployManifest",
         "AppSettings",
         "ComponentDataBinding",
-        "DataSourceConfig",
-        "GeneratedApiDefinition",
+        "DatabaseDataSourceConfig",
         "InfraManifest",
         "MediaManifest",
         "NavigatorSpec",
@@ -2159,14 +2187,14 @@
         {
           "name": "dataBindings",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/bindings\").ComponentDataBinding>> | undefined",
+          "type": "Readonly<Record<string, import(\"./src/bindings\").ComponentDataBinding>> | undefined",
           "required": false,
           "description": null
         },
         {
           "name": "dataSources",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSourceConfig>> | undefined",
+          "type": "Readonly<Record<string, import(\"./src/index\").DatabaseDataSourceConfig>> | undefined",
           "required": false,
           "description": null
         },
@@ -2174,13 +2202,6 @@
           "name": "deploy",
           "kind": "property",
           "type": "AppDeployManifest | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "generatedApis",
-          "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").GeneratedApiDefinition>> | undefined",
           "required": false,
           "description": null
         },
@@ -2252,7 +2273,7 @@
       "modulePath": "src/appManifest.ts",
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 17,
+        "line": 16,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2270,20 +2291,13 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 381,
+        "line": 382,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
       "relatedSymbols": [],
       "signatures": [],
       "members": [
-        {
-          "name": "apiBaseUrl",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
         {
           "name": "localization",
           "kind": "property",
@@ -3840,7 +3854,7 @@
         {
           "name": "createStrategy",
           "kind": "property",
-          "type": "\"app\" | \"api\" | \"trigger\" | undefined",
+          "type": "\"app\" | \"trigger\" | \"api\" | undefined",
           "required": false,
           "description": null
         },
@@ -4717,7 +4731,7 @@
       "signatures": [],
       "members": [
         {
-          "name": "dataSourceId",
+          "name": "apiId",
           "kind": "property",
           "type": "string",
           "required": true,
@@ -5097,7 +5111,7 @@
       "modulePath": "src/requirements.ts",
       "sourceLocation": {
         "filePath": "src/requirements.ts",
-        "line": 39,
+        "line": 40,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5181,7 +5195,7 @@
       "modulePath": "src/data/ids.ts",
       "sourceLocation": {
         "filePath": "src/data/ids.ts",
-        "line": 5,
+        "line": 6,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5354,7 +5368,7 @@
       "modulePath": "src/data/sources.ts",
       "sourceLocation": {
         "filePath": "src/data/sources.ts",
-        "line": 63,
+        "line": 9,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5391,7 +5405,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -5426,7 +5440,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -6401,87 +6415,6 @@
       "structuredRows": []
     },
     {
-      "name": "DataSourceBaseConfig",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "type",
-      "modulePath": "src/data/sources.ts",
-      "sourceLocation": {
-        "filePath": "src/data/sources.ts",
-        "line": 11,
-        "column": 1
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": [
-        "CredentialRef",
-        "DataContractValue",
-        "DataEndpointConfig",
-        "DataSchema",
-        "DataSourceKind"
-      ],
-      "signatures": [],
-      "members": [
-        {
-          "name": "credential",
-          "kind": "property",
-          "type": "CredentialRef | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "description",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "endpoints",
-          "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "id",
-          "kind": "property",
-          "type": "string",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "kind",
-          "kind": "property",
-          "type": "DataSourceKind",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "metadata",
-          "kind": "property",
-          "type": "DataContractValue | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "name",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "schemas",
-          "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
-          "required": false,
-          "description": null
-        }
-      ],
-      "structuredRows": []
-    },
-    {
       "name": "DataSourceConfig",
       "description": null,
       "isReadme": false,
@@ -6490,7 +6423,7 @@
       "modulePath": "src/data/sources.ts",
       "sourceLocation": {
         "filePath": "src/data/sources.ts",
-        "line": 68,
+        "line": 21,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -6508,13 +6441,20 @@
       "modulePath": "src/data/diagnostics.ts",
       "sourceLocation": {
         "filePath": "src/data/diagnostics.ts",
-        "line": 21,
+        "line": 22,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
       "relatedSymbols": ["DataDiagnosticCode", "DataDiagnosticSeverity"],
       "signatures": [],
       "members": [
+        {
+          "name": "apiId",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
         {
           "name": "code",
           "kind": "property",
@@ -6583,7 +6523,7 @@
       "modulePath": "src/data/diagnostics.ts",
       "sourceLocation": {
         "filePath": "src/data/diagnostics.ts",
-        "line": 32,
+        "line": 34,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -6601,7 +6541,7 @@
       "modulePath": "src/data/ids.ts",
       "sourceLocation": {
         "filePath": "src/data/ids.ts",
-        "line": 1,
+        "line": 2,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -6637,7 +6577,7 @@
       "modulePath": "src/data/sources.ts",
       "sourceLocation": {
         "filePath": "src/data/sources.ts",
-        "line": 70,
+        "line": 22,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -7852,7 +7792,7 @@
       "modulePath": "src/data/ids.ts",
       "sourceLocation": {
         "filePath": "src/data/ids.ts",
-        "line": 2,
+        "line": 3,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -7920,19 +7860,25 @@
       "structuredRows": []
     },
     {
-      "name": "ExternalGraphQlApiDataSourceConfig",
+      "name": "ExternalGraphQlApiDefinition",
       "description": null,
       "isReadme": false,
       "examples": [],
       "kind": "type",
-      "modulePath": "src/data/sources.ts",
+      "modulePath": "src/data/apis.ts",
       "sourceLocation": {
-        "filePath": "src/data/sources.ts",
-        "line": 41,
+        "filePath": "src/data/apis.ts",
+        "line": 40,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
-      "relatedSymbols": ["CredentialRef", "DataContractValue", "DataEndpointConfig", "DataSchema"],
+      "relatedSymbols": [
+        "CredentialRef",
+        "DataContractValue",
+        "DataEndpointConfig",
+        "DataSchema",
+        "GraphQlIntrospectionConfig"
+      ],
       "signatures": [],
       "members": [
         {
@@ -7952,7 +7898,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -7973,15 +7919,8 @@
         {
           "name": "introspection",
           "kind": "property",
-          "type": "{ readonly enabled: boolean; readonly schemaVersion?: string; } | undefined",
+          "type": "GraphQlIntrospectionConfig | undefined",
           "required": false,
-          "description": null
-        },
-        {
-          "name": "kind",
-          "kind": "property",
-          "type": "\"api\"",
-          "required": true,
           "description": null
         },
         {
@@ -8015,7 +7954,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -8023,15 +7962,15 @@
       "structuredRows": []
     },
     {
-      "name": "ExternalRestApiDataSourceConfig",
+      "name": "ExternalRestApiDefinition",
       "description": null,
       "isReadme": false,
       "examples": [],
       "kind": "type",
-      "modulePath": "src/data/sources.ts",
+      "modulePath": "src/data/apis.ts",
       "sourceLocation": {
-        "filePath": "src/data/sources.ts",
-        "line": 34,
+        "filePath": "src/data/apis.ts",
+        "line": 28,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8068,7 +8007,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -8076,13 +8015,6 @@
           "name": "id",
           "kind": "property",
           "type": "string",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "kind",
-          "kind": "property",
-          "type": "\"api\"",
           "required": true,
           "description": null
         },
@@ -8124,7 +8056,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -8251,25 +8183,7 @@
       "structuredRows": []
     },
     {
-      "name": "GENERATED_API_CRUD_OPERATIONS",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "value",
-      "modulePath": "src/data/apis.ts",
-      "sourceLocation": {
-        "filePath": "src/data/apis.ts",
-        "line": 5,
-        "column": 14
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": [],
-      "signatures": [],
-      "members": [],
-      "structuredRows": []
-    },
-    {
-      "name": "GeneratedApiAuthRequirement",
+      "name": "GraphQlIntrospectionConfig",
       "description": null,
       "isReadme": false,
       "examples": [],
@@ -8277,184 +8191,7 @@
       "modulePath": "src/data/apis.ts",
       "sourceLocation": {
         "filePath": "src/data/apis.ts",
-        "line": 18,
-        "column": 1
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": ["DataContractValue"],
-      "signatures": [],
-      "members": [
-        {
-          "name": "metadata",
-          "kind": "property",
-          "type": "DataContractValue | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "permissions",
-          "kind": "property",
-          "type": "readonly string[] | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "policy",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "required",
-          "kind": "property",
-          "type": "boolean | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "roles",
-          "kind": "property",
-          "type": "readonly string[] | undefined",
-          "required": false,
-          "description": null
-        }
-      ],
-      "structuredRows": []
-    },
-    {
-      "name": "GeneratedApiCrudOperation",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "unknown",
-      "modulePath": "src/data/apis.ts",
-      "sourceLocation": {
-        "filePath": "src/data/apis.ts",
-        "line": 12,
-        "column": 1
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": [],
-      "signatures": [],
-      "members": [],
-      "structuredRows": []
-    },
-    {
-      "name": "GeneratedApiDefinition",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "type",
-      "modulePath": "src/data/apis.ts",
-      "sourceLocation": {
-        "filePath": "src/data/apis.ts",
-        "line": 50,
-        "column": 1
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": [
-        "DatabaseAdapterRef",
-        "DataContractValue",
-        "GeneratedApiAuthRequirement",
-        "GeneratedApiResourceDefinition"
-      ],
-      "signatures": [],
-      "members": [
-        {
-          "name": "auth",
-          "kind": "property",
-          "type": "GeneratedApiAuthRequirement | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "basePath",
-          "kind": "property",
-          "type": "string",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "database",
-          "kind": "property",
-          "type": "DatabaseAdapterRef",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "description",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "id",
-          "kind": "property",
-          "type": "string",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "metadata",
-          "kind": "property",
-          "type": "DataContractValue | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "name",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "protocol",
-          "kind": "property",
-          "type": "\"rest\"",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "resources",
-          "kind": "property",
-          "type": "readonly GeneratedApiResourceDefinition[]",
-          "required": true,
-          "description": null
-        }
-      ],
-      "structuredRows": []
-    },
-    {
-      "name": "GeneratedApiId",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "unknown",
-      "modulePath": "src/data/apis.ts",
-      "sourceLocation": {
-        "filePath": "src/data/apis.ts",
-        "line": 14,
-        "column": 1
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": [],
-      "signatures": [],
-      "members": [],
-      "structuredRows": []
-    },
-    {
-      "name": "GeneratedApiOperationPolicyRef",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "type",
-      "modulePath": "src/data/apis.ts",
-      "sourceLocation": {
-        "filePath": "src/data/apis.ts",
-        "line": 26,
+        "line": 35,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8462,265 +8199,16 @@
       "signatures": [],
       "members": [
         {
-          "name": "id",
+          "name": "enabled",
           "kind": "property",
-          "type": "string",
+          "type": "boolean",
           "required": true,
           "description": null
         },
         {
-          "name": "operation",
-          "kind": "property",
-          "type": "\"list\" | \"read\" | \"create\" | \"update\" | \"delete\" | undefined",
-          "required": false,
-          "description": null
-        }
-      ],
-      "structuredRows": []
-    },
-    {
-      "name": "GeneratedApiRegistry",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "unknown",
-      "modulePath": "src/data/apis.ts",
-      "sourceLocation": {
-        "filePath": "src/data/apis.ts",
-        "line": 62,
-        "column": 1
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": [],
-      "signatures": [],
-      "members": [],
-      "structuredRows": []
-    },
-    {
-      "name": "GeneratedApiResourceDefinition",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "type",
-      "modulePath": "src/data/apis.ts",
-      "sourceLocation": {
-        "filePath": "src/data/apis.ts",
-        "line": 31,
-        "column": 1
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": [
-        "DataContractValue",
-        "DbCollectionDefinition",
-        "GeneratedApiOperationPolicyRef"
-      ],
-      "signatures": [],
-      "members": [
-        {
-          "name": "collection",
-          "kind": "property",
-          "type": "DbCollectionDefinition",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "description",
+          "name": "schemaVersion",
           "kind": "property",
           "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "id",
-          "kind": "property",
-          "type": "string",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "metadata",
-          "kind": "property",
-          "type": "DataContractValue | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "name",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "operations",
-          "kind": "property",
-          "type": "readonly (\"list\" | \"read\" | \"create\" | \"update\" | \"delete\")[]",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "path",
-          "kind": "property",
-          "type": "string",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "policies",
-          "kind": "property",
-          "type": "readonly GeneratedApiOperationPolicyRef[] | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "seed",
-          "kind": "property",
-          "type": "readonly Readonly<Record<string, DataContractValue>>[] | undefined",
-          "required": false,
-          "description": null
-        }
-      ],
-      "structuredRows": []
-    },
-    {
-      "name": "GeneratedApiResourceId",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "unknown",
-      "modulePath": "src/data/apis.ts",
-      "sourceLocation": {
-        "filePath": "src/data/apis.ts",
-        "line": 15,
-        "column": 1
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": [],
-      "signatures": [],
-      "members": [],
-      "structuredRows": []
-    },
-    {
-      "name": "GeneratedApiSeedRecord",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "unknown",
-      "modulePath": "src/data/apis.ts",
-      "sourceLocation": {
-        "filePath": "src/data/apis.ts",
-        "line": 16,
-        "column": 1
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": [],
-      "signatures": [],
-      "members": [],
-      "structuredRows": []
-    },
-    {
-      "name": "GeneratedRestApiDataSourceConfig",
-      "description": null,
-      "isReadme": false,
-      "examples": [],
-      "kind": "type",
-      "modulePath": "src/data/sources.ts",
-      "sourceLocation": {
-        "filePath": "src/data/sources.ts",
-        "line": 51,
-        "column": 1
-      },
-      "exportPaths": ["src/index.ts"],
-      "relatedSymbols": [
-        "CredentialRef",
-        "DatabaseAdapterRef",
-        "DataContractValue",
-        "DataEndpointConfig",
-        "DataSchema"
-      ],
-      "signatures": [],
-      "members": [
-        {
-          "name": "adapter",
-          "kind": "property",
-          "type": "DatabaseAdapterRef",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "credential",
-          "kind": "property",
-          "type": "CredentialRef | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "description",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "endpoints",
-          "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataEndpointConfig>>",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "generatedApiId",
-          "kind": "property",
-          "type": "string",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "id",
-          "kind": "property",
-          "type": "string",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "kind",
-          "kind": "property",
-          "type": "\"api\"",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "metadata",
-          "kind": "property",
-          "type": "DataContractValue | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "name",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "origin",
-          "kind": "property",
-          "type": "\"generated\"",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "protocol",
-          "kind": "property",
-          "type": "\"rest\"",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "schemas",
-          "kind": "property",
-          "type": "Readonly<Record<string, import(\"/Users/a_rtiphishl_e/git/contracts/src/index\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -8846,6 +8334,7 @@
       },
       "exportPaths": ["src/index.ts"],
       "relatedSymbols": [
+        "ApiDefinitionList",
         "AuthSpec",
         "DatabaseSpec",
         "DeploymentSpec",
@@ -8856,6 +8345,13 @@
       ],
       "signatures": [],
       "members": [
+        {
+          "name": "apis",
+          "kind": "property",
+          "type": "ApiDefinitionList | undefined",
+          "required": false,
+          "description": null
+        },
         {
           "name": "auth",
           "kind": "property",
@@ -8949,6 +8445,95 @@
       "structuredRows": []
     },
     {
+      "name": "InternalRestApiDefinition",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/data/apis.ts",
+      "sourceLocation": {
+        "filePath": "src/data/apis.ts",
+        "line": 54,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["CredentialRef", "DataContractValue", "DataEndpointConfig", "DataSchema"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "basePath",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "credential",
+          "kind": "property",
+          "type": "CredentialRef | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "description",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "endpoints",
+          "kind": "property",
+          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "id",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "metadata",
+          "kind": "property",
+          "type": "DataContractValue | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "name",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "origin",
+          "kind": "property",
+          "type": "\"internal\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "protocol",
+          "kind": "property",
+          "type": "\"rest\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "schemas",
+          "kind": "property",
+          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
       "name": "isAppDeployManifest",
       "description": null,
       "isReadme": false,
@@ -8989,7 +8574,7 @@
       "modulePath": "src/appManifest.ts",
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 52,
+        "line": 50,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9894,10 +9479,10 @@
       "isReadme": false,
       "examples": [],
       "kind": "type",
-      "modulePath": "src/data/sources.ts",
+      "modulePath": "src/data/apis.ts",
       "sourceLocation": {
-        "filePath": "src/data/sources.ts",
-        "line": 28,
+        "filePath": "src/data/apis.ts",
+        "line": 22,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9937,7 +9522,7 @@
       "modulePath": "src/data/ids.ts",
       "sourceLocation": {
         "filePath": "src/data/ids.ts",
-        "line": 3,
+        "line": 4,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10002,7 +9587,7 @@
       "modulePath": "src/appManifest.ts",
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 45,
+        "line": 43,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10367,7 +9952,7 @@
       "modulePath": "src/data/ids.ts",
       "sourceLocation": {
         "filePath": "src/data/ids.ts",
-        "line": 4,
+        "line": 5,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10385,7 +9970,7 @@
       "modulePath": "src/requirements.ts",
       "sourceLocation": {
         "filePath": "src/requirements.ts",
-        "line": 30,
+        "line": 31,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10395,7 +9980,7 @@
         {
           "name": "capability",
           "kind": "property",
-          "type": "\"notifications\" | \"clipboard\" | \"barcodeScanner\" | \"cameraPreview\" | \"mediaPicker\" | \"filePicker\" | \"location\"",
+          "type": "\"notifications\" | \"clipboard\" | \"barcodeScanner\" | \"cameraPreview\" | \"ebookReader\" | \"mediaPicker\" | \"filePicker\" | \"location\"",
           "required": true,
           "description": null
         }
@@ -10429,7 +10014,7 @@
       "modulePath": "src/requirements.ts",
       "sourceLocation": {
         "filePath": "src/requirements.ts",
-        "line": 26,
+        "line": 27,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10455,7 +10040,7 @@
       "modulePath": "src/requirements.ts",
       "sourceLocation": {
         "filePath": "src/requirements.ts",
-        "line": 34,
+        "line": 35,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10498,7 +10083,7 @@
         {
           "name": "dataLoaders",
           "kind": "property",
-          "type": "readonly import(\"/Users/a_rtiphishl_e/git/contracts/src/bindings\").OperationScreenDataLoaderDefinition[] | undefined",
+          "type": "readonly import(\"./src/bindings\").OperationScreenDataLoaderDefinition[] | undefined",
           "required": false,
           "description": null
         },
@@ -14410,7 +13995,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 45,
+        "line": 43,
         "column": 1
       }
     },
@@ -14419,7 +14004,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 52,
+        "line": 50,
         "column": 1
       }
     },
@@ -14428,7 +14013,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 74,
+        "line": 72,
         "column": 1
       }
     },
@@ -14437,7 +14022,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 80,
+        "line": 78,
         "column": 1
       }
     },
@@ -14446,7 +14031,97 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 84,
+        "line": 82,
+        "column": 1
+      }
+    },
+    {
+      "name": "isApiDefinitionList",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/apis.ts",
+        "line": 22,
+        "column": 1
+      }
+    },
+    {
+      "name": "isApiDefinition",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/apis.ts",
+        "line": 28,
+        "column": 1
+      }
+    },
+    {
+      "name": "isApiBaseDefinition",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/apis.ts",
+        "line": 38,
+        "column": 1
+      }
+    },
+    {
+      "name": "isExternalRestApi",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/apis.ts",
+        "line": 53,
+        "column": 1
+      }
+    },
+    {
+      "name": "isExternalGraphQlApi",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/apis.ts",
+        "line": 61,
+        "column": 1
+      }
+    },
+    {
+      "name": "isInternalRestApi",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/apis.ts",
+        "line": 69,
+        "column": 1
+      }
+    },
+    {
+      "name": "isOpenApiDocumentRef",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/apis.ts",
+        "line": 73,
+        "column": 1
+      }
+    },
+    {
+      "name": "isGraphQlIntrospection",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/apis.ts",
+        "line": 83,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNonEmptyString",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/apis.ts",
+        "line": 92,
+        "column": 1
+      }
+    },
+    {
+      "name": "hasOnlyKeys",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/apis.ts",
+        "line": 96,
         "column": 1
       }
     },
@@ -14577,29 +14252,155 @@
       }
     },
     {
+      "name": "isDataEndpointRegistry",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 21,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDataSchemaRegistry",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 25,
+        "column": 1
+      }
+    },
+    {
+      "name": "isCredentialRef",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 29,
+        "column": 1
+      }
+    },
+    {
+      "name": "isAdapterRef",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 39,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDataEndpointConfig",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 50,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDataOperationConfig",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 66,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDataOperationRequest",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 86,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDataOperationParameter",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 96,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDataOperationResponse",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 109,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDataSchemaSlot",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 121,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDataSchema",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 128,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDataSchemaType",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 135,
+        "column": 1
+      }
+    },
+    {
+      "name": "isOptionalSchemaScalars",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 144,
+        "column": 1
+      }
+    },
+    {
+      "name": "isOptionalSchemaCollections",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 158,
+        "column": 1
+      }
+    },
+    {
+      "name": "isOptionalSchemaComposition",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 170,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDataSchemaRef",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest/data.ts",
+        "line": 177,
+        "column": 1
+      }
+    },
+    {
       "name": "isDataSourceRegistry",
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/dataSources.ts",
-        "line": 3,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDataSourceConfig",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 7,
-        "column": 1
-      }
-    },
-    {
-      "name": "hasBaseDataSourceShape",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 15,
+        "line": 21,
         "column": 1
       }
     },
@@ -14608,124 +14409,16 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/dataSources.ts",
-        "line": 29,
+        "line": 28,
         "column": 1
       }
     },
     {
-      "name": "isGeneratedDataSource",
+      "name": "hasOnlyKeys",
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/dataSources.ts",
-        "line": 35,
-        "column": 1
-      }
-    },
-    {
-      "name": "isExternalDataSource",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 45,
-        "column": 1
-      }
-    },
-    {
-      "name": "isOpenApiDocumentRef",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 63,
-        "column": 1
-      }
-    },
-    {
-      "name": "isGraphQlIntrospection",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 72,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDataEndpointRegistry",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 78,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDataEndpointConfig",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 82,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDataOperationConfig",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 98,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDataOperationRequest",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 118,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDataOperationParameter",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 127,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDataOperationResponse",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 140,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDataSchemaSlot",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 152,
-        "column": 1
-      }
-    },
-    {
-      "name": "isCredentialRef",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 156,
-        "column": 1
-      }
-    },
-    {
-      "name": "isAdapterRef",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/dataSources.ts",
-        "line": 166,
+        "line": 46,
         "column": 1
       }
     },
@@ -14820,119 +14513,11 @@
       }
     },
     {
-      "name": "isGeneratedApiRegistry",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 9,
-        "column": 1
-      }
-    },
-    {
-      "name": "isGeneratedApiDefinition",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 13,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDatabaseAdapterRef",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 29,
-        "column": 1
-      }
-    },
-    {
-      "name": "isGeneratedApiAuthRequirement",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 33,
-        "column": 1
-      }
-    },
-    {
-      "name": "isGeneratedApiResourceDefinition",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 44,
-        "column": 1
-      }
-    },
-    {
-      "name": "isSeedRecords",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 61,
-        "column": 1
-      }
-    },
-    {
-      "name": "isGeneratedApiCrudOperation",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 68,
-        "column": 1
-      }
-    },
-    {
-      "name": "isGeneratedApiPolicyRef",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 72,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDbCollectionDefinition",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 80,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDbFieldDefinition",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 91,
-        "column": 1
-      }
-    },
-    {
-      "name": "isDbDefaultValue",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 103,
-        "column": 1
-      }
-    },
-    {
-      "name": "isAdapterRef",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/generatedApis.ts",
-        "line": 113,
-        "column": 1
-      }
-    },
-    {
       "name": "isInfraManifest",
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 36,
+        "line": 37,
         "column": 1
       }
     },
@@ -14941,7 +14526,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 53,
+        "line": 55,
         "column": 1
       }
     },
@@ -14950,7 +14535,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 59,
+        "line": 61,
         "column": 1
       }
     },
@@ -14959,7 +14544,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 68,
+        "line": 70,
         "column": 1
       }
     },
@@ -14968,7 +14553,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 77,
+        "line": 79,
         "column": 1
       }
     },
@@ -14977,7 +14562,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 86,
+        "line": 88,
         "column": 1
       }
     },
@@ -14986,7 +14571,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 90,
+        "line": 92,
         "column": 1
       }
     },
@@ -14995,7 +14580,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 105,
+        "line": 107,
         "column": 1
       }
     },
@@ -15004,7 +14589,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 115,
+        "line": 117,
         "column": 1
       }
     },
@@ -15013,7 +14598,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 128,
+        "line": 130,
         "column": 1
       }
     },
@@ -15022,7 +14607,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 138,
+        "line": 140,
         "column": 1
       }
     },
@@ -15031,7 +14616,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 148,
+        "line": 150,
         "column": 1
       }
     },
@@ -15040,7 +14625,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 158,
+        "line": 160,
         "column": 1
       }
     },
@@ -15049,7 +14634,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 172,
+        "line": 174,
         "column": 1
       }
     },
@@ -15058,7 +14643,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 189,
+        "line": 191,
         "column": 1
       }
     },
@@ -15489,11 +15074,6 @@
       },
       {
         "fromPath": "src/appManifest.ts",
-        "toPath": "src/appManifest/generatedApis.ts",
-        "sourcePath": "src/appManifest.ts"
-      },
-      {
-        "fromPath": "src/appManifest.ts",
         "toPath": "src/appManifest/infra.ts",
         "sourcePath": "src/appManifest.ts"
       },
@@ -15683,9 +15263,34 @@
         "sourcePath": "src/ui.ts"
       },
       {
+        "fromPath": "src/appManifest/apis.ts",
+        "toPath": "src/data/index.ts",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromPath": "src/appManifest/apis.ts",
+        "toPath": "src/appManifest/data.ts",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromPath": "src/appManifest/apis.ts",
+        "toPath": "src/appManifest/shared.ts",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
         "fromPath": "src/appManifest/bindings.ts",
         "toPath": "src/appManifest/shared.ts",
         "sourcePath": "src/appManifest/bindings.ts"
+      },
+      {
+        "fromPath": "src/appManifest/data.ts",
+        "toPath": "src/appManifest/shared.ts",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromPath": "src/appManifest/dataSources.ts",
+        "toPath": "src/appManifest/data.ts",
+        "sourcePath": "src/appManifest/dataSources.ts"
       },
       {
         "fromPath": "src/appManifest/dataSources.ts",
@@ -15703,11 +15308,6 @@
         "sourcePath": "src/appManifest/deploy.ts"
       },
       {
-        "fromPath": "src/appManifest/generatedApis.ts",
-        "toPath": "src/appManifest/shared.ts",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
         "fromPath": "src/appManifest/infra.ts",
         "toPath": "src/auth.ts",
         "sourcePath": "src/appManifest/infra.ts"
@@ -15715,6 +15315,11 @@
       {
         "fromPath": "src/appManifest/infra.ts",
         "toPath": "src/types.ts",
+        "sourcePath": "src/appManifest/infra.ts"
+      },
+      {
+        "fromPath": "src/appManifest/infra.ts",
+        "toPath": "src/appManifest/apis.ts",
         "sourcePath": "src/appManifest/infra.ts"
       },
       {
@@ -15749,12 +15354,22 @@
       },
       {
         "fromPath": "src/data/apis.ts",
-        "toPath": "src/db.ts",
+        "toPath": "src/data/endpoints.ts",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromPath": "src/data/apis.ts",
+        "toPath": "src/data/ids.ts",
         "sourcePath": "src/data/apis.ts"
       },
       {
         "fromPath": "src/data/apis.ts",
         "toPath": "src/data/refs.ts",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromPath": "src/data/apis.ts",
+        "toPath": "src/data/schemas.ts",
         "sourcePath": "src/data/apis.ts"
       },
       {
@@ -15967,12 +15582,6 @@
       },
       {
         "fromSymbol": "isAppManifest",
-        "toSymbol": "isGeneratedApiRegistry",
-        "callExpression": "isGeneratedApiRegistry",
-        "sourcePath": "src/appManifest.ts"
-      },
-      {
-        "fromSymbol": "isAppManifest",
         "toSymbol": "isDataSourceRegistry",
         "callExpression": "isDataSourceRegistry",
         "sourcePath": "src/appManifest.ts"
@@ -16002,10 +15611,154 @@
         "sourcePath": "src/appManifest.ts"
       },
       {
-        "fromSymbol": "isAppSettings",
+        "fromSymbol": "isApiDefinition",
+        "toSymbol": "isApiBaseDefinition",
+        "callExpression": "isApiBaseDefinition",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isApiDefinition",
+        "toSymbol": "isExternalRestApi",
+        "callExpression": "isExternalRestApi",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isApiDefinition",
+        "toSymbol": "isExternalGraphQlApi",
+        "callExpression": "isExternalGraphQlApi",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isApiDefinition",
+        "toSymbol": "isInternalRestApi",
+        "callExpression": "isInternalRestApi",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isApiBaseDefinition",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isApiBaseDefinition",
+        "toSymbol": "isNonEmptyString",
+        "callExpression": "isNonEmptyString",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isApiBaseDefinition",
         "toSymbol": "isOptionalString",
         "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest.ts"
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isApiBaseDefinition",
+        "toSymbol": "isCredentialRef",
+        "callExpression": "isCredentialRef",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isApiBaseDefinition",
+        "toSymbol": "isDataEndpointRegistry",
+        "callExpression": "isDataEndpointRegistry",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isApiBaseDefinition",
+        "toSymbol": "isDataSchemaRegistry",
+        "callExpression": "isDataSchemaRegistry",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isApiBaseDefinition",
+        "toSymbol": "isManifestValue",
+        "callExpression": "isManifestValue",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isExternalRestApi",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isExternalRestApi",
+        "toSymbol": "isNonEmptyString",
+        "callExpression": "isNonEmptyString",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isExternalRestApi",
+        "toSymbol": "isOpenApiDocumentRef",
+        "callExpression": "isOpenApiDocumentRef",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isExternalGraphQlApi",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isExternalGraphQlApi",
+        "toSymbol": "isNonEmptyString",
+        "callExpression": "isNonEmptyString",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isExternalGraphQlApi",
+        "toSymbol": "isGraphQlIntrospection",
+        "callExpression": "isGraphQlIntrospection",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isInternalRestApi",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isInternalRestApi",
+        "toSymbol": "isNonEmptyString",
+        "callExpression": "isNonEmptyString",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isOpenApiDocumentRef",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isOpenApiDocumentRef",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isOpenApiDocumentRef",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isGraphQlIntrospection",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isGraphQlIntrospection",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/apis.ts"
+      },
+      {
+        "fromSymbol": "isGraphQlIntrospection",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/apis.ts"
       },
       {
         "fromSymbol": "isComponentDataBindingRegistry",
@@ -16242,283 +15995,319 @@
         "sourcePath": "src/appManifest/bindings.ts"
       },
       {
+        "fromSymbol": "isDataEndpointRegistry",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataSchemaRegistry",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isCredentialRef",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isCredentialRef",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isAdapterRef",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isAdapterRef",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isAdapterRef",
+        "toSymbol": "isManifestValue",
+        "callExpression": "isManifestValue",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataEndpointConfig",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataEndpointConfig",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataEndpointConfig",
+        "toSymbol": "isCredentialRef",
+        "callExpression": "isCredentialRef",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataEndpointConfig",
+        "toSymbol": "isManifestValue",
+        "callExpression": "isManifestValue",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationConfig",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationConfig",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationConfig",
+        "toSymbol": "isDataOperationRequest",
+        "callExpression": "isDataOperationRequest",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationConfig",
+        "toSymbol": "isDataOperationResponse",
+        "callExpression": "isDataOperationResponse",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationConfig",
+        "toSymbol": "isCredentialRef",
+        "callExpression": "isCredentialRef",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationConfig",
+        "toSymbol": "isManifestValue",
+        "callExpression": "isManifestValue",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationRequest",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationRequest",
+        "toSymbol": "isDataSchemaSlot",
+        "callExpression": "isDataSchemaSlot",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationRequest",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationParameter",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationParameter",
+        "toSymbol": "isDataSchemaSlot",
+        "callExpression": "isDataSchemaSlot",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationParameter",
+        "toSymbol": "isOptionalBoolean",
+        "callExpression": "isOptionalBoolean",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationParameter",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationParameter",
+        "toSymbol": "isManifestValue",
+        "callExpression": "isManifestValue",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationResponse",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationResponse",
+        "toSymbol": "isDataSchemaSlot",
+        "callExpression": "isDataSchemaSlot",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataOperationResponse",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataSchemaSlot",
+        "toSymbol": "isDataSchema",
+        "callExpression": "isDataSchema",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataSchemaSlot",
+        "toSymbol": "isDataSchemaRef",
+        "callExpression": "isDataSchemaRef",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataSchema",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataSchema",
+        "toSymbol": "isDataSchemaType",
+        "callExpression": "isDataSchemaType",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataSchema",
+        "toSymbol": "isOptionalSchemaScalars",
+        "callExpression": "isOptionalSchemaScalars",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataSchema",
+        "toSymbol": "isOptionalSchemaCollections",
+        "callExpression": "isOptionalSchemaCollections",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataSchema",
+        "toSymbol": "isOptionalSchemaComposition",
+        "callExpression": "isOptionalSchemaComposition",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isOptionalSchemaScalars",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isOptionalSchemaScalars",
+        "toSymbol": "isOptionalBoolean",
+        "callExpression": "isOptionalBoolean",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isOptionalSchemaScalars",
+        "toSymbol": "isManifestValue",
+        "callExpression": "isManifestValue",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isOptionalSchemaScalars",
+        "toSymbol": "isDataSchemaRef",
+        "callExpression": "isDataSchemaRef",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isOptionalSchemaCollections",
+        "toSymbol": "isStringArray",
+        "callExpression": "isStringArray",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isOptionalSchemaCollections",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isOptionalSchemaCollections",
+        "toSymbol": "isDataSchema",
+        "callExpression": "isDataSchema",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
+        "fromSymbol": "isDataSchemaRef",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/data.ts"
+      },
+      {
         "fromSymbol": "isDataSourceRegistry",
         "toSymbol": "isRecord",
         "callExpression": "isRecord",
         "sourcePath": "src/appManifest/dataSources.ts"
       },
       {
-        "fromSymbol": "isDataSourceConfig",
-        "toSymbol": "hasBaseDataSourceShape",
-        "callExpression": "hasBaseDataSourceShape",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataSourceConfig",
+        "fromSymbol": "src/appManifest/dataSources.ts",
         "toSymbol": "isDatabaseDataSource",
         "callExpression": "isDatabaseDataSource",
         "sourcePath": "src/appManifest/dataSources.ts"
       },
       {
-        "fromSymbol": "isDataSourceConfig",
-        "toSymbol": "isGeneratedDataSource",
-        "callExpression": "isGeneratedDataSource",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataSourceConfig",
-        "toSymbol": "isExternalDataSource",
-        "callExpression": "isExternalDataSource",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "hasBaseDataSourceShape",
+        "fromSymbol": "isDatabaseDataSource",
         "toSymbol": "isRecord",
         "callExpression": "isRecord",
         "sourcePath": "src/appManifest/dataSources.ts"
       },
       {
-        "fromSymbol": "hasBaseDataSourceShape",
+        "fromSymbol": "isDatabaseDataSource",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/dataSources.ts"
+      },
+      {
+        "fromSymbol": "isDatabaseDataSource",
         "toSymbol": "isOptionalString",
         "callExpression": "isOptionalString",
         "sourcePath": "src/appManifest/dataSources.ts"
       },
       {
-        "fromSymbol": "hasBaseDataSourceShape",
+        "fromSymbol": "isDatabaseDataSource",
         "toSymbol": "isCredentialRef",
         "callExpression": "isCredentialRef",
         "sourcePath": "src/appManifest/dataSources.ts"
       },
       {
-        "fromSymbol": "hasBaseDataSourceShape",
+        "fromSymbol": "isDatabaseDataSource",
+        "toSymbol": "isAdapterRef",
+        "callExpression": "isAdapterRef",
+        "sourcePath": "src/appManifest/dataSources.ts"
+      },
+      {
+        "fromSymbol": "isDatabaseDataSource",
         "toSymbol": "isDataEndpointRegistry",
         "callExpression": "isDataEndpointRegistry",
         "sourcePath": "src/appManifest/dataSources.ts"
       },
       {
-        "fromSymbol": "hasBaseDataSourceShape",
-        "toSymbol": "isManifestValue",
-        "callExpression": "isManifestValue",
+        "fromSymbol": "isDatabaseDataSource",
+        "toSymbol": "isDataSchemaRegistry",
+        "callExpression": "isDataSchemaRegistry",
         "sourcePath": "src/appManifest/dataSources.ts"
       },
       {
         "fromSymbol": "isDatabaseDataSource",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDatabaseDataSource",
-        "toSymbol": "isAdapterRef",
-        "callExpression": "isAdapterRef",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedDataSource",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedDataSource",
-        "toSymbol": "isAdapterRef",
-        "callExpression": "isAdapterRef",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isExternalDataSource",
-        "toSymbol": "isOpenApiDocumentRef",
-        "callExpression": "isOpenApiDocumentRef",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isExternalDataSource",
-        "toSymbol": "isGraphQlIntrospection",
-        "callExpression": "isGraphQlIntrospection",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isOpenApiDocumentRef",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isOpenApiDocumentRef",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isGraphQlIntrospection",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isGraphQlIntrospection",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataEndpointRegistry",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataEndpointConfig",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataEndpointConfig",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataEndpointConfig",
-        "toSymbol": "isCredentialRef",
-        "callExpression": "isCredentialRef",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataEndpointConfig",
-        "toSymbol": "isManifestValue",
-        "callExpression": "isManifestValue",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationConfig",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationConfig",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationConfig",
-        "toSymbol": "isDataOperationRequest",
-        "callExpression": "isDataOperationRequest",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationConfig",
-        "toSymbol": "isDataOperationResponse",
-        "callExpression": "isDataOperationResponse",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationConfig",
-        "toSymbol": "isCredentialRef",
-        "callExpression": "isCredentialRef",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationConfig",
-        "toSymbol": "isManifestValue",
-        "callExpression": "isManifestValue",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationRequest",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationRequest",
-        "toSymbol": "isDataSchemaSlot",
-        "callExpression": "isDataSchemaSlot",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationParameter",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationParameter",
-        "toSymbol": "isDataSchemaSlot",
-        "callExpression": "isDataSchemaSlot",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationParameter",
-        "toSymbol": "isOptionalBoolean",
-        "callExpression": "isOptionalBoolean",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationParameter",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationParameter",
-        "toSymbol": "isManifestValue",
-        "callExpression": "isManifestValue",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationResponse",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationResponse",
-        "toSymbol": "isDataSchemaSlot",
-        "callExpression": "isDataSchemaSlot",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataOperationResponse",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isDataSchemaSlot",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isCredentialRef",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isCredentialRef",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isAdapterRef",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isAdapterRef",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/dataSources.ts"
-      },
-      {
-        "fromSymbol": "isAdapterRef",
         "toSymbol": "isManifestValue",
         "callExpression": "isManifestValue",
         "sourcePath": "src/appManifest/dataSources.ts"
@@ -16674,180 +16463,6 @@
         "sourcePath": "src/appManifest/deploy.ts"
       },
       {
-        "fromSymbol": "isGeneratedApiRegistry",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiDefinition",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiDefinition",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiDefinition",
-        "toSymbol": "isDatabaseAdapterRef",
-        "callExpression": "isDatabaseAdapterRef",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiDefinition",
-        "toSymbol": "isGeneratedApiAuthRequirement",
-        "callExpression": "isGeneratedApiAuthRequirement",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiDefinition",
-        "toSymbol": "isManifestValue",
-        "callExpression": "isManifestValue",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isDatabaseAdapterRef",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isDatabaseAdapterRef",
-        "toSymbol": "isAdapterRef",
-        "callExpression": "isAdapterRef",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiAuthRequirement",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiAuthRequirement",
-        "toSymbol": "isOptionalBoolean",
-        "callExpression": "isOptionalBoolean",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiAuthRequirement",
-        "toSymbol": "isStringArray",
-        "callExpression": "isStringArray",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiAuthRequirement",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiAuthRequirement",
-        "toSymbol": "isManifestValue",
-        "callExpression": "isManifestValue",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiResourceDefinition",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiResourceDefinition",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiResourceDefinition",
-        "toSymbol": "isDbCollectionDefinition",
-        "callExpression": "isDbCollectionDefinition",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiResourceDefinition",
-        "toSymbol": "isSeedRecords",
-        "callExpression": "isSeedRecords",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiResourceDefinition",
-        "toSymbol": "isManifestValue",
-        "callExpression": "isManifestValue",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "src/appManifest/generatedApis.ts",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiPolicyRef",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isGeneratedApiPolicyRef",
-        "toSymbol": "isGeneratedApiCrudOperation",
-        "callExpression": "isGeneratedApiCrudOperation",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isDbCollectionDefinition",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isDbCollectionDefinition",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isDbFieldDefinition",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isDbFieldDefinition",
-        "toSymbol": "isOptionalBoolean",
-        "callExpression": "isOptionalBoolean",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isDbFieldDefinition",
-        "toSymbol": "isDbDefaultValue",
-        "callExpression": "isDbDefaultValue",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isAdapterRef",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isAdapterRef",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
-        "fromSymbol": "isAdapterRef",
-        "toSymbol": "isManifestValue",
-        "callExpression": "isManifestValue",
-        "sourcePath": "src/appManifest/generatedApis.ts"
-      },
-      {
         "fromSymbol": "isInfraManifest",
         "toSymbol": "isRecord",
         "callExpression": "isRecord",
@@ -16887,6 +16502,12 @@
         "fromSymbol": "isInfraManifest",
         "toSymbol": "isNetworkingSpec",
         "callExpression": "isNetworkingSpec",
+        "sourcePath": "src/appManifest/infra.ts"
+      },
+      {
+        "fromSymbol": "isInfraManifest",
+        "toSymbol": "isApiDefinitionList",
+        "callExpression": "isApiDefinitionList",
         "sourcePath": "src/appManifest/infra.ts"
       },
       {
@@ -17752,48 +17373,123 @@
         "sourcePath": "src/cli/index.ts"
       },
       {
-        "fromSymbol": "GeneratedApiAuthRequirement",
+        "fromSymbol": "ApiBaseDefinition",
+        "toType": "ApiOrigin",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ApiBaseDefinition",
+        "toType": "ApiProtocol",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ApiBaseDefinition",
+        "toType": "CredentialRef",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ApiBaseDefinition",
         "toType": "DataContractValue",
         "sourcePath": "src/data/apis.ts"
       },
       {
-        "fromSymbol": "GeneratedApiResourceDefinition",
-        "toType": "DataContractValue",
+        "fromSymbol": "ApiBaseDefinition",
+        "toType": "DataEndpointConfig",
         "sourcePath": "src/data/apis.ts"
       },
       {
-        "fromSymbol": "GeneratedApiResourceDefinition",
-        "toType": "DbCollectionDefinition",
+        "fromSymbol": "ApiBaseDefinition",
+        "toType": "DataSchema",
         "sourcePath": "src/data/apis.ts"
       },
       {
-        "fromSymbol": "GeneratedApiResourceDefinition",
-        "toType": "GeneratedApiOperationPolicyRef",
-        "sourcePath": "src/data/apis.ts"
-      },
-      {
-        "fromSymbol": "GeneratedApiResourceDefinition",
+        "fromSymbol": "ApiBaseDefinition",
         "toType": "Readonly",
         "sourcePath": "src/data/apis.ts"
       },
       {
-        "fromSymbol": "GeneratedApiDefinition",
-        "toType": "DatabaseAdapterRef",
+        "fromSymbol": "ExternalRestApiDefinition",
+        "toType": "CredentialRef",
         "sourcePath": "src/data/apis.ts"
       },
       {
-        "fromSymbol": "GeneratedApiDefinition",
+        "fromSymbol": "ExternalRestApiDefinition",
         "toType": "DataContractValue",
         "sourcePath": "src/data/apis.ts"
       },
       {
-        "fromSymbol": "GeneratedApiDefinition",
-        "toType": "GeneratedApiAuthRequirement",
+        "fromSymbol": "ExternalRestApiDefinition",
+        "toType": "DataEndpointConfig",
         "sourcePath": "src/data/apis.ts"
       },
       {
-        "fromSymbol": "GeneratedApiDefinition",
-        "toType": "GeneratedApiResourceDefinition",
+        "fromSymbol": "ExternalRestApiDefinition",
+        "toType": "DataSchema",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ExternalRestApiDefinition",
+        "toType": "OpenApiDocumentRef",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ExternalRestApiDefinition",
+        "toType": "Readonly",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ExternalGraphQlApiDefinition",
+        "toType": "CredentialRef",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ExternalGraphQlApiDefinition",
+        "toType": "DataContractValue",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ExternalGraphQlApiDefinition",
+        "toType": "DataEndpointConfig",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ExternalGraphQlApiDefinition",
+        "toType": "DataSchema",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ExternalGraphQlApiDefinition",
+        "toType": "GraphQlIntrospectionConfig",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "ExternalGraphQlApiDefinition",
+        "toType": "Readonly",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "InternalRestApiDefinition",
+        "toType": "CredentialRef",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "InternalRestApiDefinition",
+        "toType": "DataContractValue",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "InternalRestApiDefinition",
+        "toType": "DataEndpointConfig",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "InternalRestApiDefinition",
+        "toType": "DataSchema",
+        "sourcePath": "src/data/apis.ts"
+      },
+      {
+        "fromSymbol": "InternalRestApiDefinition",
+        "toType": "Readonly",
         "sourcePath": "src/data/apis.ts"
       },
       {
@@ -17972,181 +17668,6 @@
         "sourcePath": "src/data/schemas.ts"
       },
       {
-        "fromSymbol": "DataSourceBaseConfig",
-        "toType": "CredentialRef",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "DataSourceBaseConfig",
-        "toType": "DataContractValue",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "DataSourceBaseConfig",
-        "toType": "DataEndpointConfig",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "DataSourceBaseConfig",
-        "toType": "DataSchema",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "DataSourceBaseConfig",
-        "toType": "DataSourceKind",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "DataSourceBaseConfig",
-        "toType": "Readonly",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "DataSourceBaseConfig",
-        "toType": "Users",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ApiDataSourceBaseConfig",
-        "toType": "ApiOrigin",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ApiDataSourceBaseConfig",
-        "toType": "ApiProtocol",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ApiDataSourceBaseConfig",
-        "toType": "CredentialRef",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ApiDataSourceBaseConfig",
-        "toType": "DataContractValue",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ApiDataSourceBaseConfig",
-        "toType": "DataEndpointConfig",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ApiDataSourceBaseConfig",
-        "toType": "DataSchema",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ApiDataSourceBaseConfig",
-        "toType": "Readonly",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ApiDataSourceBaseConfig",
-        "toType": "Users",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalRestApiDataSourceConfig",
-        "toType": "CredentialRef",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalRestApiDataSourceConfig",
-        "toType": "DataContractValue",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalRestApiDataSourceConfig",
-        "toType": "DataEndpointConfig",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalRestApiDataSourceConfig",
-        "toType": "DataSchema",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalRestApiDataSourceConfig",
-        "toType": "OpenApiDocumentRef",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalRestApiDataSourceConfig",
-        "toType": "Readonly",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalRestApiDataSourceConfig",
-        "toType": "Users",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalGraphQlApiDataSourceConfig",
-        "toType": "CredentialRef",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalGraphQlApiDataSourceConfig",
-        "toType": "DataContractValue",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalGraphQlApiDataSourceConfig",
-        "toType": "DataEndpointConfig",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalGraphQlApiDataSourceConfig",
-        "toType": "DataSchema",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalGraphQlApiDataSourceConfig",
-        "toType": "Readonly",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "ExternalGraphQlApiDataSourceConfig",
-        "toType": "Users",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "GeneratedRestApiDataSourceConfig",
-        "toType": "CredentialRef",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "GeneratedRestApiDataSourceConfig",
-        "toType": "DatabaseAdapterRef",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "GeneratedRestApiDataSourceConfig",
-        "toType": "DataContractValue",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "GeneratedRestApiDataSourceConfig",
-        "toType": "DataEndpointConfig",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "GeneratedRestApiDataSourceConfig",
-        "toType": "DataSchema",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "GeneratedRestApiDataSourceConfig",
-        "toType": "Readonly",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "GeneratedRestApiDataSourceConfig",
-        "toType": "Users",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
         "fromSymbol": "DatabaseDataSourceConfig",
         "toType": "CredentialRef",
         "sourcePath": "src/data/sources.ts"
@@ -18174,11 +17695,6 @@
       {
         "fromSymbol": "DatabaseDataSourceConfig",
         "toType": "Readonly",
-        "sourcePath": "src/data/sources.ts"
-      },
-      {
-        "fromSymbol": "DatabaseDataSourceConfig",
-        "toType": "Users",
         "sourcePath": "src/data/sources.ts"
       },
       {
@@ -18862,11 +18378,6 @@
         "sourcePath": "src/types.ts"
       },
       {
-        "fromSymbol": "ScreenSpec",
-        "toType": "Users",
-        "sourcePath": "src/types.ts"
-      },
-      {
         "fromSymbol": "NavigatorSpec",
         "toType": "RouteDefinition",
         "sourcePath": "src/types.ts"
@@ -18973,6 +18484,11 @@
       },
       {
         "fromSymbol": "InfraManifest",
+        "toType": "ApiDefinitionList",
+        "sourcePath": "src/types.ts"
+      },
+      {
+        "fromSymbol": "InfraManifest",
         "toType": "AuthSpec",
         "sourcePath": "src/types.ts"
       },
@@ -19028,12 +18544,7 @@
       },
       {
         "fromSymbol": "AppManifest",
-        "toType": "DataSourceConfig",
-        "sourcePath": "src/types.ts"
-      },
-      {
-        "fromSymbol": "AppManifest",
-        "toType": "GeneratedApiDefinition",
+        "toType": "DatabaseDataSourceConfig",
         "sourcePath": "src/types.ts"
       },
       {
@@ -19069,11 +18580,6 @@
       {
         "fromSymbol": "AppManifest",
         "toType": "ThemeConfig",
-        "sourcePath": "src/types.ts"
-      },
-      {
-        "fromSymbol": "AppManifest",
-        "toType": "Users",
         "sourcePath": "src/types.ts"
       },
       {

--- a/src/appManifest.test.ts
+++ b/src/appManifest.test.ts
@@ -117,7 +117,7 @@ function createManifest(): Record<string, unknown> {
         ],
         requires: {
           permissions: [{ permission: 'camera' }],
-          capabilities: [{ capability: 'barcodeScanner' }],
+          capabilities: [{ capability: 'barcodeScanner' }, { capability: 'ebookReader' }],
         },
       },
     },

--- a/src/requirements.test.ts
+++ b/src/requirements.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  ANKHORAGE_CAPABILITY_NAMES,
+  type AnkhorageCapabilityName,
+  type ComponentRequirements,
+  type ScreenRequirements,
+} from './index';
+
+describe('platform requirements', () => {
+  it('exports ebookReader as the canonical reader capability', () => {
+    const capability: AnkhorageCapabilityName = 'ebookReader';
+    const componentRequirements: ComponentRequirements = {
+      capabilities: [{ capability }],
+    };
+    const screenRequirements: ScreenRequirements = {
+      capabilities: [{ capability }],
+    };
+
+    expect(ANKHORAGE_CAPABILITY_NAMES).toContain(capability);
+    expect(componentRequirements).toEqual(screenRequirements);
+  });
+});

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -14,6 +14,7 @@ export type AnkhoragePermissionName = (typeof ANKHORAGE_PERMISSION_NAMES)[number
 export const ANKHORAGE_CAPABILITY_NAMES = [
   'barcodeScanner',
   'cameraPreview',
+  'ebookReader',
   'mediaPicker',
   'filePicker',
   'location',


### PR DESCRIPTION
Closes #139

Parent roadmap: ankhorage/zora#307

## Summary

- add `ebookReader` to the canonical platform requirement capability vocabulary
- exercise the literal through public root exports and the canonical manifest fixture
- add a patch changeset and regenerate Paradox documentation

The Paradox output also synchronizes previously stale generated API documentation with the current `main` source graph; no generated README or Paradox artifact was edited manually.

## Boundary

Contracts owns only the serializable requirement literal. Reader UI, EPUB/PDF parsing, rendering, swipe gestures, persistence, and platform packages remain in their roadmap owners.

This remains distinct from #134's dotted executable `CapabilityId` vocabulary: `ebookReader` is a screen/component platform requirement alongside `barcodeScanner`.

## Validation

- `bun run build`
- `bun run lint:fix`
- `bun run lint`
- `bun run format`
- `bun run format:check`
- `bun run knip`
- `bun run test` (109 passing)
- `bun run typecheck`
- `bun run docs`
- `bun run changeset:status`
- `git diff --cached --check`

## Release gate

After merge, publish the Contracts patch release before ZORA finalizes `ebookReader` metadata against the released public contract.
