### PR TITLE
refactor: extract app navigator manifest contract

### DIFF
--- a/.changeset/extract-app-navigator-manifest.md
+++ b/.changeset/extract-app-navigator-manifest.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': major
+---
+
+Replace the legacy `NavigatorSpec` contract with the focused `AppNavigatorManifest` slice, publish it through `@ankhorage/contracts/navigator`, and add typed topology presets plus adaptive, JavaScript, native, and custom tab implementation/presentation desired state.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
       "types": "./dist/media.d.ts",
       "default": "./dist/media.js"
     },
+    "./navigator": {
+      "types": "./dist/navigator.d.ts",
+      "default": "./dist/navigator.js"
+    },
     "./repository": {
       "types": "./dist/repository.d.ts",
       "default": "./dist/repository.js"
@@ -89,6 +93,7 @@
     "storage",
     "adapter",
     "media",
+    "navigator",
     "assets"
   ],
   "files": [

--- a/src/appManifest.ts
+++ b/src/appManifest.ts
@@ -4,8 +4,8 @@ import { isAppDeployManifest } from './appManifest/deploy';
 import { isInfraManifest } from './appManifest/infra';
 import { isMediaManifest } from './appManifest/media';
 import {
+  isAppNavigatorManifest,
   isManifestMetadata,
-  isNavigatorSpec,
   isScreenRegistry,
   isSplashScreenSpec,
   isThemeConfig,
@@ -62,7 +62,7 @@ export function isAppManifest(value: unknown): value is AppManifest {
     (value.media === undefined || isMediaManifest(value.media)) &&
     (value.deploy === undefined || isAppDeployManifest(value.deploy)) &&
     isInfraManifest(value.infra) &&
-    isNavigatorSpec(value.navigator) &&
+    isAppNavigatorManifest(value.navigator) &&
     isScreenRegistry(value.screens) &&
     (value.dataSources === undefined || isDataSourceRegistry(value.dataSources)) &&
     (value.dataBindings === undefined || isComponentDataBindingRegistry(value.dataBindings)) &&

--- a/src/appManifest/screens.ts
+++ b/src/appManifest/screens.ts
@@ -1,6 +1,13 @@
 import { COLOR_HARMONIES } from '@ankhorage/color-theory';
 
-import { APP_CATEGORIES, NAVIGATOR_TYPES } from '../types';
+import {
+  CUSTOM_TABS_PRESENTATIONS,
+  FIXED_CUSTOM_TABS_PRESENTATIONS,
+  JAVASCRIPT_TABS_PRESENTATIONS,
+  NAVIGATOR_PRESETS,
+  NAVIGATOR_TYPES,
+} from '../navigator';
+import { APP_CATEGORIES } from '../types';
 import { isBindingValueSource, isScreenDataLoaderDefinition } from './bindings';
 import {
   isOptionalBoolean,
@@ -12,6 +19,10 @@ import {
 
 const APP_CATEGORY_SET = new Set<string>(APP_CATEGORIES);
 const COLOR_HARMONY_SET = new Set<string>(COLOR_HARMONIES);
+const CUSTOM_TABS_PRESENTATION_SET = new Set<string>(CUSTOM_TABS_PRESENTATIONS);
+const FIXED_CUSTOM_TABS_PRESENTATION_SET = new Set<string>(FIXED_CUSTOM_TABS_PRESENTATIONS);
+const JAVASCRIPT_TABS_PRESENTATION_SET = new Set<string>(JAVASCRIPT_TABS_PRESENTATIONS);
+const NAVIGATOR_PRESET_SET = new Set<string>(NAVIGATOR_PRESETS);
 const NAVIGATOR_TYPE_SET = new Set<string>(NAVIGATOR_TYPES);
 const SPLASH_SCREEN_RESIZE_MODE_SET = new Set<string>(['contain', 'cover', 'native']);
 
@@ -39,15 +50,16 @@ export function isThemeConfig(value: unknown): boolean {
   );
 }
 
-export function isNavigatorSpec(value: unknown): boolean {
+/*** Validate the complete serialized `AppManifest.navigator` slice. */
+export function isAppNavigatorManifest(value: unknown): boolean {
   return (
     isRecord(value) &&
-    typeof value.type === 'string' &&
-    NAVIGATOR_TYPE_SET.has(value.type) &&
-    isOptionalString(value.initialRouteName) &&
-    Array.isArray(value.routes) &&
-    value.routes.every(isRouteDefinition) &&
-    (value.options === undefined || isRecord(value.options))
+    isNavigatorNode(value) &&
+    (value.preset === undefined ||
+      (typeof value.preset === 'string' && NAVIGATOR_PRESET_SET.has(value.preset))) &&
+    (value.flows === undefined || isNavigatorFlows(value.flows)) &&
+    (value.defaults === undefined || isNavigatorDefaults(value.defaults)) &&
+    (value.platforms === undefined || isNavigatorPlatforms(value.platforms))
   );
 }
 
@@ -117,6 +129,20 @@ function isScreenSpec(value: unknown): boolean {
   );
 }
 
+/*** Validate one nested navigator node independently from app-level authoring metadata. */
+function isNavigatorNode(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.type === 'string' &&
+    NAVIGATOR_TYPE_SET.has(value.type) &&
+    isOptionalString(value.initialRouteName) &&
+    Array.isArray(value.routes) &&
+    value.routes.every(isRouteDefinition) &&
+    (value.options === undefined || isRecord(value.options)) &&
+    (value.type !== 'tabs' || isTabsImplementationConfig(value))
+  );
+}
+
 function isRouteDefinition(value: unknown): boolean {
   return (
     isRecord(value) &&
@@ -127,7 +153,7 @@ function isRouteDefinition(value: unknown): boolean {
     isOptionalBoolean(value.showInPrimaryNavigation) &&
     (value.guards === undefined || isStringArray(value.guards)) &&
     isOptionalString(value.screenId) &&
-    (value.navigator === undefined || isNavigatorSpec(value.navigator))
+    (value.navigator === undefined || isNavigatorNode(value.navigator))
   );
 }
 
@@ -140,6 +166,115 @@ function isIconSpec(value: unknown): boolean {
       typeof value.size === 'string' ||
       typeof value.size === 'number') &&
     isOptionalString(value.color)
+  );
+}
+
+/*** Validate tabs implementation desired state, with omitted implementation meaning adaptive. */
+function isTabsImplementationConfig(value: Record<string, unknown>): boolean {
+  if (value.implementation === undefined || value.implementation === 'adaptive') {
+    return (
+      (value.native === undefined || isNativeTabsConfig(value.native)) &&
+      (value.web === undefined || isCustomTabsWebConfig(value.web))
+    );
+  }
+
+  if (value.implementation === 'native') return true;
+
+  if (value.implementation === 'javascript') {
+    return (
+      value.presentation === undefined ||
+      (typeof value.presentation === 'string' &&
+        JAVASCRIPT_TABS_PRESENTATION_SET.has(value.presentation))
+    );
+  }
+
+  return value.implementation === 'custom' && isCustomTabsConfig(value);
+}
+
+/*** Validate the native branch used by adaptive tabs. */
+function isNativeTabsConfig(value: unknown): boolean {
+  return isRecord(value) && value.implementation === 'native';
+}
+
+/*** Validate a full custom-tabs implementation config. */
+function isCustomTabsConfig(value: Record<string, unknown>): boolean {
+  return value.implementation === 'custom' && isCustomTabsPresentationConfig(value);
+}
+
+/*** Validate the implementation-free custom-tabs Web branch inside adaptive tabs. */
+function isCustomTabsWebConfig(value: unknown): boolean {
+  return (
+    isRecord(value) && value.implementation === undefined && isCustomTabsPresentationConfig(value)
+  );
+}
+
+/*** Validate custom-tab presentation and its conditional serializable configuration. */
+function isCustomTabsPresentationConfig(value: Record<string, unknown>): boolean {
+  if (
+    typeof value.presentation !== 'string' ||
+    !CUSTOM_TABS_PRESENTATION_SET.has(value.presentation)
+  ) {
+    return false;
+  }
+
+  if (value.responsive !== undefined && !isResponsiveTabsPresentation(value.responsive)) {
+    return false;
+  }
+
+  if (!isOptionalString(value.customPresentationId)) return false;
+  if (value.presentation === 'responsive' && value.responsive === undefined) return false;
+
+  return (
+    value.presentation !== 'custom' ||
+    (typeof value.customPresentationId === 'string' && value.customPresentationId.length > 0)
+  );
+}
+
+/*** Validate semantic compact/medium/expanded custom-tab presentation mapping. */
+function isResponsiveTabsPresentation(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.compact === 'string' &&
+    FIXED_CUSTOM_TABS_PRESENTATION_SET.has(value.compact) &&
+    (value.medium === undefined ||
+      (typeof value.medium === 'string' && FIXED_CUSTOM_TABS_PRESENTATION_SET.has(value.medium))) &&
+    typeof value.expanded === 'string' &&
+    FIXED_CUSTOM_TABS_PRESENTATION_SET.has(value.expanded)
+  );
+}
+
+/*** Validate optional app-level navigator flow intent. */
+function isNavigatorFlows(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    isOptionalBoolean(value.onboarding) &&
+    isOptionalBoolean(value.authentication)
+  );
+}
+
+/*** Validate package-owned navigator defaults without requiring a navigator node type. */
+function isNavigatorDefaults(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    (value.tabs === undefined || (isRecord(value.tabs) && isTabsImplementationConfig(value.tabs)))
+  );
+}
+
+/*** Validate per-platform navigator implementation overrides. */
+function isNavigatorPlatforms(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    (value.android === undefined || isNavigatorPlatformConfig(value.android)) &&
+    (value.ios === undefined || isNavigatorPlatformConfig(value.ios)) &&
+    (value.web === undefined || isNavigatorPlatformConfig(value.web))
+  );
+}
+
+/*** Validate one platform-specific navigator override slice. */
+function isNavigatorPlatformConfig(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    (value.tabs === undefined || (isRecord(value.tabs) && isTabsImplementationConfig(value.tabs)))
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './data';
 export * from './db';
 export * from './deploy';
 export * from './media';
+export * from './navigator';
 export * from './repository';
 export * from './requirements';
 export * from './runtimeCallbacks';

--- a/src/navigator.test.ts
+++ b/src/navigator.test.ts
@@ -1,0 +1,117 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'bun:test';
+
+import { isAppNavigatorManifest } from './appManifest/screens';
+import {
+  NAVIGATOR_PRESETS,
+  type AppNavigatorManifest,
+  type TabsNavigatorConfig,
+} from './navigator';
+
+function createAdaptiveTabs(): AppNavigatorManifest {
+  return {
+    type: 'tabs',
+    preset: 'tabs-stack',
+    implementation: 'adaptive',
+    web: {
+      presentation: 'responsive',
+      responsive: {
+        compact: 'bottom',
+        medium: 'rail',
+        expanded: 'sidebar',
+      },
+    },
+    flows: { onboarding: true },
+    routes: [{ name: 'home', path: '/', screenId: 'home' }],
+  };
+}
+
+describe('app navigator manifest contract', () => {
+  it('keeps canonical topology presets finite and authorable', () => {
+    expect(NAVIGATOR_PRESETS).toContain('root-stack-tabs-stack');
+    expect(NAVIGATOR_PRESETS).toContain('root-stack-drawer-tabs-stack');
+  });
+
+  it('accepts adaptive native/Web tabs with responsive custom presentation', () => {
+    expect(isAppNavigatorManifest(createAdaptiveTabs())).toBe(true);
+  });
+
+  it('treats omitted tabs implementation as the canonical adaptive default', () => {
+    const tabs: TabsNavigatorConfig = { type: 'tabs' };
+    const navigator: AppNavigatorManifest = { ...tabs, routes: [] };
+
+    expect(isAppNavigatorManifest(navigator)).toBe(true);
+  });
+
+  it('accepts fixed and registered custom Web presentations', () => {
+    expect(
+      isAppNavigatorManifest({
+        type: 'tabs',
+        implementation: 'custom',
+        presentation: 'sidebar',
+        routes: [],
+      }),
+    ).toBe(true);
+
+    expect(
+      isAppNavigatorManifest({
+        type: 'tabs',
+        implementation: 'custom',
+        presentation: 'custom',
+        customPresentationId: 'workspace-tabs',
+        routes: [],
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects incomplete responsive and custom presentation configuration', () => {
+    expect(
+      isAppNavigatorManifest({
+        type: 'tabs',
+        implementation: 'custom',
+        presentation: 'responsive',
+        routes: [],
+      }),
+    ).toBe(false);
+
+    expect(
+      isAppNavigatorManifest({
+        type: 'tabs',
+        implementation: 'custom',
+        presentation: 'custom',
+        routes: [],
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps nested topology separate from app-level flow metadata', () => {
+    expect(
+      isAppNavigatorManifest({
+        type: 'stack',
+        flows: { authentication: true },
+        routes: [
+          {
+            name: 'app',
+            navigator: {
+              type: 'tabs',
+              routes: [{ name: 'home', screenId: 'home' }],
+            },
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('publishes the focused navigator contract subpath', async () => {
+    const packageJson = JSON.parse(await readFile(join(process.cwd(), 'package.json'), 'utf8')) as {
+      exports?: Record<string, { default?: string; types?: string }>;
+    };
+
+    expect(packageJson.exports?.['./navigator']).toEqual({
+      types: './dist/navigator.d.ts',
+      default: './dist/navigator.js',
+    });
+  });
+});

--- a/src/navigator.test.ts
+++ b/src/navigator.test.ts
@@ -5,8 +5,8 @@ import { describe, expect, it } from 'bun:test';
 
 import { isAppNavigatorManifest } from './appManifest/screens';
 import {
-  NAVIGATOR_PRESETS,
   type AppNavigatorManifest,
+  NAVIGATOR_PRESETS,
   type TabsNavigatorConfig,
 } from './navigator';
 
@@ -28,7 +28,7 @@ function createAdaptiveTabs(): AppNavigatorManifest {
   };
 }
 
-describe('app navigator manifest contract', () => {
+describe('app navigator manifest topology', () => {
   it('keeps canonical topology presets finite and authorable', () => {
     expect(NAVIGATOR_PRESETS).toContain('root-stack-tabs-stack');
     expect(NAVIGATOR_PRESETS).toContain('root-stack-drawer-tabs-stack');
@@ -44,7 +44,9 @@ describe('app navigator manifest contract', () => {
 
     expect(isAppNavigatorManifest(navigator)).toBe(true);
   });
+});
 
+describe('app navigator manifest presentation', () => {
   it('accepts fixed and registered custom Web presentations', () => {
     expect(
       isAppNavigatorManifest({

--- a/src/navigator.test.ts
+++ b/src/navigator.test.ts
@@ -46,7 +46,7 @@ describe('app navigator manifest topology', () => {
   });
 });
 
-describe('app navigator manifest presentation', () => {
+describe('app navigator manifest custom presentation', () => {
   it('accepts fixed and registered custom Web presentations', () => {
     expect(
       isAppNavigatorManifest({
@@ -87,7 +87,9 @@ describe('app navigator manifest presentation', () => {
       }),
     ).toBe(false);
   });
+});
 
+describe('app navigator manifest composition', () => {
   it('keeps nested topology separate from app-level flow metadata', () => {
     expect(
       isAppNavigatorManifest({

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -1,0 +1,139 @@
+import type { IconSpec } from './types';
+
+export const NAVIGATOR_TYPES = ['stack', 'tabs', 'drawer'] as const;
+export type NavigatorType = (typeof NAVIGATOR_TYPES)[number];
+
+export const NAVIGATOR_PRESETS = [
+  'stack',
+  'tabs',
+  'tabs-stack',
+  'drawer',
+  'drawer-stack',
+  'drawer-tabs',
+  'drawer-tabs-stack',
+  'root-stack-tabs',
+  'root-stack-tabs-stack',
+  'root-stack-drawer',
+  'root-stack-drawer-stack',
+  'root-stack-drawer-tabs',
+  'root-stack-drawer-tabs-stack',
+] as const;
+export type NavigatorPreset = (typeof NAVIGATOR_PRESETS)[number];
+
+export const FIXED_CUSTOM_TABS_PRESENTATIONS = ['bottom', 'top', 'rail', 'sidebar'] as const;
+export type FixedCustomTabsPresentation = (typeof FIXED_CUSTOM_TABS_PRESENTATIONS)[number];
+
+export const CUSTOM_TABS_PRESENTATIONS = [
+  ...FIXED_CUSTOM_TABS_PRESENTATIONS,
+  'responsive',
+  'custom',
+] as const;
+export type CustomTabsPresentation = (typeof CUSTOM_TABS_PRESENTATIONS)[number];
+
+export const JAVASCRIPT_TABS_PRESENTATIONS = ['bottom', 'top'] as const;
+export type JavaScriptTabsPresentation = (typeof JAVASCRIPT_TABS_PRESENTATIONS)[number];
+
+export interface ResponsiveTabsPresentation {
+  readonly compact: FixedCustomTabsPresentation;
+  readonly medium?: FixedCustomTabsPresentation;
+  readonly expanded: FixedCustomTabsPresentation;
+}
+
+export interface CustomTabsConfig {
+  readonly implementation: 'custom';
+  readonly presentation: CustomTabsPresentation;
+  readonly responsive?: ResponsiveTabsPresentation;
+  /** Serializable registered presentation id used when `presentation` is `custom`. */
+  readonly customPresentationId?: string;
+}
+
+export interface NativeTabsConfig {
+  readonly implementation: 'native';
+}
+
+export interface JavaScriptTabsConfig {
+  readonly implementation: 'javascript';
+  readonly presentation?: JavaScriptTabsPresentation;
+}
+
+export interface AdaptiveTabsConfig {
+  /** Omission selects the canonical adaptive default. */
+  readonly implementation?: 'adaptive';
+  /** Android/iOS branch. Expo Router may expose this implementation as unstable. */
+  readonly native?: NativeTabsConfig;
+  /** Web branch rendered through headless custom tabs. */
+  readonly web?: Omit<CustomTabsConfig, 'implementation'>;
+}
+
+export type TabsImplementationConfig =
+  | AdaptiveTabsConfig
+  | CustomTabsConfig
+  | JavaScriptTabsConfig
+  | NativeTabsConfig;
+
+interface NavigatorNodeBase {
+  readonly initialRouteName?: string;
+  readonly routes: readonly RouteDefinition[];
+  /** Typed upstream options can be layered by the owning Navigator package. */
+  readonly options?: Record<string, unknown>;
+}
+
+export interface StackNavigatorNode extends NavigatorNodeBase {
+  readonly type: 'stack';
+}
+
+export interface DrawerNavigatorNode extends NavigatorNodeBase {
+  readonly type: 'drawer';
+}
+
+export type TabsNavigatorConfig = {
+  readonly type: 'tabs';
+} & TabsImplementationConfig;
+
+export type TabsNavigatorNode = NavigatorNodeBase & TabsNavigatorConfig;
+
+export type NavigatorNode = DrawerNavigatorNode | StackNavigatorNode | TabsNavigatorNode;
+
+export interface RouteDefinition {
+  readonly name: string;
+  readonly path?: string;
+  readonly label?: string;
+  readonly icon?: IconSpec;
+  /** Hide this route from primary Tabs/Drawer presentation without making it unnavigable. */
+  readonly showInPrimaryNavigation?: boolean;
+  readonly guards?: readonly string[];
+  readonly screenId?: string;
+  readonly navigator?: NavigatorNode;
+}
+
+export interface NavigatorFlows {
+  readonly onboarding?: boolean;
+  readonly authentication?: boolean;
+}
+
+export interface NavigatorDefaults {
+  readonly tabs?: TabsImplementationConfig;
+}
+
+export interface NavigatorPlatformConfig {
+  readonly tabs?: TabsImplementationConfig;
+}
+
+export interface NavigatorPlatforms {
+  readonly android?: NavigatorPlatformConfig;
+  readonly ios?: NavigatorPlatformConfig;
+  readonly web?: NavigatorPlatformConfig;
+}
+
+/**
+ * Serializable desired state for `AppManifest.navigator`.
+ *
+ * The manifest slice is the root navigator tree itself; optional authoring metadata does not add
+ * a redundant `root` wrapper. The standalone Navigator capability consumes this slice directly.
+ */
+export type AppNavigatorManifest = NavigatorNode & {
+  readonly preset?: NavigatorPreset;
+  readonly flows?: NavigatorFlows;
+  readonly defaults?: NavigatorDefaults;
+  readonly platforms?: NavigatorPlatforms;
+};

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -65,11 +65,7 @@ export interface AdaptiveTabsConfig {
   web?: Omit<CustomTabsConfig, 'implementation'>;
 }
 
-export type TabsImplementationConfig =
-  | AdaptiveTabsConfig
-  | CustomTabsConfig
-  | JavaScriptTabsConfig
-  | NativeTabsConfig;
+export type TabsImplementationConfig = AdaptiveTabsConfig | CustomTabsConfig | JavaScriptTabsConfig | NativeTabsConfig;
 
 interface NavigatorNodeBase {
   initialRouteName?: string;

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -34,35 +34,35 @@ export const JAVASCRIPT_TABS_PRESENTATIONS = ['bottom', 'top'] as const;
 export type JavaScriptTabsPresentation = (typeof JAVASCRIPT_TABS_PRESENTATIONS)[number];
 
 export interface ResponsiveTabsPresentation {
-  readonly compact: FixedCustomTabsPresentation;
-  readonly medium?: FixedCustomTabsPresentation;
-  readonly expanded: FixedCustomTabsPresentation;
+  compact: FixedCustomTabsPresentation;
+  medium?: FixedCustomTabsPresentation;
+  expanded: FixedCustomTabsPresentation;
 }
 
 export interface CustomTabsConfig {
-  readonly implementation: 'custom';
-  readonly presentation: CustomTabsPresentation;
-  readonly responsive?: ResponsiveTabsPresentation;
+  implementation: 'custom';
+  presentation: CustomTabsPresentation;
+  responsive?: ResponsiveTabsPresentation;
   /** Serializable registered presentation id used when `presentation` is `custom`. */
-  readonly customPresentationId?: string;
+  customPresentationId?: string;
 }
 
 export interface NativeTabsConfig {
-  readonly implementation: 'native';
+  implementation: 'native';
 }
 
 export interface JavaScriptTabsConfig {
-  readonly implementation: 'javascript';
-  readonly presentation?: JavaScriptTabsPresentation;
+  implementation: 'javascript';
+  presentation?: JavaScriptTabsPresentation;
 }
 
 export interface AdaptiveTabsConfig {
   /** Omission selects the canonical adaptive default. */
-  readonly implementation?: 'adaptive';
+  implementation?: 'adaptive';
   /** Android/iOS branch. Expo Router may expose this implementation as unstable. */
-  readonly native?: NativeTabsConfig;
+  native?: NativeTabsConfig;
   /** Web branch rendered through headless custom tabs. */
-  readonly web?: Omit<CustomTabsConfig, 'implementation'>;
+  web?: Omit<CustomTabsConfig, 'implementation'>;
 }
 
 export type TabsImplementationConfig =
@@ -72,22 +72,22 @@ export type TabsImplementationConfig =
   | NativeTabsConfig;
 
 interface NavigatorNodeBase {
-  readonly initialRouteName?: string;
-  readonly routes: readonly RouteDefinition[];
+  initialRouteName?: string;
+  routes: RouteDefinition[];
   /** Typed upstream options can be layered by the owning Navigator package. */
-  readonly options?: Record<string, unknown>;
+  options?: Record<string, unknown>;
 }
 
 export interface StackNavigatorNode extends NavigatorNodeBase {
-  readonly type: 'stack';
+  type: 'stack';
 }
 
 export interface DrawerNavigatorNode extends NavigatorNodeBase {
-  readonly type: 'drawer';
+  type: 'drawer';
 }
 
 export type TabsNavigatorConfig = {
-  readonly type: 'tabs';
+  type: 'tabs';
 } & TabsImplementationConfig;
 
 export type TabsNavigatorNode = NavigatorNodeBase & TabsNavigatorConfig;
@@ -95,34 +95,34 @@ export type TabsNavigatorNode = NavigatorNodeBase & TabsNavigatorConfig;
 export type NavigatorNode = DrawerNavigatorNode | StackNavigatorNode | TabsNavigatorNode;
 
 export interface RouteDefinition {
-  readonly name: string;
-  readonly path?: string;
-  readonly label?: string;
-  readonly icon?: IconSpec;
+  name: string;
+  path?: string;
+  label?: string;
+  icon?: IconSpec;
   /** Hide this route from primary Tabs/Drawer presentation without making it unnavigable. */
-  readonly showInPrimaryNavigation?: boolean;
-  readonly guards?: readonly string[];
-  readonly screenId?: string;
-  readonly navigator?: NavigatorNode;
+  showInPrimaryNavigation?: boolean;
+  guards?: string[];
+  screenId?: string;
+  navigator?: NavigatorNode;
 }
 
 export interface NavigatorFlows {
-  readonly onboarding?: boolean;
-  readonly authentication?: boolean;
+  onboarding?: boolean;
+  authentication?: boolean;
 }
 
 export interface NavigatorDefaults {
-  readonly tabs?: TabsImplementationConfig;
+  tabs?: TabsImplementationConfig;
 }
 
 export interface NavigatorPlatformConfig {
-  readonly tabs?: TabsImplementationConfig;
+  tabs?: TabsImplementationConfig;
 }
 
 export interface NavigatorPlatforms {
-  readonly android?: NavigatorPlatformConfig;
-  readonly ios?: NavigatorPlatformConfig;
-  readonly web?: NavigatorPlatformConfig;
+  android?: NavigatorPlatformConfig;
+  ios?: NavigatorPlatformConfig;
+  web?: NavigatorPlatformConfig;
 }
 
 /**
@@ -132,8 +132,8 @@ export interface NavigatorPlatforms {
  * a redundant `root` wrapper. The standalone Navigator capability consumes this slice directly.
  */
 export type AppNavigatorManifest = NavigatorNode & {
-  readonly preset?: NavigatorPreset;
-  readonly flows?: NavigatorFlows;
-  readonly defaults?: NavigatorDefaults;
-  readonly platforms?: NavigatorPlatforms;
+  preset?: NavigatorPreset;
+  flows?: NavigatorFlows;
+  defaults?: NavigatorDefaults;
+  platforms?: NavigatorPlatforms;
 };

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -65,7 +65,8 @@ export interface AdaptiveTabsConfig {
   web?: Omit<CustomTabsConfig, 'implementation'>;
 }
 
-export type TabsImplementationConfig = AdaptiveTabsConfig | CustomTabsConfig | JavaScriptTabsConfig | NativeTabsConfig;
+export type TabsImplementationConfig =
+  AdaptiveTabsConfig | CustomTabsConfig | JavaScriptTabsConfig | NativeTabsConfig;
 
 interface NavigatorNodeBase {
   initialRouteName?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ import type {
 import type { ApiDefinitionList, DataSourceRegistry } from './data';
 import type { AppDeployManifest } from './deploy';
 import type { MediaManifest } from './media';
+import type { AppNavigatorManifest } from './navigator';
 import type { RepositoryManifest } from './repository';
 import type { ScreenRequirements } from './requirements';
 import type { ThemeGlobalTokenOverrides, ThemeRecipeOverrides } from './theme';
@@ -135,9 +136,6 @@ export type ComponentEventDtoKind =
 export type KnownComponentEventDto =
   ButtonPressEventDto | CollectionItemPressEventDto | FormSubmitEventDto;
 
-export const NAVIGATOR_TYPES = ['stack', 'tabs', 'drawer'] as const;
-export type NavigatorType = (typeof NAVIGATOR_TYPES)[number];
-
 export const APP_CATEGORIES = [
   'books_reading',
   'business_productivity',
@@ -258,31 +256,6 @@ export interface ScreenSpec {
   requires?: ScreenRequirements;
 }
 
-export interface NavigatorSpec {
-  type: NavigatorType;
-  initialRouteName?: string;
-  routes: RouteDefinition[];
-  options?: Record<string, unknown>;
-}
-
-export interface RouteDefinition {
-  name: string;
-  path?: string;
-  label?: string;
-  icon?: IconSpec;
-  /**
-   * Whether this route appears in Tabs and Drawer primary navigation.
-   *
-   * Omitted routes are visible by default. Setting this to `false` hides the
-   * route from primary navigation without making it unnavigable. Stack
-   * navigators preserve the value but do not present primary navigation.
-   */
-  showInPrimaryNavigation?: boolean;
-  guards?: string[];
-  screenId?: string;
-  navigator?: NavigatorSpec;
-}
-
 export type SplashScreenResizeMode = 'contain' | 'cover' | 'native';
 
 export interface SplashScreenAssetSpec {
@@ -396,7 +369,7 @@ export interface AppManifest {
   /** App distribution desired state. Infrastructure deployment remains under `infra.deployment`. */
   deploy?: AppDeployManifest;
   infra: InfraManifest;
-  navigator: NavigatorSpec;
+  navigator: AppNavigatorManifest;
   screens: Record<string, ScreenSpec>;
   dataSources?: DataSourceRegistry;
   dataBindings?: ComponentDataBindingRegistry;


### PR DESCRIPTION
## Summary

- replace the legacy `NavigatorSpec` public contract with focused `AppNavigatorManifest`
- publish the slice through `@ankhorage/contracts/navigator`
- preserve the existing root navigator JSON shape instead of adding a redundant `root` wrapper
- add finite topology presets and typed tabs implementation/presentation desired state
- make omitted tab `implementation` mean the canonical adaptive default
- validate adaptive native/Web tabs, responsive bottom/rail/sidebar presentation and registered custom presentation
- preserve existing route/navigator mutability for Studio authoring drafts

## Boundary

Contracts owns only serialized types and structural validation. `@ankhorage/navigator` must consume `AppNavigatorManifest` directly and must never import or accept the full `AppManifest`.

## Public API

Breaking rename: `NavigatorSpec` is removed; consumers migrate to `AppNavigatorManifest` / `NavigatorNode`. Existing serialized stack/tabs/drawer trees remain representable.

## Validation

CI is authoritative for build, Doctor, lint, format, Knip, tests, typecheck and Changesets. Added focused navigator contract tests and `./navigator` export acceptance.

Closes #170

## Codex

Model: `gpt-5.6-sol`
Reasoning: `high`