### PR TITLE
refactor: rename repository config to manifest

### DIFF
--- a/.changeset/rename-repository-manifest.md
+++ b/.changeset/rename-repository-manifest.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": major
+'@ankhorage/contracts': major
 ---
 
 Rename the serialized `RepositoryConfig` contract to `RepositoryManifest` while keeping `manifest.repository` as the canonical singular repository desired-state property.

--- a/.changeset/rename-repository-manifest.md
+++ b/.changeset/rename-repository-manifest.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": major
+---
+
+Rename the serialized `RepositoryConfig` contract to `RepositoryManifest` while keeping `manifest.repository` as the canonical singular repository desired-state property.

--- a/src/appManifest.ts
+++ b/src/appManifest.ts
@@ -66,7 +66,7 @@ export function isAppManifest(value: unknown): value is AppManifest {
     isScreenRegistry(value.screens) &&
     (value.dataSources === undefined || isDataSourceRegistry(value.dataSources)) &&
     (value.dataBindings === undefined || isComponentDataBindingRegistry(value.dataBindings)) &&
-    (value.repository === undefined || isAppRepositoryConfig(value.repository)) &&
+    (value.repository === undefined || isRepositoryManifest(value.repository)) &&
     isAppSettings(value.settings)
   );
 }
@@ -81,7 +81,7 @@ function isActiveThemeMode(value: unknown): boolean {
   return value === undefined || value === 'dark' || value === 'light';
 }
 
-function isAppRepositoryConfig(value: unknown): boolean {
+function isRepositoryManifest(value: unknown): boolean {
   return (
     isRecord(value) &&
     value.provider === 'github' &&

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,4 +1,4 @@
-export interface RepositoryConfig {
+export interface RepositoryManifest {
   readonly provider: 'github';
   readonly owner: string;
   readonly name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ import type {
 import type { ApiDefinitionList, DataSourceRegistry } from './data';
 import type { AppDeployManifest } from './deploy';
 import type { MediaManifest } from './media';
-import type { RepositoryConfig } from './repository';
+import type { RepositoryManifest } from './repository';
 import type { ScreenRequirements } from './requirements';
 import type { ThemeGlobalTokenOverrides, ThemeRecipeOverrides } from './theme';
 
@@ -400,6 +400,6 @@ export interface AppManifest {
   screens: Record<string, ScreenSpec>;
   dataSources?: DataSourceRegistry;
   dataBindings?: ComponentDataBindingRegistry;
-  repository?: RepositoryConfig;
+  repository?: RepositoryManifest;
   settings: AppSettings;
 }


### PR DESCRIPTION
## Summary

- rename the serialized repository slice from `RepositoryConfig` to `RepositoryManifest`
- keep `manifest.repository` singular and unchanged
- rename structural validation to manifest terminology
- remove the old public type without a compatibility alias
- add a major Changeset for the breaking public API rename

## Architecture

Contracts continues to own only the portable serialized `RepositoryManifest` slice. Repository behavior remains outside Contracts, and downstream capability packages must consume the released slice rather than the full `AppManifest`.

## Validation

CI is the authoritative repository validation for this connector-driven change. The diff is limited to the contract rename and Changeset.

Closes #166