### PR TITLE
feat: add canonical app repository configuration

### DIFF
--- a/.changeset/add-app-repository-config.md
+++ b/.changeset/add-app-repository-config.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Add the canonical optional GitHub repository configuration to `AppManifest`.

--- a/src/appManifest.test.ts
+++ b/src/appManifest.test.ts
@@ -152,6 +152,32 @@ describe('AppManifest runtime parsing', () => {
     expect(parseAppManifest(manifest)).toEqual({ ok: true, manifest });
   });
 
+  it('accepts an optional GitHub repository configuration', () => {
+    const manifest = createManifest();
+    manifest.repository = {
+      provider: 'github',
+      owner: 'ankhorage',
+      name: 'example',
+      url: 'https://github.com/ankhorage/example',
+      defaultBranch: 'main',
+    };
+
+    expect(parseAppManifest(manifest)).toEqual({ ok: true, manifest });
+  });
+
+  it('rejects malformed GitHub repository configurations', () => {
+    const manifest = createManifest();
+    manifest.repository = {
+      provider: 'gitlab',
+      owner: 'ankhorage',
+      name: 'example',
+      url: 'https://github.com/ankhorage/example',
+      defaultBranch: 'main',
+    };
+
+    expect(isAppManifest(manifest)).toBe(false);
+  });
+
   it('rejects missing required top-level sections', () => {
     const manifest = createManifest();
     delete manifest.settings;

--- a/src/appManifest.ts
+++ b/src/appManifest.ts
@@ -30,6 +30,7 @@ const APP_MANIFEST_KEY_POLICY = {
   screens: 'required',
   dataSources: 'optional',
   dataBindings: 'optional',
+  repository: 'optional',
   settings: 'required',
 } as const satisfies Record<keyof AppManifest, 'optional' | 'required'>;
 
@@ -65,6 +66,7 @@ export function isAppManifest(value: unknown): value is AppManifest {
     isScreenRegistry(value.screens) &&
     (value.dataSources === undefined || isDataSourceRegistry(value.dataSources)) &&
     (value.dataBindings === undefined || isComponentDataBindingRegistry(value.dataBindings)) &&
+    (value.repository === undefined || isAppRepositoryConfig(value.repository)) &&
     isAppSettings(value.settings)
   );
 }
@@ -77,6 +79,20 @@ function hasRequiredManifestKeys(value: Record<string, unknown>): boolean {
 
 function isActiveThemeMode(value: unknown): boolean {
   return value === undefined || value === 'dark' || value === 'light';
+}
+
+function isAppRepositoryConfig(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    value.provider === 'github' &&
+    typeof value.owner === 'string' &&
+    value.owner.length > 0 &&
+    typeof value.name === 'string' &&
+    value.name.length > 0 &&
+    typeof value.url === 'string' &&
+    value.url.length > 0 &&
+    value.defaultBranch === 'main'
+  );
 }
 
 function isAppSettings(value: unknown): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -376,6 +376,14 @@ export interface AppSettings {
   };
 }
 
+export interface AppRepositoryConfig {
+  readonly provider: 'github';
+  readonly owner: string;
+  readonly name: string;
+  readonly url: string;
+  readonly defaultBranch: 'main';
+}
+
 export interface AppManifest {
   metadata: {
     name: string;
@@ -399,5 +407,6 @@ export interface AppManifest {
   screens: Record<string, ScreenSpec>;
   dataSources?: DataSourceRegistry;
   dataBindings?: ComponentDataBindingRegistry;
+  repository?: AppRepositoryConfig;
   settings: AppSettings;
 }


### PR DESCRIPTION
## Summary
- add optional canonical GitHub repository configuration to AppManifest
- validate provider, identity, URL, and default branch
- add focused parser coverage

Closes ankhorage/gh#2.