### PR TITLE
feat: export repository config contract

### DIFF
--- a/.changeset/repository-config.md
+++ b/.changeset/repository-config.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Export the reusable `RepositoryConfig` contract slice and compose `AppManifest` from it.

--- a/package.json
+++ b/package.json
@@ -71,6 +71,10 @@
     "./media": {
       "types": "./dist/media.d.ts",
       "default": "./dist/media.js"
+    },
+    "./repository": {
+      "types": "./dist/repository.d.ts",
+      "default": "./dist/repository.js"
     }
   },
   "description": "Serializable app, action, theme, auth, and secret-store contracts for Ankhorage.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './data';
 export * from './db';
 export * from './deploy';
 export * from './media';
+export * from './repository';
 export * from './requirements';
 export * from './runtimeCallbacks';
 export * from './secretManifest';

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,0 +1,11 @@
+export interface AppRepositoryConfig {
+  readonly provider: 'github';
+  readonly owner: string;
+  readonly name: string;
+  readonly url: string;
+  readonly defaultBranch: 'main';
+}
+
+export interface RepositoryConfig {
+  repository?: AppRepositoryConfig;
+}

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,11 +1,7 @@
-export interface AppRepositoryConfig {
+export interface RepositoryConfig {
   readonly provider: 'github';
   readonly owner: string;
   readonly name: string;
   readonly url: string;
   readonly defaultBranch: 'main';
-}
-
-export interface RepositoryConfig {
-  repository?: AppRepositoryConfig;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -377,7 +377,7 @@ export interface AppSettings {
   };
 }
 
-export interface AppManifest extends RepositoryConfig {
+export interface AppManifest {
   metadata: {
     name: string;
     slug: string;
@@ -400,5 +400,6 @@ export interface AppManifest extends RepositoryConfig {
   screens: Record<string, ScreenSpec>;
   dataSources?: DataSourceRegistry;
   dataBindings?: ComponentDataBindingRegistry;
+  repository?: RepositoryConfig;
   settings: AppSettings;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ import type {
 import type { ApiDefinitionList, DataSourceRegistry } from './data';
 import type { AppDeployManifest } from './deploy';
 import type { MediaManifest } from './media';
+import type { RepositoryConfig } from './repository';
 import type { ScreenRequirements } from './requirements';
 import type { ThemeGlobalTokenOverrides, ThemeRecipeOverrides } from './theme';
 
@@ -376,15 +377,7 @@ export interface AppSettings {
   };
 }
 
-export interface AppRepositoryConfig {
-  readonly provider: 'github';
-  readonly owner: string;
-  readonly name: string;
-  readonly url: string;
-  readonly defaultBranch: 'main';
-}
-
-export interface AppManifest {
+export interface AppManifest extends RepositoryConfig {
   metadata: {
     name: string;
     slug: string;
@@ -407,6 +400,5 @@ export interface AppManifest {
   screens: Record<string, ScreenSpec>;
   dataSources?: DataSourceRegistry;
   dataBindings?: ComponentDataBindingRegistry;
-  repository?: AppRepositoryConfig;
   settings: AppSettings;
 }


### PR DESCRIPTION
Export a reusable `RepositoryConfig` slice from `@ankhorage/contracts` and compose `AppManifest` from it. This lets capability packages such as `@ankhorage/gh` depend on the canonical repository contract without importing the aggregate manifest.\n\nIncludes a minor changeset.