### PR TITLE
chore: release contracts 9.0.0

### DIFF
--- a/.changeset/rename-repository-manifest.md
+++ b/.changeset/rename-repository-manifest.md
@@ -1,5 +1,0 @@
----
-'@ankhorage/contracts': major
----
-
-Rename the serialized `RepositoryConfig` contract to `RepositoryManifest` while keeping `manifest.repository` as the canonical singular repository desired-state property.

--- a/.changeset/renovate-162.md
+++ b/.changeset/renovate-162.md
@@ -1,4 +1,0 @@
----
----
-
-Update Ankhorage dependencies: `@ankhorage/devtools`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ankhorage/contracts
 
+## 9.0.0
+
+### Major Changes
+
+- f41542b: Rename the serialized `RepositoryConfig` contract to `RepositoryManifest` while keeping `manifest.repository` as the canonical singular repository desired-state property.
+
 ## 8.2.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ankhorage/contracts",
-  "version": "8.2.0",
+  "version": "9.0.0",
   "main": "./dist/index.js",
   "ankh": {
     "category": "contracts",


### PR DESCRIPTION
Release `@ankhorage/contracts@9.0.0` from the already reviewed and merged `RepositoryManifest` breaking change.

This branch is byte-equivalent to the Changesets-generated release branch, but is user-authored so normal CI can execute instead of remaining `action_required` on the bot-created PR.

Release contents:
- remove consumed changesets
- update package version to `9.0.0`
- update changelog

Related: #167, #168