### PR TITLE
feat: support SVG media icon sources

### DIFF
--- a/.changeset/svg-icon-source.md
+++ b/.changeset/svg-icon-source.md
@@ -1,0 +1,6 @@
+---
+'@ankhorage/contracts': minor
+---
+
+Allow manifest icon specifications to reference SVG media assets through a mutually exclusive
+`source` branch.

--- a/src/appManifest/icon.ts
+++ b/src/appManifest/icon.ts
@@ -1,0 +1,26 @@
+import { isMediaAssetReference } from '../media';
+import { isOptionalString, isRecord } from './shared';
+
+/*** Validate a serializable icon as either a named font glyph or an SVG media reference. */
+export function isIconSpec(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+
+  const hasValidPresentation =
+    (value.size === undefined ||
+      typeof value.size === 'string' ||
+      typeof value.size === 'number') &&
+    isOptionalString(value.color);
+  if (!hasValidPresentation) return false;
+
+  if ('source' in value) {
+    return (
+      isMediaAssetReference(value.source) &&
+      value.name === undefined &&
+      value.provider === undefined
+    );
+  }
+
+  return (
+    typeof value.name === 'string' && isOptionalString(value.provider) && value.source === undefined
+  );
+}

--- a/src/appManifest/infra.ts
+++ b/src/appManifest/infra.ts
@@ -13,6 +13,7 @@ import {
   STORAGE_PROVIDERS,
 } from '../types';
 import { isApiDefinitionList } from './apis';
+import { isIconSpec } from './icon';
 import {
   isOptionalBoolean,
   isOptionalString,
@@ -185,17 +186,5 @@ function isAuthProfileSpec(value: unknown): boolean {
     (value.updateStrategy === undefined ||
       (typeof value.updateStrategy === 'string' &&
         AUTH_PROFILE_UPDATE_STRATEGY_SET.has(value.updateStrategy)))
-  );
-}
-
-function isIconSpec(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    typeof value.name === 'string' &&
-    isOptionalString(value.provider) &&
-    (value.size === undefined ||
-      typeof value.size === 'string' ||
-      typeof value.size === 'number') &&
-    isOptionalString(value.color)
   );
 }

--- a/src/appManifest/screens.ts
+++ b/src/appManifest/screens.ts
@@ -9,6 +9,7 @@ import {
 } from '../navigator';
 import { APP_CATEGORIES } from '../types';
 import { isBindingValueSource, isScreenDataLoaderDefinition } from './bindings';
+import { isIconSpec } from './icon';
 import {
   isOptionalBoolean,
   isOptionalNumber,
@@ -154,18 +155,6 @@ function isRouteDefinition(value: unknown): boolean {
     (value.guards === undefined || isStringArray(value.guards)) &&
     isOptionalString(value.screenId) &&
     (value.navigator === undefined || isNavigatorNode(value.navigator))
-  );
-}
-
-function isIconSpec(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    typeof value.name === 'string' &&
-    isOptionalString(value.provider) &&
-    (value.size === undefined ||
-      typeof value.size === 'string' ||
-      typeof value.size === 'number') &&
-    isOptionalString(value.color)
   );
 }
 

--- a/src/navigator.test.ts
+++ b/src/navigator.test.ts
@@ -38,6 +38,29 @@ describe('app navigator manifest topology', () => {
     expect(isAppNavigatorManifest(createAdaptiveTabs())).toBe(true);
   });
 
+  it('accepts SVG media icon references without a provider', () => {
+    const navigator = createAdaptiveTabs();
+    navigator.routes[0] = {
+      ...navigator.routes[0],
+      icon: { source: { mediaId: 'navigation-home' } },
+    };
+
+    expect(isAppNavigatorManifest(navigator)).toBe(true);
+  });
+
+  it('rejects icon definitions that mix named and media sources', () => {
+    const navigator = createAdaptiveTabs();
+    navigator.routes[0] = {
+      ...navigator.routes[0],
+      icon: {
+        name: 'home-outline',
+        source: { mediaId: 'navigation-home' },
+      } as never,
+    };
+
+    expect(isAppNavigatorManifest(navigator)).toBe(false);
+  });
+
   it('treats omitted tabs implementation as the canonical adaptive default', () => {
     const tabs: TabsNavigatorConfig = { type: 'tabs' };
     const navigator: AppNavigatorManifest = { ...tabs, routes: [] };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import type {
 } from './bindings';
 import type { ApiDefinitionList, DataSourceRegistry } from './data';
 import type { AppDeployManifest } from './deploy';
-import type { MediaManifest } from './media';
+import type { MediaAssetReference, MediaManifest } from './media';
 import type { AppNavigatorManifest } from './navigator';
 import type { RepositoryManifest } from './repository';
 import type { ScreenRequirements } from './requirements';
@@ -222,12 +222,24 @@ export type AuthProfileCreateStrategy = (typeof AUTH_PROFILE_CREATE_STRATEGIES)[
 export const AUTH_PROFILE_UPDATE_STRATEGIES = ['api', 'app'] as const;
 export type AuthProfileUpdateStrategy = (typeof AUTH_PROFILE_UPDATE_STRATEGIES)[number];
 
-export interface IconSpec {
-  name: string;
-  provider?: string;
+interface IconPresentationSpec {
   size?: number | string;
   color?: string;
 }
+
+export interface NamedIconSpec extends IconPresentationSpec {
+  name: string;
+  provider?: string;
+  source?: never;
+}
+
+export interface SvgIconSpec extends IconPresentationSpec {
+  source: MediaAssetReference;
+  name?: never;
+  provider?: never;
+}
+
+export type IconSpec = NamedIconSpec | SvgIconSpec;
 
 export interface UiNodeRepeatSpec {
   source: BindingValueSource;


### PR DESCRIPTION
## Summary\n- add mutually exclusive named and SVG media icon specifications\n- share one structural icon validator across navigator and OAuth manifests\n- cover accepted SVG references and rejected mixed sources\n\nCloses #173