### PR TITLE
fix: consume canonical harmony catalog

### DIFF
--- a/.changeset/canonical-harmony-catalog.md
+++ b/.changeset/canonical-harmony-catalog.md
@@ -1,0 +1,6 @@
+---
+'@ankhorage/contracts': patch
+---
+
+Consume the complete canonical Color Theory harmony catalog through `ThemeModeConfig`, including
+the new `square` harmony, without redefining the catalog in Contracts.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@ankhorage/contracts",
       "dependencies": {
-        "@ankhorage/color-theory": "^0.0.8",
+        "@ankhorage/color-theory": "^0.3.0",
       },
       "devDependencies": {
         "@ankhorage/devtools": "^1.9.4",
@@ -17,7 +17,7 @@
     },
   },
   "packages": {
-    "@ankhorage/color-theory": ["@ankhorage/color-theory@0.0.8", "", { "dependencies": { "culori": "^4.0.2" } }, "sha512-+JRLkvBUiPxFrRANyewRZxLv1sU5cKFOc3VBYB+b/eFngLFDIAqXf/a4e0A6gQE+lk6e3wb3FcGQYIyYB1Dqzg=="],
+    "@ankhorage/color-theory": ["@ankhorage/color-theory@0.3.0", "", { "dependencies": { "culori": "^4.0.2" } }, "sha512-M6McHR2obnslpPESe84xr1E/1PuGKlb1S6ypDzNhkVdwJXS9gL53GDALfqszi5QyQNxQHFNyCOVnnzaQlGn52g=="],
 
     "@ankhorage/devtools": ["@ankhorage/devtools@1.9.4", "", { "dependencies": { "@ankhorage/utility": "^0.2.0", "@changesets/cli": "^3.0.1", "@eslint/compat": "^2.1.0", "@eslint/js": "^10.0.1", "eslint": "^10.9.1", "eslint-config-prettier": "^10.1.8", "eslint-plugin-import": "^2.32.0", "eslint-plugin-prettier": "^5.5.6", "eslint-plugin-react": "^7.37.5", "eslint-plugin-react-hooks": "^7.1.1", "eslint-plugin-react-native": "^5.0.0", "eslint-plugin-security": "^4.0.1", "eslint-plugin-simple-import-sort": "^14.0.0", "eslint-plugin-unused-imports": "^4.4.1", "knip": "^6.34.0", "prettier": "^3.9.6", "typescript-eslint": "^8.69.0" }, "bin": { "ankhorage-changeset": "dist/cli/bin/changeset.js", "ankhorage-eslint": "dist/cli/bin/eslint.js", "ankhorage-knip": "dist/cli/bin/knip.js", "ankhorage-prettier": "dist/cli/bin/prettier.js" } }, "sha512-tA3Zm8tEGNlq8dVgoBTHz1qwXz1HblliqftXdLiTbhN6yo0yWIZ5uuv61sApQJqs6FZX1esDSMpJdU9fcO3J0w=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "dependencies": {
-    "@ankhorage/color-theory": "^0.0.8"
+    "@ankhorage/color-theory": "^0.3.0"
   },
   "devDependencies": {
     "@ankhorage/devtools": "^1.9.4",


### PR DESCRIPTION
## Summary

- update Contracts to the released `@ankhorage/color-theory` `^0.3.0` catalog
- keep `ThemeModeConfig.harmony` sourced directly from Color Theory
- add a patch changeset for the dependency-backed public type expansion

## Architecture

Color Theory remains the only owner of harmony names and geometry. Contracts imports its public
`ColorHarmony` type and does not define, mirror, cast, or translate the catalog. This lets ZORA and
other consumers follow one released contract without compatibility paths.

The normal Contracts Renovate dashboard rerun was requested first, but it was not consumed, so this
owner branch applies the same narrow dependency and lockfile refresh.

## Validation

- `bun run build`
- `bun run lint`
- `bun run test` (109 pass)
- `bun run typecheck`
- `bun run knip:check`
- `bun run format:check`
- `bun run changeset:status`

Generated Paradox documentation remains deferred to the final zora-designer roadmap documentation
pass. No source documentation changed.

Changeset: `.changeset/canonical-harmony-catalog.md`

Roadmap owner issue: ankhorage/contracts#146
