### PR TITLE
feat!: extend navigator manifest variants

### DIFF
--- a/.changeset/strong-routes-navigate.md
+++ b/.changeset/strong-routes-navigate.md
@@ -1,0 +1,7 @@
+---
+'@ankhorage/contracts': major
+---
+
+Add serializable Slot, typed Stack, Drawer, Tabs, Split View, and Custom navigator variants with matching structural validation.
+
+This is a breaking contract change: the arbitrary navigator `options` bag is removed, Stack and Drawer options are now finite typed branches, custom tabs use strict presentation discriminants, and invalid or non-JSON custom configuration is rejected. No authored `options` values were found in the current canonical consumers; the major release prevents their existing `^10` ranges from receiving the narrowed contract automatically.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # CONTRACTS
 
-![license: MIT](././paradox/badges/license.svg) ![npm: v8.0.1](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
+![license: MIT](././paradox/badges/license.svg) ![npm: v10.1.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
 
 Serializable app, action, theme, auth, and secret-store contracts for Ankhorage.
 

--- a/paradox/badges/npm.svg
+++ b/paradox/badges/npm.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="npm: v8.0.1">
-<title>npm: v8.0.1</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="97" height="20" role="img" aria-label="npm: v10.1.0">
+<title>npm: v10.1.0</title>
 <rect width="38" height="20" fill="#374151"/>
-<rect x="38" width="52" height="20" fill="#cb3837"/>
+<rect x="38" width="59" height="20" fill="#cb3837"/>
 <text x="19" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">npm</text>
-<text x="64" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v8.0.1</text>
+<text x="67.5" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v10.1.0</text>
 </svg>

--- a/paradox/diagrams/architecture-overview.mmd
+++ b/paradox/diagrams/architecture-overview.mmd
@@ -31,9 +31,14 @@ graph TD
   package__ankhorage_contracts -.-> module_src_appManifest_deploy_ts
   module_src_appManifest_deploy_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --> module_src_deploy_ts
+  module_src_appManifest_icon_ts["src/appManifest/icon.ts"]
+  package__ankhorage_contracts -.-> module_src_appManifest_icon_ts
+  module_src_appManifest_icon_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_icon_ts --> module_src_media_ts
   module_src_appManifest_infra_ts["src/appManifest/infra.ts"]
   package__ankhorage_contracts -.-> module_src_appManifest_infra_ts
   module_src_appManifest_infra_ts --> module_src_appManifest_apis_ts
+  module_src_appManifest_infra_ts --> module_src_appManifest_icon_ts
   module_src_appManifest_infra_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_infra_ts --> module_src_auth_ts
   module_src_appManifest_infra_ts --> module_src_types_ts
@@ -41,6 +46,16 @@ graph TD
   package__ankhorage_contracts -.-> module_src_appManifest_media_ts
   module_src_appManifest_media_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_media_ts --> module_src_media_ts
+  module_src_appManifest_navigator_ts["src/appManifest/navigator.ts"]
+  package__ankhorage_contracts -.-> module_src_appManifest_navigator_ts
+  module_src_appManifest_navigator_ts --> module_src_appManifest_icon_ts
+  module_src_appManifest_navigator_ts --> module_src_appManifest_navigatorOptions_ts
+  module_src_appManifest_navigator_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_navigator_ts --> module_src_navigator_ts
+  module_src_appManifest_navigatorOptions_ts["src/appManifest/navigatorOptions.ts"]
+  package__ankhorage_contracts -.-> module_src_appManifest_navigatorOptions_ts
+  module_src_appManifest_navigatorOptions_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_navigatorOptions_ts --> module_src_navigator_ts
   module_src_appManifest_screens_ts["src/appManifest/screens.ts"]
   package__ankhorage_contracts -.-> module_src_appManifest_screens_ts
   module_src_appManifest_screens_ts --> module_src_appManifest_bindings_ts
@@ -108,6 +123,11 @@ graph TD
   module_src_index_ts["src/index.ts"]
   module_src_media_ts["src/media.ts"]
   package__ankhorage_contracts -.-> module_src_media_ts
+  module_src_navigator_ts["src/navigator.ts"]
+  package__ankhorage_contracts -.-> module_src_navigator_ts
+  module_src_navigator_ts --> module_src_types_ts
+  module_src_repository_ts["src/repository.ts"]
+  package__ankhorage_contracts -.-> module_src_repository_ts
   module_src_requirements_ts["src/requirements.ts"]
   package__ankhorage_contracts -.-> module_src_requirements_ts
   module_src_runtimeCallbacks_ts["src/runtimeCallbacks.ts"]
@@ -131,6 +151,8 @@ graph TD
   module_src_types_ts --> module_src_data_index_ts
   module_src_types_ts --> module_src_deploy_ts
   module_src_types_ts --> module_src_media_ts
+  module_src_types_ts --> module_src_navigator_ts
+  module_src_types_ts --> module_src_repository_ts
   module_src_types_ts --> module_src_requirements_ts
   module_src_types_ts --> module_src_theme_ts
   module_src_ui_ts["src/ui.ts"]

--- a/paradox/diagrams/export-graph.mmd
+++ b/paradox/diagrams/export-graph.mmd
@@ -5,8 +5,11 @@ graph LR
   module_src_appManifest_data_ts["src/appManifest/data.ts"]
   module_src_appManifest_dataSources_ts["src/appManifest/dataSources.ts"]
   module_src_appManifest_deploy_ts["src/appManifest/deploy.ts"]
+  module_src_appManifest_icon_ts["src/appManifest/icon.ts"]
   module_src_appManifest_infra_ts["src/appManifest/infra.ts"]
   module_src_appManifest_media_ts["src/appManifest/media.ts"]
+  module_src_appManifest_navigator_ts["src/appManifest/navigator.ts"]
+  module_src_appManifest_navigatorOptions_ts["src/appManifest/navigatorOptions.ts"]
   module_src_appManifest_screens_ts["src/appManifest/screens.ts"]
   module_src_appManifest_shared_ts["src/appManifest/shared.ts"]
   module_src_auth_ts["src/auth.ts"]
@@ -26,6 +29,8 @@ graph LR
   module_src_deploy_ts["src/deploy.ts"]
   module_src_index_ts["src/index.ts"]
   module_src_media_ts["src/media.ts"]
+  module_src_navigator_ts["src/navigator.ts"]
+  module_src_repository_ts["src/repository.ts"]
   module_src_requirements_ts["src/requirements.ts"]
   module_src_runtimeCallbacks_ts["src/runtimeCallbacks.ts"]
   module_src_secretManifest_ts["src/secretManifest.ts"]
@@ -47,6 +52,10 @@ graph LR
   module_src_data_refs_ts --> export_AdapterRef
   export_AdapterRef -.-> export_AdapterKind
   export_AdapterRef -.-> export_DataContractValue
+  export_AdaptiveTabsConfig["AdaptiveTabsConfig"]
+  module_src_navigator_ts --> export_AdaptiveTabsConfig
+  export_AdaptiveTabsConfig -.-> export_CustomTabsPresentationConfig
+  export_AdaptiveTabsConfig -.-> export_NativeTabsConfig
   export_AlertAction["AlertAction"]
   module_src_types_ts --> export_AlertAction
   export_AnkhCapabilityId["AnkhCapabilityId"]
@@ -123,17 +132,20 @@ graph LR
   module_src_types_ts --> export_AppManifest
   export_AppManifest -.-> export_AppCategory
   export_AppManifest -.-> export_AppDeployManifest
+  export_AppManifest -.-> export_AppNavigatorManifest
   export_AppManifest -.-> export_AppSettings
   export_AppManifest -.-> export_ComponentDataBinding
   export_AppManifest -.-> export_DatabaseDataSourceConfig
   export_AppManifest -.-> export_InfraManifest
   export_AppManifest -.-> export_MediaManifest
-  export_AppManifest -.-> export_NavigatorSpec
+  export_AppManifest -.-> export_RepositoryManifest
   export_AppManifest -.-> export_ScreenSpec
   export_AppManifest -.-> export_SplashScreenSpec
   export_AppManifest -.-> export_ThemeConfig
   export_AppManifestParseResult["AppManifestParseResult"]
   module_src_appManifest_ts --> export_AppManifestParseResult
+  export_AppNavigatorManifest["AppNavigatorManifest"]
+  module_src_navigator_ts --> export_AppNavigatorManifest
   export_AppSettings["AppSettings"]
   module_src_types_ts --> export_AppSettings
   export_AUTH_IDENTIFIER_KINDS["AUTH_IDENTIFIER_KINDS"]
@@ -400,6 +412,20 @@ graph LR
   export_CredentialRef["CredentialRef"]
   module_src_data_refs_ts --> export_CredentialRef
   export_CredentialRef -.-> export_CredentialKind
+  export_CUSTOM_TABS_PRESENTATIONS["CUSTOM_TABS_PRESENTATIONS"]
+  module_src_navigator_ts --> export_CUSTOM_TABS_PRESENTATIONS
+  export_CustomNavigatorNode["CustomNavigatorNode"]
+  module_src_navigator_ts --> export_CustomNavigatorNode
+  export_CustomNavigatorNode -.-> export_ManifestValue
+  export_CustomNavigatorNode -.-> export_RouteDefinition
+  export_CustomTabsConfig["CustomTabsConfig"]
+  module_src_navigator_ts --> export_CustomTabsConfig
+  export_CustomTabsPresentation["CustomTabsPresentation"]
+  module_src_navigator_ts --> export_CustomTabsPresentation
+  export_CustomTabsPresentationConfig["CustomTabsPresentationConfig"]
+  module_src_navigator_ts --> export_CustomTabsPresentationConfig
+  export_CustomTabsWebConfig["CustomTabsWebConfig"]
+  module_src_navigator_ts --> export_CustomTabsWebConfig
   export_DATABASE_PROVIDERS["DATABASE_PROVIDERS"]
   module_src_types_ts --> export_DATABASE_PROVIDERS
   export_DATABASE_TIERS["DATABASE_TIERS"]
@@ -606,6 +632,20 @@ graph LR
   export_DeploymentSpec -.-> export_DeploymentTarget
   export_DeploymentTarget["DeploymentTarget"]
   module_src_types_ts --> export_DeploymentTarget
+  export_DRAWER_POSITIONS["DRAWER_POSITIONS"]
+  module_src_navigator_ts --> export_DRAWER_POSITIONS
+  export_DRAWER_TYPES["DRAWER_TYPES"]
+  module_src_navigator_ts --> export_DRAWER_TYPES
+  export_DrawerNavigatorNode["DrawerNavigatorNode"]
+  module_src_navigator_ts --> export_DrawerNavigatorNode
+  export_DrawerNavigatorNode -.-> export_DrawerNavigatorOptions
+  export_DrawerNavigatorNode -.-> export_RouteDefinition
+  export_DrawerNavigatorOptions["DrawerNavigatorOptions"]
+  module_src_navigator_ts --> export_DrawerNavigatorOptions
+  export_DrawerPosition["DrawerPosition"]
+  module_src_navigator_ts --> export_DrawerPosition
+  export_DrawerType["DrawerType"]
+  module_src_navigator_ts --> export_DrawerType
   export_EndpointId["EndpointId"]
   module_src_data_ids_ts --> export_EndpointId
   export_EventBinding["EventBinding"]
@@ -633,6 +673,10 @@ graph LR
   module_src_types_ts --> export_FilterAction
   export_findForbiddenInlineSecretFields["findForbiddenInlineSecretFields"]
   module_src_secrets_ts --> export_findForbiddenInlineSecretFields
+  export_FIXED_CUSTOM_TABS_PRESENTATIONS["FIXED_CUSTOM_TABS_PRESENTATIONS"]
+  module_src_navigator_ts --> export_FIXED_CUSTOM_TABS_PRESENTATIONS
+  export_FixedCustomTabsPresentation["FixedCustomTabsPresentation"]
+  module_src_navigator_ts --> export_FixedCustomTabsPresentation
   export_FORBIDDEN_INLINE_SECRET_FIELDS["FORBIDDEN_INLINE_SECRET_FIELDS"]
   module_src_secrets_ts --> export_FORBIDDEN_INLINE_SECRET_FIELDS
   export_FormSubmitEventDto["FormSubmitEventDto"]
@@ -672,6 +716,18 @@ graph LR
   module_src_appManifest_ts --> export_isAppManifest
   export_isMediaAssetReference["isMediaAssetReference"]
   module_src_media_ts --> export_isMediaAssetReference
+  export_JAVASCRIPT_STACK_PRESENTATIONS["JAVASCRIPT_STACK_PRESENTATIONS"]
+  module_src_navigator_ts --> export_JAVASCRIPT_STACK_PRESENTATIONS
+  export_JAVASCRIPT_TABS_PRESENTATIONS["JAVASCRIPT_TABS_PRESENTATIONS"]
+  module_src_navigator_ts --> export_JAVASCRIPT_TABS_PRESENTATIONS
+  export_JavaScriptStackPresentation["JavaScriptStackPresentation"]
+  module_src_navigator_ts --> export_JavaScriptStackPresentation
+  export_JavaScriptStackScreenOptions["JavaScriptStackScreenOptions"]
+  module_src_navigator_ts --> export_JavaScriptStackScreenOptions
+  export_JavaScriptTabsConfig["JavaScriptTabsConfig"]
+  module_src_navigator_ts --> export_JavaScriptTabsConfig
+  export_JavaScriptTabsPresentation["JavaScriptTabsPresentation"]
+  module_src_navigator_ts --> export_JavaScriptTabsPresentation
   export_KnownAuthOAuthProviderId["KnownAuthOAuthProviderId"]
   module_src_auth_ts --> export_KnownAuthOAuthProviderId
   export_KnownAuthOAuthTransportId["KnownAuthOAuthTransportId"]
@@ -733,15 +789,42 @@ graph LR
   module_src_media_ts --> export_MediaStorageSource
   export_MediaUrlSource["MediaUrlSource"]
   module_src_media_ts --> export_MediaUrlSource
+  export_NamedIconSpec["NamedIconSpec"]
+  module_src_types_ts --> export_NamedIconSpec
+  export_NATIVE_TABS_MINIMIZE_BEHAVIORS["NATIVE_TABS_MINIMIZE_BEHAVIORS"]
+  module_src_navigator_ts --> export_NATIVE_TABS_MINIMIZE_BEHAVIORS
+  export_NativeTabsConfig["NativeTabsConfig"]
+  module_src_navigator_ts --> export_NativeTabsConfig
+  export_NativeTabsConfig -.-> export_NavigatorScreenReference
+  export_NativeTabsMinimizeBehavior["NativeTabsMinimizeBehavior"]
+  module_src_navigator_ts --> export_NativeTabsMinimizeBehavior
   export_NavigateAction["NavigateAction"]
   module_src_types_ts --> export_NavigateAction
+  export_NAVIGATOR_PRESETS["NAVIGATOR_PRESETS"]
+  module_src_navigator_ts --> export_NAVIGATOR_PRESETS
   export_NAVIGATOR_TYPES["NAVIGATOR_TYPES"]
-  module_src_types_ts --> export_NAVIGATOR_TYPES
-  export_NavigatorSpec["NavigatorSpec"]
-  module_src_types_ts --> export_NavigatorSpec
-  export_NavigatorSpec -.-> export_RouteDefinition
+  module_src_navigator_ts --> export_NAVIGATOR_TYPES
+  export_NavigatorDefaults["NavigatorDefaults"]
+  module_src_navigator_ts --> export_NavigatorDefaults
+  export_NavigatorDefaults -.-> export_StackImplementationConfig
+  export_NavigatorDefaults -.-> export_TabsImplementationConfig
+  export_NavigatorFlows["NavigatorFlows"]
+  module_src_navigator_ts --> export_NavigatorFlows
+  export_NavigatorNode["NavigatorNode"]
+  module_src_navigator_ts --> export_NavigatorNode
+  export_NavigatorPlatformConfig["NavigatorPlatformConfig"]
+  module_src_navigator_ts --> export_NavigatorPlatformConfig
+  export_NavigatorPlatformConfig -.-> export_StackImplementationConfig
+  export_NavigatorPlatformConfig -.-> export_TabsImplementationConfig
+  export_NavigatorPlatforms["NavigatorPlatforms"]
+  module_src_navigator_ts --> export_NavigatorPlatforms
+  export_NavigatorPlatforms -.-> export_NavigatorPlatformConfig
+  export_NavigatorPreset["NavigatorPreset"]
+  module_src_navigator_ts --> export_NavigatorPreset
+  export_NavigatorScreenReference["NavigatorScreenReference"]
+  module_src_navigator_ts --> export_NavigatorScreenReference
   export_NavigatorType["NavigatorType"]
-  module_src_types_ts --> export_NavigatorType
+  module_src_navigator_ts --> export_NavigatorType
   export_NetworkingSpec["NetworkingSpec"]
   module_src_types_ts --> export_NetworkingSpec
   export_normalizeSecretRef["normalizeSecretRef"]
@@ -771,13 +854,18 @@ graph LR
   export_PropBinding -.-> export_BindingLifecycleBehavior
   export_PropBinding -.-> export_BindingValueSource
   export_PropBinding -.-> export_BindingValueTransform
+  export_RepositoryManifest["RepositoryManifest"]
+  module_src_repository_ts --> export_RepositoryManifest
   export_resolveAuthFlow["resolveAuthFlow"]
   module_src_auth_ts --> export_resolveAuthFlow
   export_resolveAuthFlow -.-> export_AuthFlowConfig
+  export_ResponsiveTabsPresentation["ResponsiveTabsPresentation"]
+  module_src_navigator_ts --> export_ResponsiveTabsPresentation
   export_RouteDefinition["RouteDefinition"]
-  module_src_types_ts --> export_RouteDefinition
+  module_src_navigator_ts --> export_RouteDefinition
   export_RouteDefinition -.-> export_IconSpec
-  export_RouteDefinition -.-> export_NavigatorSpec
+  export_RouteDefinition -.-> export_NavigatorNode
+  export_RouteDefinition -.-> export_StackScreenOptions
   export_RuntimeCallback["RuntimeCallback"]
   module_src_runtimeCallbacks_ts --> export_RuntimeCallback
   export_RuntimeCallbackArgs["RuntimeCallbackArgs"]
@@ -871,6 +959,9 @@ graph LR
   export_SignUpInput["SignUpInput"]
   module_src_auth_ts --> export_SignUpInput
   export_SignUpInput -.-> export_AuthIdentifier
+  export_SlotNavigatorNode["SlotNavigatorNode"]
+  module_src_navigator_ts --> export_SlotNavigatorNode
+  export_SlotNavigatorNode -.-> export_RouteDefinition
   export_SplashScreenAssetSpec["SplashScreenAssetSpec"]
   module_src_types_ts --> export_SplashScreenAssetSpec
   export_SplashScreenAssetSpec -.-> export_SplashScreenResizeMode
@@ -883,6 +974,26 @@ graph LR
   module_src_types_ts --> export_SplashScreenSpec
   export_SplashScreenSpec -.-> export_SplashScreenModeSpec
   export_SplashScreenSpec -.-> export_SplashScreenResizeMode
+  export_SplitViewNavigatorNode["SplitViewNavigatorNode"]
+  module_src_navigator_ts --> export_SplitViewNavigatorNode
+  export_SplitViewNavigatorNode -.-> export_NavigatorScreenReference
+  export_SplitViewNavigatorNode -.-> export_RouteDefinition
+  export_STACK_IMPLEMENTATIONS["STACK_IMPLEMENTATIONS"]
+  module_src_navigator_ts --> export_STACK_IMPLEMENTATIONS
+  export_STACK_PRESENTATIONS["STACK_PRESENTATIONS"]
+  module_src_navigator_ts --> export_STACK_PRESENTATIONS
+  export_StackHeaderOptions["StackHeaderOptions"]
+  module_src_navigator_ts --> export_StackHeaderOptions
+  export_StackImplementation["StackImplementation"]
+  module_src_navigator_ts --> export_StackImplementation
+  export_StackImplementationConfig["StackImplementationConfig"]
+  module_src_navigator_ts --> export_StackImplementationConfig
+  export_StackNavigatorNode["StackNavigatorNode"]
+  module_src_navigator_ts --> export_StackNavigatorNode
+  export_StackPresentation["StackPresentation"]
+  module_src_navigator_ts --> export_StackPresentation
+  export_StackScreenOptions["StackScreenOptions"]
+  module_src_navigator_ts --> export_StackScreenOptions
   export_StartOAuthAuthorizationInput["StartOAuthAuthorizationInput"]
   module_src_auth_ts --> export_StartOAuthAuthorizationInput
   export_StartOAuthAuthorizationInput -.-> export_AuthOAuthProviderId
@@ -992,6 +1103,15 @@ graph LR
   export_StorageUploadResult["StorageUploadResult"]
   module_src_storage_ts --> export_StorageUploadResult
   export_StorageUploadResult -.-> export_StorageAssetReference
+  export_SvgIconSpec["SvgIconSpec"]
+  module_src_types_ts --> export_SvgIconSpec
+  export_SvgIconSpec -.-> export_MediaAssetReference
+  export_TabsImplementationConfig["TabsImplementationConfig"]
+  module_src_navigator_ts --> export_TabsImplementationConfig
+  export_TabsNavigatorConfig["TabsNavigatorConfig"]
+  module_src_navigator_ts --> export_TabsNavigatorConfig
+  export_TabsNavigatorNode["TabsNavigatorNode"]
+  module_src_navigator_ts --> export_TabsNavigatorNode
   export_ThemeConfig["ThemeConfig"]
   module_src_types_ts --> export_ThemeConfig
   export_ThemeConfig -.-> export_ThemeGlobalTokenOverrides

--- a/paradox/diagrams/module-relationships.mmd
+++ b/paradox/diagrams/module-relationships.mmd
@@ -5,8 +5,11 @@ graph LR
   module_src_appManifest_data_ts["src/appManifest/data.ts"]
   module_src_appManifest_dataSources_ts["src/appManifest/dataSources.ts"]
   module_src_appManifest_deploy_ts["src/appManifest/deploy.ts"]
+  module_src_appManifest_icon_ts["src/appManifest/icon.ts"]
   module_src_appManifest_infra_ts["src/appManifest/infra.ts"]
   module_src_appManifest_media_ts["src/appManifest/media.ts"]
+  module_src_appManifest_navigator_ts["src/appManifest/navigator.ts"]
+  module_src_appManifest_navigatorOptions_ts["src/appManifest/navigatorOptions.ts"]
   module_src_appManifest_screens_ts["src/appManifest/screens.ts"]
   module_src_appManifest_shared_ts["src/appManifest/shared.ts"]
   module_src_auth_ts["src/auth.ts"]
@@ -26,6 +29,8 @@ graph LR
   module_src_deploy_ts["src/deploy.ts"]
   module_src_index_ts["src/index.ts"]
   module_src_media_ts["src/media.ts"]
+  module_src_navigator_ts["src/navigator.ts"]
+  module_src_repository_ts["src/repository.ts"]
   module_src_requirements_ts["src/requirements.ts"]
   module_src_runtimeCallbacks_ts["src/runtimeCallbacks.ts"]
   module_src_secretManifest_ts["src/secretManifest.ts"]
@@ -52,12 +57,21 @@ graph LR
   module_src_appManifest_dataSources_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --> module_src_deploy_ts
+  module_src_appManifest_icon_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_icon_ts --> module_src_media_ts
   module_src_appManifest_infra_ts --> module_src_appManifest_apis_ts
+  module_src_appManifest_infra_ts --> module_src_appManifest_icon_ts
   module_src_appManifest_infra_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_infra_ts --> module_src_auth_ts
   module_src_appManifest_infra_ts --> module_src_types_ts
   module_src_appManifest_media_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_media_ts --> module_src_media_ts
+  module_src_appManifest_navigator_ts --> module_src_appManifest_icon_ts
+  module_src_appManifest_navigator_ts --> module_src_appManifest_navigatorOptions_ts
+  module_src_appManifest_navigator_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_navigator_ts --> module_src_navigator_ts
+  module_src_appManifest_navigatorOptions_ts --> module_src_appManifest_shared_ts
+  module_src_appManifest_navigatorOptions_ts --> module_src_navigator_ts
   module_src_appManifest_screens_ts --> module_src_appManifest_bindings_ts
   module_src_appManifest_screens_ts --> module_src_appManifest_shared_ts
   module_src_appManifest_screens_ts --> module_src_types_ts
@@ -88,6 +102,7 @@ graph LR
   module_src_data_sources_ts --> module_src_data_refs_ts
   module_src_data_sources_ts --> module_src_data_schemas_ts
   module_src_data_sources_ts --> module_src_data_values_ts
+  module_src_navigator_ts --> module_src_types_ts
   module_src_runtimeCallbacks_ts --> module_src_types_ts
   module_src_secretManifest_ts --> module_src_secrets_ts
   module_src_types_ts --> module_src_auth_ts
@@ -95,6 +110,8 @@ graph LR
   module_src_types_ts --> module_src_data_index_ts
   module_src_types_ts --> module_src_deploy_ts
   module_src_types_ts --> module_src_media_ts
+  module_src_types_ts --> module_src_navigator_ts
+  module_src_types_ts --> module_src_repository_ts
   module_src_types_ts --> module_src_requirements_ts
   module_src_types_ts --> module_src_theme_ts
   module_src_ui_ts --> module_src_media_ts

--- a/paradox/exports.json
+++ b/paradox/exports.json
@@ -8,7 +8,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 82,
+      "line": 84,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -26,7 +26,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 31,
+      "line": 33,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -126,6 +126,46 @@
     "structuredRows": []
   },
   {
+    "name": "AdaptiveTabsConfig",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 165,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["CustomTabsPresentationConfig", "NativeTabsConfig"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "implementation",
+        "kind": "property",
+        "type": "\"adaptive\" | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "native",
+        "kind": "property",
+        "type": "NativeTabsConfig | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "web",
+        "kind": "property",
+        "type": "CustomTabsPresentationConfig | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
     "name": "AlertAction",
     "description": null,
     "isReadme": false,
@@ -134,7 +174,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 42,
+      "line": 44,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -472,7 +512,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"./endpoints\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -514,7 +554,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"./schemas\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -620,7 +660,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 140,
+      "line": 139,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -674,7 +714,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 165,
+      "line": 164,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -958,19 +998,20 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 379,
+      "line": 365,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
     "relatedSymbols": [
       "AppCategory",
       "AppDeployManifest",
+      "AppNavigatorManifest",
       "AppSettings",
       "ComponentDataBinding",
       "DatabaseDataSourceConfig",
       "InfraManifest",
       "MediaManifest",
-      "NavigatorSpec",
+      "RepositoryManifest",
       "ScreenSpec",
       "SplashScreenSpec",
       "ThemeConfig"
@@ -994,14 +1035,14 @@
       {
         "name": "dataBindings",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/bindings\").ComponentDataBinding>> | undefined",
+        "type": "Readonly<Record<string, import(\"./bindings\").ComponentDataBinding>> | undefined",
         "required": false,
         "description": null
       },
       {
         "name": "dataSources",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DatabaseDataSourceConfig>> | undefined",
+        "type": "Readonly<Record<string, import(\"./data\").DatabaseDataSourceConfig>> | undefined",
         "required": false,
         "description": null
       },
@@ -1036,8 +1077,15 @@
       {
         "name": "navigator",
         "kind": "property",
-        "type": "NavigatorSpec",
+        "type": "AppNavigatorManifest",
         "required": true,
+        "description": null
+      },
+      {
+        "name": "repository",
+        "kind": "property",
+        "type": "RepositoryManifest | undefined",
+        "required": false,
         "description": null
       },
       {
@@ -1090,6 +1138,24 @@
     "structuredRows": []
   },
   {
+    "name": "AppNavigatorManifest",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 267,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
     "name": "AppSettings",
     "description": null,
     "isReadme": false,
@@ -1098,7 +1164,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 372,
+      "line": 358,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1322,7 +1388,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 220,
+      "line": 219,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1340,7 +1406,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 207,
+      "line": 206,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1358,7 +1424,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 217,
+      "line": 216,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1376,7 +1442,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 223,
+      "line": 222,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1394,7 +1460,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 197,
+      "line": 196,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1412,7 +1478,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 194,
+      "line": 193,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1430,7 +1496,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 201,
+      "line": 200,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -1466,7 +1532,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 204,
+      "line": 203,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -2593,7 +2659,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 221,
+      "line": 220,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2611,7 +2677,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 215,
+      "line": 214,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2629,7 +2695,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 218,
+      "line": 217,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2647,7 +2713,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 336,
+      "line": 322,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2701,7 +2767,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 224,
+      "line": 223,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2719,7 +2785,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 199,
+      "line": 198,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2816,7 +2882,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 195,
+      "line": 194,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2914,7 +2980,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 202,
+      "line": 201,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -2932,7 +2998,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 326,
+      "line": 312,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3009,7 +3075,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 205,
+      "line": 204,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3027,7 +3093,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 330,
+      "line": 316,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3067,7 +3133,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 344,
+      "line": 330,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3218,7 +3284,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 191,
+      "line": 190,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -3236,7 +3302,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 188,
+      "line": 187,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -3254,7 +3320,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 192,
+      "line": 191,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3272,7 +3338,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 189,
+      "line": 188,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3290,7 +3356,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 321,
+      "line": 307,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3653,7 +3719,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 119,
+      "line": 121,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3671,7 +3737,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 126,
+      "line": 128,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3689,7 +3755,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 121,
+      "line": 123,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3820,7 +3886,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 101,
+      "line": 103,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3860,7 +3926,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 131,
+      "line": 133,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3878,7 +3944,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 99,
+      "line": 101,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -3965,7 +4031,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 49,
+      "line": 51,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -4073,6 +4139,150 @@
     "structuredRows": []
   },
   {
+    "name": "CUSTOM_TABS_PRESENTATIONS",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 100,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "CustomNavigatorNode",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 212,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["ManifestValue", "RouteDefinition"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "config",
+        "kind": "property",
+        "type": "Readonly<Record<string, ManifestValue>> | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "initialRouteName",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "navigatorId",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "routes",
+        "kind": "property",
+        "type": "RouteDefinition[]",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "type",
+        "kind": "property",
+        "type": "\"custom\"",
+        "required": true,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "CustomTabsConfig",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 142,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "CustomTabsPresentation",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 105,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "CustomTabsPresentationConfig",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 124,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "CustomTabsWebConfig",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 146,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
     "name": "DATABASE_PROVIDERS",
     "description": null,
     "isReadme": false,
@@ -4081,7 +4291,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 171,
+      "line": 170,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -4099,7 +4309,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 175,
+      "line": 174,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -4208,7 +4418,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"./endpoints\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -4243,7 +4453,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"./schemas\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -4259,7 +4469,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 173,
+      "line": 172,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -4277,7 +4487,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 306,
+      "line": 292,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -4310,7 +4520,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 176,
+      "line": 175,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6526,7 +6736,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 167,
+      "line": 166,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -6544,7 +6754,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 301,
+      "line": 287,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6577,7 +6787,173 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 169,
+      "line": 168,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "DRAWER_POSITIONS",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 84,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "DRAWER_TYPES",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 87,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "DrawerNavigatorNode",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 190,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["DrawerNavigatorOptions", "RouteDefinition"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "initialRouteName",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "options",
+        "kind": "property",
+        "type": "DrawerNavigatorOptions | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "routes",
+        "kind": "property",
+        "type": "RouteDefinition[]",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "type",
+        "kind": "property",
+        "type": "\"drawer\"",
+        "required": true,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "DrawerNavigatorOptions",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 90,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "drawerPosition",
+        "kind": "property",
+        "type": "\"left\" | \"right\" | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "drawerType",
+        "kind": "property",
+        "type": "\"front\" | \"back\" | \"slide\" | \"permanent\" | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "headerShown",
+        "kind": "property",
+        "type": "boolean | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "swipeEnabled",
+        "kind": "property",
+        "type": "boolean | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "DrawerPosition",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 85,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "DrawerType",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 88,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6701,7 +7077,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"./endpoints\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -6757,7 +7133,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"./schemas\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -6810,7 +7186,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"./endpoints\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -6859,7 +7235,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"./schemas\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -6875,7 +7251,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 74,
+      "line": 76,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6932,6 +7308,42 @@
     "structuredRows": []
   },
   {
+    "name": "FIXED_CUSTOM_TABS_PRESENTATIONS",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 97,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "FixedCustomTabsPresentation",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 98,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
     "name": "FORBIDDEN_INLINE_SECRET_FIELDS",
     "description": null,
     "isReadme": false,
@@ -6958,7 +7370,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 112,
+      "line": 114,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6976,7 +7388,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 110,
+      "line": 112,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7023,46 +7435,17 @@
     "description": null,
     "isReadme": false,
     "examples": [],
-    "kind": "type",
+    "kind": "unknown",
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 226,
+      "line": 242,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
     "relatedSymbols": [],
     "signatures": [],
-    "members": [
-      {
-        "name": "color",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "name",
-        "kind": "property",
-        "type": "string",
-        "required": true,
-        "description": null
-      },
-      {
-        "name": "provider",
-        "kind": "property",
-        "type": "string | undefined",
-        "required": false,
-        "description": null
-      },
-      {
-        "name": "size",
-        "kind": "property",
-        "type": "string | number | undefined",
-        "required": false,
-        "description": null
-      }
-    ],
+    "members": [],
     "structuredRows": []
   },
   {
@@ -7132,7 +7515,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 360,
+      "line": 346,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7287,7 +7670,7 @@
       {
         "name": "endpoints",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+        "type": "Readonly<Record<string, import(\"./endpoints\").DataEndpointConfig>>",
         "required": true,
         "description": null
       },
@@ -7329,7 +7712,7 @@
       {
         "name": "schemas",
         "kind": "property",
-        "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+        "type": "Readonly<Record<string, import(\"./schemas\").DataSchema>> | undefined",
         "required": false,
         "description": null
       }
@@ -7377,7 +7760,7 @@
     "modulePath": "src/appManifest.ts",
     "sourceLocation": {
       "filePath": "src/appManifest.ts",
-      "line": 50,
+      "line": 51,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7433,6 +7816,129 @@
     "structuredRows": []
   },
   {
+    "name": "JAVASCRIPT_STACK_PRESENTATIONS",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 40,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "JAVASCRIPT_TABS_PRESENTATIONS",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 107,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "JavaScriptStackPresentation",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 41,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "JavaScriptStackScreenOptions",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 64,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "JavaScriptTabsConfig",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 160,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "implementation",
+        "kind": "property",
+        "type": "\"javascript\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "presentation",
+        "kind": "property",
+        "type": "\"bottom\" | \"top\" | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "JavaScriptTabsPresentation",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 108,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
     "name": "KnownAuthOAuthProviderId",
     "description": null,
     "isReadme": false,
@@ -7477,7 +7983,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 214,
+      "line": 213,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7495,7 +8001,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 198,
+      "line": 197,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7531,7 +8037,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 134,
+      "line": 136,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7549,7 +8055,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 172,
+      "line": 171,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7567,7 +8073,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 168,
+      "line": 167,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7603,7 +8109,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 182,
+      "line": 181,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7621,7 +8127,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 91,
+      "line": 93,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8064,6 +8570,136 @@
     "structuredRows": []
   },
   {
+    "name": "NamedIconSpec",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/types.ts",
+    "sourceLocation": {
+      "filePath": "src/types.ts",
+      "line": 230,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "color",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "name",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "provider",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "size",
+        "kind": "property",
+        "type": "string | number | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "source",
+        "kind": "property",
+        "type": "undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "NATIVE_TABS_MINIMIZE_BEHAVIORS",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 110,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "NativeTabsConfig",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 152,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["NavigatorScreenReference"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "bottomAccessory",
+        "kind": "property",
+        "type": "NavigatorScreenReference | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "implementation",
+        "kind": "property",
+        "type": "\"native\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "minimizeBehavior",
+        "kind": "property",
+        "type": "\"automatic\" | \"never\" | \"onScrollDown\" | \"onScrollUp\" | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "NativeTabsMinimizeBehavior",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 116,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
     "name": "NavigateAction",
     "description": null,
     "isReadme": false,
@@ -8072,7 +8708,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 34,
+      "line": 36,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8097,15 +8733,15 @@
     "structuredRows": []
   },
   {
-    "name": "NAVIGATOR_TYPES",
+    "name": "NAVIGATOR_PRESETS",
     "description": null,
     "isReadme": false,
     "examples": [],
     "kind": "value",
-    "modulePath": "src/types.ts",
+    "modulePath": "src/navigator.ts",
     "sourceLocation": {
-      "filePath": "src/types.ts",
-      "line": 137,
+      "filePath": "src/navigator.ts",
+      "line": 6,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -8115,46 +8751,218 @@
     "structuredRows": []
   },
   {
-    "name": "NavigatorSpec",
+    "name": "NAVIGATOR_TYPES",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 3,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "NavigatorDefaults",
     "description": null,
     "isReadme": false,
     "examples": [],
     "kind": "type",
-    "modulePath": "src/types.ts",
+    "modulePath": "src/navigator.ts",
     "sourceLocation": {
-      "filePath": "src/types.ts",
-      "line": 260,
+      "filePath": "src/navigator.ts",
+      "line": 245,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
-    "relatedSymbols": ["RouteDefinition"],
+    "relatedSymbols": ["StackImplementationConfig", "TabsImplementationConfig"],
     "signatures": [],
     "members": [
       {
-        "name": "initialRouteName",
+        "name": "stack",
         "kind": "property",
-        "type": "string | undefined",
+        "type": "StackImplementationConfig | undefined",
         "required": false,
         "description": null
       },
       {
-        "name": "options",
+        "name": "tabs",
         "kind": "property",
-        "type": "Record<string, unknown> | undefined",
+        "type": "TabsImplementationConfig | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "NavigatorFlows",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 240,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "authentication",
+        "kind": "property",
+        "type": "boolean | undefined",
         "required": false,
         "description": null
       },
       {
-        "name": "routes",
+        "name": "onboarding",
         "kind": "property",
-        "type": "RouteDefinition[]",
-        "required": true,
+        "type": "boolean | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "NavigatorNode",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 218,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "NavigatorPlatformConfig",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 250,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["StackImplementationConfig", "TabsImplementationConfig"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "stack",
+        "kind": "property",
+        "type": "StackImplementationConfig | undefined",
+        "required": false,
         "description": null
       },
       {
-        "name": "type",
+        "name": "tabs",
         "kind": "property",
-        "type": "\"stack\" | \"tabs\" | \"drawer\"",
+        "type": "TabsImplementationConfig | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "NavigatorPlatforms",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 255,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["NavigatorPlatformConfig"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "android",
+        "kind": "property",
+        "type": "NavigatorPlatformConfig | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "ios",
+        "kind": "property",
+        "type": "NavigatorPlatformConfig | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "web",
+        "kind": "property",
+        "type": "NavigatorPlatformConfig | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "NavigatorPreset",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 24,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "NavigatorScreenReference",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 148,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "screenId",
+        "kind": "property",
+        "type": "string",
         "required": true,
         "description": null
       }
@@ -8167,10 +8975,10 @@
     "isReadme": false,
     "examples": [],
     "kind": "unknown",
-    "modulePath": "src/types.ts",
+    "modulePath": "src/navigator.ts",
     "sourceLocation": {
-      "filePath": "src/types.ts",
-      "line": 138,
+      "filePath": "src/navigator.ts",
+      "line": 4,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8188,7 +8996,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 355,
+      "line": 341,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8390,7 +9198,7 @@
     "modulePath": "src/appManifest.ts",
     "sourceLocation": {
       "filePath": "src/appManifest.ts",
-      "line": 43,
+      "line": 44,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8513,6 +9321,60 @@
     "structuredRows": []
   },
   {
+    "name": "RepositoryManifest",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/repository.ts",
+    "sourceLocation": {
+      "filePath": "src/repository.ts",
+      "line": 1,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "defaultBranch",
+        "kind": "property",
+        "type": "\"main\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "name",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "owner",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "provider",
+        "kind": "property",
+        "type": "\"github\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "url",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
     "name": "resolveAuthFlow",
     "description": null,
     "isReadme": false,
@@ -8545,19 +9407,59 @@
     "structuredRows": []
   },
   {
+    "name": "ResponsiveTabsPresentation",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 118,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "compact",
+        "kind": "property",
+        "type": "\"bottom\" | \"top\" | \"rail\" | \"sidebar\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "expanded",
+        "kind": "property",
+        "type": "\"bottom\" | \"top\" | \"rail\" | \"sidebar\"",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "medium",
+        "kind": "property",
+        "type": "\"bottom\" | \"top\" | \"rail\" | \"sidebar\" | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
     "name": "RouteDefinition",
     "description": null,
     "isReadme": false,
     "examples": [],
     "kind": "type",
-    "modulePath": "src/types.ts",
+    "modulePath": "src/navigator.ts",
     "sourceLocation": {
-      "filePath": "src/types.ts",
-      "line": 267,
+      "filePath": "src/navigator.ts",
+      "line": 226,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
-    "relatedSymbols": ["IconSpec", "NavigatorSpec"],
+    "relatedSymbols": ["IconSpec", "NavigatorNode", "StackScreenOptions"],
     "signatures": [],
     "members": [
       {
@@ -8591,7 +9493,7 @@
       {
         "name": "navigator",
         "kind": "property",
-        "type": "NavigatorSpec | undefined",
+        "type": "NavigatorNode | undefined",
         "required": false,
         "description": null
       },
@@ -8613,6 +9515,13 @@
         "name": "showInPrimaryNavigation",
         "kind": "property",
         "type": "boolean | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "stackOptions",
+        "kind": "property",
+        "type": "StackScreenOptions | undefined",
         "required": false,
         "description": null
       }
@@ -8876,7 +9785,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 250,
+      "line": 261,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8886,7 +9795,7 @@
       {
         "name": "dataLoaders",
         "kind": "property",
-        "type": "readonly import(\"./src/bindings\").OperationScreenDataLoaderDefinition[] | undefined",
+        "type": "readonly import(\"./bindings\").OperationScreenDataLoaderDefinition[] | undefined",
         "required": false,
         "description": null
       },
@@ -8944,7 +9853,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 66,
+      "line": 68,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9566,7 +10475,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 59,
+      "line": 61,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9725,6 +10634,46 @@
     "structuredRows": []
   },
   {
+    "name": "SlotNavigatorNode",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 182,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["RouteDefinition"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "initialRouteName",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "routes",
+        "kind": "property",
+        "type": "RouteDefinition[]",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "type",
+        "kind": "property",
+        "type": "\"slot\"",
+        "required": true,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
     "name": "SplashScreenAssetSpec",
     "description": null,
     "isReadme": false,
@@ -9733,7 +10682,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 287,
+      "line": 273,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9773,7 +10722,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 293,
+      "line": 279,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9820,7 +10769,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 285,
+      "line": 271,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9838,7 +10787,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 297,
+      "line": 283,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9881,6 +10830,240 @@
         "description": null
       }
     ],
+    "structuredRows": []
+  },
+  {
+    "name": "SplitViewNavigatorNode",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 201,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["NavigatorScreenReference", "RouteDefinition"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "columns",
+        "kind": "property",
+        "type": "{ primary: NavigatorScreenReference; supplementary?: NavigatorScreenReference; }",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "initialRouteName",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "inspector",
+        "kind": "property",
+        "type": "NavigatorScreenReference | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "routes",
+        "kind": "property",
+        "type": "RouteDefinition[]",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "topColumnForCollapsing",
+        "kind": "property",
+        "type": "\"primary\" | \"supplementary\" | \"secondary\" | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "type",
+        "kind": "property",
+        "type": "\"split-view\"",
+        "required": true,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "STACK_IMPLEMENTATIONS",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 26,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "STACK_PRESENTATIONS",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 29,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "StackHeaderOptions",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 43,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "headerBackVisible",
+        "kind": "property",
+        "type": "boolean | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "headerShown",
+        "kind": "property",
+        "type": "boolean | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "headerTransparent",
+        "kind": "property",
+        "type": "boolean | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "title",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "StackImplementation",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 27,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "StackImplementationConfig",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 68,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "StackNavigatorNode",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 186,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "StackPresentation",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 38,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "StackScreenOptions",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 50,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
     "structuredRows": []
   },
   {
@@ -9939,7 +11122,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 185,
+      "line": 184,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -9957,7 +11140,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 181,
+      "line": 180,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -10152,7 +11335,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 186,
+      "line": 185,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10188,7 +11371,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 183,
+      "line": 182,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10257,7 +11440,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 316,
+      "line": 302,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10352,7 +11535,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 178,
+      "line": 177,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -10808,7 +11991,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 179,
+      "line": 178,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -11135,7 +12318,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 311,
+      "line": 297,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -11178,7 +12361,7 @@
       {
         "name": "body",
         "kind": "property",
-        "type": "Uint8Array",
+        "type": "Uint8Array<ArrayBufferLike>",
         "required": true,
         "description": null
       },
@@ -11254,6 +12437,114 @@
     "structuredRows": []
   },
   {
+    "name": "SvgIconSpec",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/types.ts",
+    "sourceLocation": {
+      "filePath": "src/types.ts",
+      "line": 236,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["MediaAssetReference"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "color",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "name",
+        "kind": "property",
+        "type": "undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "provider",
+        "kind": "property",
+        "type": "undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "size",
+        "kind": "property",
+        "type": "string | number | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "source",
+        "kind": "property",
+        "type": "MediaAssetReference",
+        "required": true,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "TabsImplementationConfig",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 174,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "TabsNavigatorConfig",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 195,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "TabsNavigatorNode",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "unknown",
+    "modulePath": "src/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/navigator.ts",
+      "line": 199,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
     "name": "ThemeConfig",
     "description": null,
     "isReadme": false,
@@ -11262,7 +12553,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 20,
+      "line": 22,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -11370,7 +12661,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 15,
+      "line": 17,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -11380,7 +12671,7 @@
       {
         "name": "harmony",
         "kind": "property",
-        "type": "\"monochromatic\" | \"analogous\" | \"complementary\" | \"triadic\" | \"tetradic\" | \"splitComplementary\"",
+        "type": "\"monochromatic\" | \"analogous\" | \"complementary\" | \"splitComplementary\" | \"triadic\" | \"tetradic\" | \"square\"",
         "required": true,
         "description": null
       },
@@ -11588,7 +12879,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 54,
+      "line": 56,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -12537,7 +13828,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 240,
+      "line": 251,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -12605,7 +13896,7 @@
     "modulePath": "src/types.ts",
     "sourceLocation": {
       "filePath": "src/types.ts",
-      "line": 233,
+      "line": 244,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],

--- a/paradox/exports.md
+++ b/paradox/exports.md
@@ -4,13 +4,13 @@
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:82:1`
+Source: `src/types.ts:84:1`
 
 ## ActionType
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:31:1`
+Source: `src/types.ts:33:1`
 
 ## AdapterId
 
@@ -40,11 +40,25 @@ Source: `src/data/refs.ts:15:1`
 | kind        | property | `AdapterKind`                    | yes      |             |
 | packageName | property | `string \| undefined`            | no       |             |
 
+## AdaptiveTabsConfig
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:165:1`
+
+### Members
+
+| Name           | Kind     | Type                                        | Required | Description |
+| -------------- | -------- | ------------------------------------------- | -------- | ----------- |
+| implementation | property | `"adaptive" \| undefined`                   | no       |             |
+| native         | property | `NativeTabsConfig \| undefined`             | no       |             |
+| web            | property | `CustomTabsPresentationConfig \| undefined` | no       |             |
+
 ## AlertAction
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:42:1`
+Source: `src/types.ts:44:1`
 
 ### Members
 
@@ -149,17 +163,17 @@ Source: `src/data/apis.ts:10:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                      | Required | Description |
-| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
-| description | property | `string \| undefined`                                                     | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                  | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
-| name        | property | `string \| undefined`                                                     | no       |             |
-| origin      | property | `ApiOrigin`                                                               | yes      |             |
-| protocol    | property | `ApiProtocol`                                                             | yes      |             |
-| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                    | Required | Description |
+| ----------- | -------- | ----------------------------------------------------------------------- | -------- | ----------- |
+| credential  | property | `CredentialRef \| undefined`                                            | no       |             |
+| description | property | `string \| undefined`                                                   | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("./endpoints").DataEndpointConfig>>`    | yes      |             |
+| id          | property | `string`                                                                | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                        | no       |             |
+| name        | property | `string \| undefined`                                                   | no       |             |
+| origin      | property | `ApiOrigin`                                                             | yes      |             |
+| protocol    | property | `ApiProtocol`                                                           | yes      |             |
+| schemas     | property | `Readonly<Record<string, import("./schemas").DataSchema>> \| undefined` | no       |             |
 
 ## ApiDefinition
 
@@ -195,7 +209,7 @@ Source: `src/data/apis.ts:8:1`
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:140:14`
+Source: `src/types.ts:139:14`
 
 ## APP_DEPLOY_ENVIRONMENT_IDS
 
@@ -213,7 +227,7 @@ Source: `src/deploy.ts:1:14`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:165:1`
+Source: `src/types.ts:164:1`
 
 ## AppDeployAndroidTargetConfig
 
@@ -313,7 +327,7 @@ Source: `src/deploy.ts:21:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:379:1`
+Source: `src/types.ts:365:1`
 
 ### Members
 
@@ -321,13 +335,14 @@ Source: `src/types.ts:379:1`
 | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------- |
 | activeThemeId   | property | `string`                                                                                                                       | yes      |             |
 | activeThemeMode | property | `"dark" \| "light" \| undefined`                                                                                               | no       |             |
-| dataBindings    | property | `Readonly<Record<string, import("./src/bindings").ComponentDataBinding>> \| undefined`                                         | no       |             |
-| dataSources     | property | `Readonly<Record<string, import("./src/index").DatabaseDataSourceConfig>> \| undefined`                                        | no       |             |
+| dataBindings    | property | `Readonly<Record<string, import("./bindings").ComponentDataBinding>> \| undefined`                                             | no       |             |
+| dataSources     | property | `Readonly<Record<string, import("./data").DatabaseDataSourceConfig>> \| undefined`                                             | no       |             |
 | deploy          | property | `AppDeployManifest \| undefined`                                                                                               | no       |             |
 | infra           | property | `InfraManifest`                                                                                                                | yes      |             |
 | media           | property | `MediaManifest \| undefined`                                                                                                   | no       |             |
 | metadata        | property | `{ name: string; slug: string; version: string; category: AppCategory; themeId: string; created?: string; updated?: string; }` | yes      |             |
-| navigator       | property | `NavigatorSpec`                                                                                                                | yes      |             |
+| navigator       | property | `AppNavigatorManifest`                                                                                                         | yes      |             |
+| repository      | property | `RepositoryManifest \| undefined`                                                                                              | no       |             |
 | screens         | property | `Record<string, ScreenSpec>`                                                                                                   | yes      |             |
 | settings        | property | `AppSettings`                                                                                                                  | yes      |             |
 | splashScreen    | property | `SplashScreenSpec \| undefined`                                                                                                | no       |             |
@@ -339,11 +354,17 @@ Kind: `unknown`
 Module: `src/appManifest.ts`
 Source: `src/appManifest.ts:16:1`
 
+## AppNavigatorManifest
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:267:1`
+
 ## AppSettings
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:372:1`
+Source: `src/types.ts:358:1`
 
 ### Members
 
@@ -421,43 +442,43 @@ Source: `src/auth.ts:42:14`
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:220:14`
+Source: `src/types.ts:219:14`
 
 ## AUTH_PROFILE_FIELDS
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:207:14`
+Source: `src/types.ts:206:14`
 
 ## AUTH_PROFILE_PRIMARY_KEY_STRATEGIES
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:217:14`
+Source: `src/types.ts:216:14`
 
 ## AUTH_PROFILE_UPDATE_STRATEGIES
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:223:14`
+Source: `src/types.ts:222:14`
 
 ## AUTH_PROVIDERS
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:197:14`
+Source: `src/types.ts:196:14`
 
 ## AUTH_SCOPES
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:194:14`
+Source: `src/types.ts:193:14`
 
 ## AUTH_SIGN_IN_IDENTIFIERS
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:201:14`
+Source: `src/types.ts:200:14`
 
 ## AUTH_SIGN_UP_FIELDS
 
@@ -469,7 +490,7 @@ Source: `src/auth.ts:8:14`
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:204:14`
+Source: `src/types.ts:203:14`
 
 ## AuthAdapter
 
@@ -815,25 +836,25 @@ Source: `src/auth.ts:44:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:221:1`
+Source: `src/types.ts:220:1`
 
 ## AuthProfileField
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:215:1`
+Source: `src/types.ts:214:1`
 
 ## AuthProfilePrimaryKeyStrategy
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:218:1`
+Source: `src/types.ts:217:1`
 
 ## AuthProfileSpec
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:336:1`
+Source: `src/types.ts:322:1`
 
 ### Members
 
@@ -849,13 +870,13 @@ Source: `src/types.ts:336:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:224:1`
+Source: `src/types.ts:223:1`
 
 ## AuthProvider
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:199:1`
+Source: `src/types.ts:198:1`
 
 ## AuthProviderConfig
 
@@ -884,7 +905,7 @@ Source: `src/auth.ts:196:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:195:1`
+Source: `src/types.ts:194:1`
 
 ## AuthSession
 
@@ -918,13 +939,13 @@ Source: `src/auth.ts:133:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:202:1`
+Source: `src/types.ts:201:1`
 
 ## AuthSignInSpec
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:326:1`
+Source: `src/types.ts:312:1`
 
 ### Members
 
@@ -955,13 +976,13 @@ Source: `src/auth.ts:16:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:205:1`
+Source: `src/types.ts:204:1`
 
 ## AuthSignUpSpec
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:330:1`
+Source: `src/types.ts:316:1`
 
 ### Members
 
@@ -975,7 +996,7 @@ Source: `src/types.ts:330:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:344:1`
+Source: `src/types.ts:330:1`
 
 ### Members
 
@@ -1012,31 +1033,31 @@ Source: `src/auth.ts:172:1`
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:191:14`
+Source: `src/types.ts:190:14`
 
 ## AUTHZ_KINDS
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:188:14`
+Source: `src/types.ts:187:14`
 
 ## AuthzEngine
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:192:1`
+Source: `src/types.ts:191:1`
 
 ## AuthzKind
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:189:1`
+Source: `src/types.ts:188:1`
 
 ## AuthzSpec
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:321:1`
+Source: `src/types.ts:307:1`
 
 ### Members
 
@@ -1165,19 +1186,19 @@ Source: `src/bindings.ts:18:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:119:1`
+Source: `src/types.ts:121:1`
 
 ## CollectionItemPressEventDto
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:126:1`
+Source: `src/types.ts:128:1`
 
 ## CollectionItemPressPayload
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:121:1`
+Source: `src/types.ts:123:1`
 
 ### Members
 
@@ -1224,7 +1245,7 @@ Source: `src/bindings.ts:137:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:101:1`
+Source: `src/types.ts:103:1`
 
 ### Members
 
@@ -1238,13 +1259,13 @@ Source: `src/types.ts:101:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:131:1`
+Source: `src/types.ts:133:1`
 
 ## ComponentEventPayloadValue
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:99:1`
+Source: `src/types.ts:101:1`
 
 ## ComponentInstanceId
 
@@ -1275,7 +1296,7 @@ Source: `src/bindings.ts:4:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:49:1`
+Source: `src/types.ts:51:1`
 
 ### Members
 
@@ -1311,17 +1332,63 @@ Source: `src/data/refs.ts:6:1`
 | label | property | `string \| undefined`             | no       |             |
 | scope | property | `string \| undefined`             | no       |             |
 
+## CUSTOM_TABS_PRESENTATIONS
+
+Kind: `value`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:100:14`
+
+## CustomNavigatorNode
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:212:1`
+
+### Members
+
+| Name             | Kind     | Type                                                   | Required | Description |
+| ---------------- | -------- | ------------------------------------------------------ | -------- | ----------- |
+| config           | property | `Readonly<Record<string, ManifestValue>> \| undefined` | no       |             |
+| initialRouteName | property | `string \| undefined`                                  | no       |             |
+| navigatorId      | property | `string`                                               | yes      |             |
+| routes           | property | `RouteDefinition[]`                                    | yes      |             |
+| type             | property | `"custom"`                                             | yes      |             |
+
+## CustomTabsConfig
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:142:1`
+
+## CustomTabsPresentation
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:105:1`
+
+## CustomTabsPresentationConfig
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:124:1`
+
+## CustomTabsWebConfig
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:146:1`
+
 ## DATABASE_PROVIDERS
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:171:14`
+Source: `src/types.ts:170:14`
 
 ## DATABASE_TIERS
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:175:14`
+Source: `src/types.ts:174:14`
 
 ## DatabaseAdapterRef
 
@@ -1347,29 +1414,29 @@ Source: `src/data/sources.ts:9:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                      | Required | Description |
-| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| adapter     | property | `DatabaseAdapterRef`                                                      | yes      |             |
-| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
-| description | property | `string \| undefined`                                                     | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                  | yes      |             |
-| kind        | property | `"database"`                                                              | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
-| name        | property | `string \| undefined`                                                     | no       |             |
-| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                    | Required | Description |
+| ----------- | -------- | ----------------------------------------------------------------------- | -------- | ----------- |
+| adapter     | property | `DatabaseAdapterRef`                                                    | yes      |             |
+| credential  | property | `CredentialRef \| undefined`                                            | no       |             |
+| description | property | `string \| undefined`                                                   | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("./endpoints").DataEndpointConfig>>`    | yes      |             |
+| id          | property | `string`                                                                | yes      |             |
+| kind        | property | `"database"`                                                            | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                        | no       |             |
+| name        | property | `string \| undefined`                                                   | no       |             |
+| schemas     | property | `Readonly<Record<string, import("./schemas").DataSchema>> \| undefined` | no       |             |
 
 ## DatabaseProvider
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:173:1`
+Source: `src/types.ts:172:1`
 
 ## DatabaseSpec
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:306:1`
+Source: `src/types.ts:292:1`
 
 ### Members
 
@@ -1382,7 +1449,7 @@ Source: `src/types.ts:306:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:176:1`
+Source: `src/types.ts:175:1`
 
 ## DataContractValue
 
@@ -2061,13 +2128,13 @@ Source: `src/auth.ts:120:14`
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:167:14`
+Source: `src/types.ts:166:14`
 
 ## DeploymentSpec
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:301:1`
+Source: `src/types.ts:287:1`
 
 ### Members
 
@@ -2080,7 +2147,61 @@ Source: `src/types.ts:301:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:169:1`
+Source: `src/types.ts:168:1`
+
+## DRAWER_POSITIONS
+
+Kind: `value`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:84:14`
+
+## DRAWER_TYPES
+
+Kind: `value`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:87:14`
+
+## DrawerNavigatorNode
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:190:1`
+
+### Members
+
+| Name             | Kind     | Type                                  | Required | Description |
+| ---------------- | -------- | ------------------------------------- | -------- | ----------- |
+| initialRouteName | property | `string \| undefined`                 | no       |             |
+| options          | property | `DrawerNavigatorOptions \| undefined` | no       |             |
+| routes           | property | `RouteDefinition[]`                   | yes      |             |
+| type             | property | `"drawer"`                            | yes      |             |
+
+## DrawerNavigatorOptions
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:90:1`
+
+### Members
+
+| Name           | Kind     | Type                                                       | Required | Description |
+| -------------- | -------- | ---------------------------------------------------------- | -------- | ----------- |
+| drawerPosition | property | `"left" \| "right" \| undefined`                           | no       |             |
+| drawerType     | property | `"front" \| "back" \| "slide" \| "permanent" \| undefined` | no       |             |
+| headerShown    | property | `boolean \| undefined`                                     | no       |             |
+| swipeEnabled   | property | `boolean \| undefined`                                     | no       |             |
+
+## DrawerPosition
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:85:1`
+
+## DrawerType
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:88:1`
 
 ## EndpointId
 
@@ -2116,19 +2237,19 @@ Source: `src/data/apis.ts:40:1`
 
 ### Members
 
-| Name          | Kind     | Type                                                                      | Required | Description |
-| ------------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| credential    | property | `CredentialRef \| undefined`                                              | no       |             |
-| description   | property | `string \| undefined`                                                     | no       |             |
-| endpoints     | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
-| endpointUrl   | property | `string`                                                                  | yes      |             |
-| id            | property | `string`                                                                  | yes      |             |
-| introspection | property | `GraphQlIntrospectionConfig \| undefined`                                 | no       |             |
-| metadata      | property | `DataContractValue \| undefined`                                          | no       |             |
-| name          | property | `string \| undefined`                                                     | no       |             |
-| origin        | property | `"external"`                                                              | yes      |             |
-| protocol      | property | `"graphql"`                                                               | yes      |             |
-| schemas       | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+| Name          | Kind     | Type                                                                    | Required | Description |
+| ------------- | -------- | ----------------------------------------------------------------------- | -------- | ----------- |
+| credential    | property | `CredentialRef \| undefined`                                            | no       |             |
+| description   | property | `string \| undefined`                                                   | no       |             |
+| endpoints     | property | `Readonly<Record<string, import("./endpoints").DataEndpointConfig>>`    | yes      |             |
+| endpointUrl   | property | `string`                                                                | yes      |             |
+| id            | property | `string`                                                                | yes      |             |
+| introspection | property | `GraphQlIntrospectionConfig \| undefined`                               | no       |             |
+| metadata      | property | `DataContractValue \| undefined`                                        | no       |             |
+| name          | property | `string \| undefined`                                                   | no       |             |
+| origin        | property | `"external"`                                                            | yes      |             |
+| protocol      | property | `"graphql"`                                                             | yes      |             |
+| schemas       | property | `Readonly<Record<string, import("./schemas").DataSchema>> \| undefined` | no       |             |
 
 ## ExternalRestApiDefinition
 
@@ -2138,25 +2259,25 @@ Source: `src/data/apis.ts:28:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                      | Required | Description |
-| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| baseUrl     | property | `string`                                                                  | yes      |             |
-| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
-| description | property | `string \| undefined`                                                     | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                  | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
-| name        | property | `string \| undefined`                                                     | no       |             |
-| openApi     | property | `OpenApiDocumentRef \| undefined`                                         | no       |             |
-| origin      | property | `"external"`                                                              | yes      |             |
-| protocol    | property | `"rest"`                                                                  | yes      |             |
-| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                    | Required | Description |
+| ----------- | -------- | ----------------------------------------------------------------------- | -------- | ----------- |
+| baseUrl     | property | `string`                                                                | yes      |             |
+| credential  | property | `CredentialRef \| undefined`                                            | no       |             |
+| description | property | `string \| undefined`                                                   | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("./endpoints").DataEndpointConfig>>`    | yes      |             |
+| id          | property | `string`                                                                | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                        | no       |             |
+| name        | property | `string \| undefined`                                                   | no       |             |
+| openApi     | property | `OpenApiDocumentRef \| undefined`                                       | no       |             |
+| origin      | property | `"external"`                                                            | yes      |             |
+| protocol    | property | `"rest"`                                                                | yes      |             |
+| schemas     | property | `Readonly<Record<string, import("./schemas").DataSchema>> \| undefined` | no       |             |
 
 ## FilterAction
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:74:1`
+Source: `src/types.ts:76:1`
 
 ### Members
 
@@ -2177,6 +2298,18 @@ Source: `src/secrets.ts:183:1`
   - value: `unknown`
   - returns: `readonly string[]`
 
+## FIXED_CUSTOM_TABS_PRESENTATIONS
+
+Kind: `value`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:97:14`
+
+## FixedCustomTabsPresentation
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:98:1`
+
 ## FORBIDDEN_INLINE_SECRET_FIELDS
 
 Kind: `value`
@@ -2187,13 +2320,13 @@ Source: `src/secrets.ts:174:14`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:112:1`
+Source: `src/types.ts:114:1`
 
 ## FormSubmitValues
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:110:1`
+Source: `src/types.ts:112:1`
 
 ## GraphQlIntrospectionConfig
 
@@ -2210,18 +2343,9 @@ Source: `src/data/apis.ts:35:1`
 
 ## IconSpec
 
-Kind: `type`
+Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:226:1`
-
-### Members
-
-| Name     | Kind     | Type                            | Required | Description |
-| -------- | -------- | ------------------------------- | -------- | ----------- |
-| color    | property | `string \| undefined`           | no       |             |
-| name     | property | `string`                        | yes      |             |
-| provider | property | `string \| undefined`           | no       |             |
-| size     | property | `string \| number \| undefined` | no       |             |
+Source: `src/types.ts:242:1`
 
 ## ImageAssetSource
 
@@ -2247,7 +2371,7 @@ Source: `src/storage.ts:102:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:360:1`
+Source: `src/types.ts:346:1`
 
 ### Members
 
@@ -2284,18 +2408,18 @@ Source: `src/data/apis.ts:54:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                      | Required | Description |
-| ----------- | -------- | ------------------------------------------------------------------------- | -------- | ----------- |
-| basePath    | property | `string`                                                                  | yes      |             |
-| credential  | property | `CredentialRef \| undefined`                                              | no       |             |
-| description | property | `string \| undefined`                                                     | no       |             |
-| endpoints   | property | `Readonly<Record<string, import("./src/index").DataEndpointConfig>>`      | yes      |             |
-| id          | property | `string`                                                                  | yes      |             |
-| metadata    | property | `DataContractValue \| undefined`                                          | no       |             |
-| name        | property | `string \| undefined`                                                     | no       |             |
-| origin      | property | `"internal"`                                                              | yes      |             |
-| protocol    | property | `"rest"`                                                                  | yes      |             |
-| schemas     | property | `Readonly<Record<string, import("./src/index").DataSchema>> \| undefined` | no       |             |
+| Name        | Kind     | Type                                                                    | Required | Description |
+| ----------- | -------- | ----------------------------------------------------------------------- | -------- | ----------- |
+| basePath    | property | `string`                                                                | yes      |             |
+| credential  | property | `CredentialRef \| undefined`                                            | no       |             |
+| description | property | `string \| undefined`                                                   | no       |             |
+| endpoints   | property | `Readonly<Record<string, import("./endpoints").DataEndpointConfig>>`    | yes      |             |
+| id          | property | `string`                                                                | yes      |             |
+| metadata    | property | `DataContractValue \| undefined`                                        | no       |             |
+| name        | property | `string \| undefined`                                                   | no       |             |
+| origin      | property | `"internal"`                                                            | yes      |             |
+| protocol    | property | `"rest"`                                                                | yes      |             |
+| schemas     | property | `Readonly<Record<string, import("./schemas").DataSchema>> \| undefined` | no       |             |
 
 ## isAppDeployManifest
 
@@ -2313,7 +2437,7 @@ Source: `src/appManifest/deploy.ts:19:1`
 
 Kind: `function`
 Module: `src/appManifest.ts`
-Source: `src/appManifest.ts:50:1`
+Source: `src/appManifest.ts:51:1`
 
 ### Signatures
 
@@ -2333,6 +2457,49 @@ Source: `src/media.ts:58:1`
   - value: `unknown`
   - returns: `boolean`
 
+## JAVASCRIPT_STACK_PRESENTATIONS
+
+Kind: `value`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:40:14`
+
+## JAVASCRIPT_TABS_PRESENTATIONS
+
+Kind: `value`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:107:14`
+
+## JavaScriptStackPresentation
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:41:1`
+
+## JavaScriptStackScreenOptions
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:64:1`
+
+## JavaScriptTabsConfig
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:160:1`
+
+### Members
+
+| Name           | Kind     | Type                             | Required | Description |
+| -------------- | -------- | -------------------------------- | -------- | ----------- |
+| implementation | property | `"javascript"`                   | yes      |             |
+| presentation   | property | `"bottom" \| "top" \| undefined` | no       |             |
+
+## JavaScriptTabsPresentation
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:108:1`
+
 ## KnownAuthOAuthProviderId
 
 Kind: `unknown`
@@ -2349,13 +2516,13 @@ Source: `src/auth.ts:43:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:214:1`
+Source: `src/types.ts:213:1`
 
 ## KnownAuthProvider
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:198:1`
+Source: `src/types.ts:197:1`
 
 ## KnownAuthSignUpField
 
@@ -2367,19 +2534,19 @@ Source: `src/auth.ts:15:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:134:1`
+Source: `src/types.ts:136:1`
 
 ## KnownDatabaseProvider
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:172:1`
+Source: `src/types.ts:171:1`
 
 ## KnownDeploymentTarget
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:168:1`
+Source: `src/types.ts:167:1`
 
 ## KnownSecretStoreProvider
 
@@ -2391,13 +2558,13 @@ Source: `src/secrets.ts:2:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:182:1`
+Source: `src/types.ts:181:1`
 
 ## ManifestValue
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:91:1`
+Source: `src/types.ts:93:1`
 
 ## MEDIA_ASSET_KINDS
 
@@ -2539,11 +2706,53 @@ Source: `src/media.ts:13:1`
 | kind | property | `"url"`  | yes      |             |
 | url  | property | `string` | yes      |             |
 
+## NamedIconSpec
+
+Kind: `type`
+Module: `src/types.ts`
+Source: `src/types.ts:230:1`
+
+### Members
+
+| Name     | Kind     | Type                            | Required | Description |
+| -------- | -------- | ------------------------------- | -------- | ----------- |
+| color    | property | `string \| undefined`           | no       |             |
+| name     | property | `string`                        | yes      |             |
+| provider | property | `string \| undefined`           | no       |             |
+| size     | property | `string \| number \| undefined` | no       |             |
+| source   | property | `undefined`                     | no       |             |
+
+## NATIVE_TABS_MINIMIZE_BEHAVIORS
+
+Kind: `value`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:110:14`
+
+## NativeTabsConfig
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:152:1`
+
+### Members
+
+| Name             | Kind     | Type                                                                    | Required | Description |
+| ---------------- | -------- | ----------------------------------------------------------------------- | -------- | ----------- |
+| bottomAccessory  | property | `NavigatorScreenReference \| undefined`                                 | no       |             |
+| implementation   | property | `"native"`                                                              | yes      |             |
+| minimizeBehavior | property | `"automatic" \| "never" \| "onScrollDown" \| "onScrollUp" \| undefined` | no       |             |
+
+## NativeTabsMinimizeBehavior
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:116:1`
+
 ## NavigateAction
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:34:1`
+Source: `src/types.ts:36:1`
 
 ### Members
 
@@ -2552,38 +2761,106 @@ Source: `src/types.ts:34:1`
 | payload | property | `{ route: string; params?: Record<string, number \| string>; }` | yes      |             |
 | type    | property | `"navigate"`                                                    | yes      |             |
 
+## NAVIGATOR_PRESETS
+
+Kind: `value`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:6:14`
+
 ## NAVIGATOR_TYPES
 
 Kind: `value`
-Module: `src/types.ts`
-Source: `src/types.ts:137:14`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:3:14`
 
-## NavigatorSpec
+## NavigatorDefaults
 
 Kind: `type`
-Module: `src/types.ts`
-Source: `src/types.ts:260:1`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:245:1`
 
 ### Members
 
-| Name             | Kind     | Type                                   | Required | Description |
-| ---------------- | -------- | -------------------------------------- | -------- | ----------- |
-| initialRouteName | property | `string \| undefined`                  | no       |             |
-| options          | property | `Record<string, unknown> \| undefined` | no       |             |
-| routes           | property | `RouteDefinition[]`                    | yes      |             |
-| type             | property | `"stack" \| "tabs" \| "drawer"`        | yes      |             |
+| Name  | Kind     | Type                                     | Required | Description |
+| ----- | -------- | ---------------------------------------- | -------- | ----------- |
+| stack | property | `StackImplementationConfig \| undefined` | no       |             |
+| tabs  | property | `TabsImplementationConfig \| undefined`  | no       |             |
+
+## NavigatorFlows
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:240:1`
+
+### Members
+
+| Name           | Kind     | Type                   | Required | Description |
+| -------------- | -------- | ---------------------- | -------- | ----------- |
+| authentication | property | `boolean \| undefined` | no       |             |
+| onboarding     | property | `boolean \| undefined` | no       |             |
+
+## NavigatorNode
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:218:1`
+
+## NavigatorPlatformConfig
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:250:1`
+
+### Members
+
+| Name  | Kind     | Type                                     | Required | Description |
+| ----- | -------- | ---------------------------------------- | -------- | ----------- |
+| stack | property | `StackImplementationConfig \| undefined` | no       |             |
+| tabs  | property | `TabsImplementationConfig \| undefined`  | no       |             |
+
+## NavigatorPlatforms
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:255:1`
+
+### Members
+
+| Name    | Kind     | Type                                   | Required | Description |
+| ------- | -------- | -------------------------------------- | -------- | ----------- |
+| android | property | `NavigatorPlatformConfig \| undefined` | no       |             |
+| ios     | property | `NavigatorPlatformConfig \| undefined` | no       |             |
+| web     | property | `NavigatorPlatformConfig \| undefined` | no       |             |
+
+## NavigatorPreset
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:24:1`
+
+## NavigatorScreenReference
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:148:1`
+
+### Members
+
+| Name     | Kind     | Type     | Required | Description |
+| -------- | -------- | -------- | -------- | ----------- |
+| screenId | property | `string` | yes      |             |
 
 ## NavigatorType
 
 Kind: `unknown`
-Module: `src/types.ts`
-Source: `src/types.ts:138:1`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:4:1`
 
 ## NetworkingSpec
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:355:1`
+Source: `src/types.ts:341:1`
 
 ### Members
 
@@ -2655,7 +2932,7 @@ Source: `src/bindings.ts:97:1`
 
 Kind: `function`
 Module: `src/appManifest.ts`
-Source: `src/appManifest.ts:43:1`
+Source: `src/appManifest.ts:44:1`
 
 ### Signatures
 
@@ -2693,6 +2970,22 @@ Source: `src/bindings.ts:67:1`
 | source     | property | `BindingValueSource`                            | yes      |             |
 | transforms | property | `readonly BindingValueTransform[] \| undefined` | no       |             |
 
+## RepositoryManifest
+
+Kind: `type`
+Module: `src/repository.ts`
+Source: `src/repository.ts:1:1`
+
+### Members
+
+| Name          | Kind     | Type       | Required | Description |
+| ------------- | -------- | ---------- | -------- | ----------- |
+| defaultBranch | property | `"main"`   | yes      |             |
+| name          | property | `string`   | yes      |             |
+| owner         | property | `string`   | yes      |             |
+| provider      | property | `"github"` | yes      |             |
+| url           | property | `string`   | yes      |             |
+
 ## resolveAuthFlow
 
 Kind: `function`
@@ -2705,24 +2998,39 @@ Source: `src/auth.ts:129:1`
   - flow: `AuthFlowConfig | undefined` (optional)
   - returns: `AuthFlowConfig`
 
-## RouteDefinition
+## ResponsiveTabsPresentation
 
 Kind: `type`
-Module: `src/types.ts`
-Source: `src/types.ts:267:1`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:118:1`
 
 ### Members
 
-| Name                    | Kind     | Type                         | Required | Description |
-| ----------------------- | -------- | ---------------------------- | -------- | ----------- |
-| guards                  | property | `string[] \| undefined`      | no       |             |
-| icon                    | property | `IconSpec \| undefined`      | no       |             |
-| label                   | property | `string \| undefined`        | no       |             |
-| name                    | property | `string`                     | yes      |             |
-| navigator               | property | `NavigatorSpec \| undefined` | no       |             |
-| path                    | property | `string \| undefined`        | no       |             |
-| screenId                | property | `string \| undefined`        | no       |             |
-| showInPrimaryNavigation | property | `boolean \| undefined`       | no       |             |
+| Name     | Kind     | Type                                                    | Required | Description |
+| -------- | -------- | ------------------------------------------------------- | -------- | ----------- |
+| compact  | property | `"bottom" \| "top" \| "rail" \| "sidebar"`              | yes      |             |
+| expanded | property | `"bottom" \| "top" \| "rail" \| "sidebar"`              | yes      |             |
+| medium   | property | `"bottom" \| "top" \| "rail" \| "sidebar" \| undefined` | no       |             |
+
+## RouteDefinition
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:226:1`
+
+### Members
+
+| Name                    | Kind     | Type                              | Required | Description |
+| ----------------------- | -------- | --------------------------------- | -------- | ----------- |
+| guards                  | property | `string[] \| undefined`           | no       |             |
+| icon                    | property | `IconSpec \| undefined`           | no       |             |
+| label                   | property | `string \| undefined`             | no       |             |
+| name                    | property | `string`                          | yes      |             |
+| navigator               | property | `NavigatorNode \| undefined`      | no       |             |
+| path                    | property | `string \| undefined`             | no       |             |
+| screenId                | property | `string \| undefined`             | no       |             |
+| showInPrimaryNavigation | property | `boolean \| undefined`            | no       |             |
+| stackOptions            | property | `StackScreenOptions \| undefined` | no       |             |
 
 ## RuntimeCallback
 
@@ -2822,25 +3130,25 @@ Source: `src/requirements.ts:35:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:250:1`
+Source: `src/types.ts:261:1`
 
 ### Members
 
-| Name        | Kind     | Type                                                                                   | Required | Description |
-| ----------- | -------- | -------------------------------------------------------------------------------------- | -------- | ----------- |
-| dataLoaders | property | `readonly import("./src/bindings").OperationScreenDataLoaderDefinition[] \| undefined` | no       |             |
-| description | property | `string \| undefined`                                                                  | no       |             |
-| id          | property | `string`                                                                               | yes      |             |
-| name        | property | `string`                                                                               | yes      |             |
-| requires    | property | `ScreenRequirements \| undefined`                                                      | no       |             |
-| root        | property | `UiNode`                                                                               | yes      |             |
-| title       | property | `string \| undefined`                                                                  | no       |             |
+| Name        | Kind     | Type                                                                               | Required | Description |
+| ----------- | -------- | ---------------------------------------------------------------------------------- | -------- | ----------- |
+| dataLoaders | property | `readonly import("./bindings").OperationScreenDataLoaderDefinition[] \| undefined` | no       |             |
+| description | property | `string \| undefined`                                                              | no       |             |
+| id          | property | `string`                                                                           | yes      |             |
+| name        | property | `string`                                                                           | yes      |             |
+| requires    | property | `ScreenRequirements \| undefined`                                                  | no       |             |
+| root        | property | `UiNode`                                                                           | yes      |             |
+| title       | property | `string \| undefined`                                                              | no       |             |
 
 ## SearchAction
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:66:1`
+Source: `src/types.ts:68:1`
 
 ### Members
 
@@ -3046,7 +3354,7 @@ Source: `src/secrets.ts:46:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:59:1`
+Source: `src/types.ts:61:1`
 
 ### Members
 
@@ -3099,11 +3407,25 @@ Source: `src/auth.ts:214:1`
 | profile    | property | `Record<string, unknown> \| undefined` | no       |             |
 | redirectTo | property | `string \| undefined`                  | no       |             |
 
+## SlotNavigatorNode
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:182:1`
+
+### Members
+
+| Name             | Kind     | Type                  | Required | Description |
+| ---------------- | -------- | --------------------- | -------- | ----------- |
+| initialRouteName | property | `string \| undefined` | no       |             |
+| routes           | property | `RouteDefinition[]`   | yes      |             |
+| type             | property | `"slot"`              | yes      |             |
+
 ## SplashScreenAssetSpec
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:287:1`
+Source: `src/types.ts:273:1`
 
 ### Members
 
@@ -3117,7 +3439,7 @@ Source: `src/types.ts:287:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:293:1`
+Source: `src/types.ts:279:1`
 
 ### Members
 
@@ -3132,13 +3454,13 @@ Source: `src/types.ts:293:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:285:1`
+Source: `src/types.ts:271:1`
 
 ## SplashScreenSpec
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:297:1`
+Source: `src/types.ts:283:1`
 
 ### Members
 
@@ -3149,6 +3471,80 @@ Source: `src/types.ts:297:1`
 | image           | property | `string \| undefined`                 | no       |             |
 | imageWidth      | property | `number \| undefined`                 | no       |             |
 | resizeMode      | property | `SplashScreenResizeMode \| undefined` | no       |             |
+
+## SplitViewNavigatorNode
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:201:1`
+
+### Members
+
+| Name                   | Kind     | Type                                                                               | Required | Description |
+| ---------------------- | -------- | ---------------------------------------------------------------------------------- | -------- | ----------- |
+| columns                | property | `{ primary: NavigatorScreenReference; supplementary?: NavigatorScreenReference; }` | yes      |             |
+| initialRouteName       | property | `string \| undefined`                                                              | no       |             |
+| inspector              | property | `NavigatorScreenReference \| undefined`                                            | no       |             |
+| routes                 | property | `RouteDefinition[]`                                                                | yes      |             |
+| topColumnForCollapsing | property | `"primary" \| "supplementary" \| "secondary" \| undefined`                         | no       |             |
+| type                   | property | `"split-view"`                                                                     | yes      |             |
+
+## STACK_IMPLEMENTATIONS
+
+Kind: `value`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:26:14`
+
+## STACK_PRESENTATIONS
+
+Kind: `value`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:29:14`
+
+## StackHeaderOptions
+
+Kind: `type`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:43:1`
+
+### Members
+
+| Name              | Kind     | Type                   | Required | Description |
+| ----------------- | -------- | ---------------------- | -------- | ----------- |
+| headerBackVisible | property | `boolean \| undefined` | no       |             |
+| headerShown       | property | `boolean \| undefined` | no       |             |
+| headerTransparent | property | `boolean \| undefined` | no       |             |
+| title             | property | `string \| undefined`  | no       |             |
+
+## StackImplementation
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:27:1`
+
+## StackImplementationConfig
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:68:1`
+
+## StackNavigatorNode
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:186:1`
+
+## StackPresentation
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:38:1`
+
+## StackScreenOptions
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:50:1`
 
 ## StartOAuthAuthorizationInput
 
@@ -3169,13 +3565,13 @@ Source: `src/auth.ts:299:1`
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:185:14`
+Source: `src/types.ts:184:14`
 
 ## STATE_PROVIDERS
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:181:14`
+Source: `src/types.ts:180:14`
 
 ## StateAdapter
 
@@ -3237,7 +3633,7 @@ Source: `src/state.ts:10:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:186:1`
+Source: `src/types.ts:185:1`
 
 ## StatePrimitive
 
@@ -3249,7 +3645,7 @@ Source: `src/state.ts:1:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:183:1`
+Source: `src/types.ts:182:1`
 
 ## StateResult
 
@@ -3274,7 +3670,7 @@ Source: `src/state.ts:40:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:316:1`
+Source: `src/types.ts:302:1`
 
 ### Members
 
@@ -3311,7 +3707,7 @@ Source: `src/state.ts:3:1`
 
 Kind: `value`
 Module: `src/types.ts`
-Source: `src/types.ts:178:14`
+Source: `src/types.ts:177:14`
 
 ## StorageAdapter
 
@@ -3448,7 +3844,7 @@ Source: `src/storage.ts:7:1`
 
 Kind: `unknown`
 Module: `src/types.ts`
-Source: `src/types.ts:179:1`
+Source: `src/types.ts:178:1`
 
 ## StoragePublicUrlInput
 
@@ -3563,7 +3959,7 @@ Source: `src/storage.ts:11:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:311:1`
+Source: `src/types.ts:297:1`
 
 ### Members
 
@@ -3580,15 +3976,15 @@ Source: `src/storage.ts:25:1`
 
 ### Members
 
-| Name         | Kind     | Type                   | Required | Description |
-| ------------ | -------- | ---------------------- | -------- | ----------- |
-| body         | property | `Uint8Array`           | yes      |             |
-| bucket       | property | `string`               | yes      |             |
-| cacheControl | property | `string \| undefined`  | no       |             |
-| contentType  | property | `string \| undefined`  | no       |             |
-| path         | property | `string`               | yes      |             |
-| storageId    | property | `string \| undefined`  | no       |             |
-| upsert       | property | `boolean \| undefined` | no       |             |
+| Name         | Kind     | Type                          | Required | Description |
+| ------------ | -------- | ----------------------------- | -------- | ----------- |
+| body         | property | `Uint8Array<ArrayBufferLike>` | yes      |             |
+| bucket       | property | `string`                      | yes      |             |
+| cacheControl | property | `string \| undefined`         | no       |             |
+| contentType  | property | `string \| undefined`         | no       |             |
+| path         | property | `string`                      | yes      |             |
+| storageId    | property | `string \| undefined`         | no       |             |
+| upsert       | property | `boolean \| undefined`        | no       |             |
 
 ## StorageUploadResult
 
@@ -3602,11 +3998,45 @@ Source: `src/storage.ts:35:1`
 | ----- | -------- | ----------------------- | -------- | ----------- |
 | asset | property | `StorageAssetReference` | yes      |             |
 
+## SvgIconSpec
+
+Kind: `type`
+Module: `src/types.ts`
+Source: `src/types.ts:236:1`
+
+### Members
+
+| Name     | Kind     | Type                            | Required | Description |
+| -------- | -------- | ------------------------------- | -------- | ----------- |
+| color    | property | `string \| undefined`           | no       |             |
+| name     | property | `undefined`                     | no       |             |
+| provider | property | `undefined`                     | no       |             |
+| size     | property | `string \| number \| undefined` | no       |             |
+| source   | property | `MediaAssetReference`           | yes      |             |
+
+## TabsImplementationConfig
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:174:1`
+
+## TabsNavigatorConfig
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:195:1`
+
+## TabsNavigatorNode
+
+Kind: `unknown`
+Module: `src/navigator.ts`
+Source: `src/navigator.ts:199:1`
+
 ## ThemeConfig
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:20:1`
+Source: `src/types.ts:22:1`
 
 ### Members
 
@@ -3638,14 +4068,14 @@ Source: `src/theme.ts:28:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:15:1`
+Source: `src/types.ts:17:1`
 
 ### Members
 
-| Name         | Kind     | Type                                                                                                   | Required | Description |
-| ------------ | -------- | ------------------------------------------------------------------------------------------------------ | -------- | ----------- |
-| harmony      | property | `"monochromatic" \| "analogous" \| "complementary" \| "triadic" \| "tetradic" \| "splitComplementary"` | yes      |             |
-| primaryColor | property | `string`                                                                                               | yes      |             |
+| Name         | Kind     | Type                                                                                                               | Required | Description |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------ | -------- | ----------- |
+| harmony      | property | `"monochromatic" \| "analogous" \| "complementary" \| "splitComplementary" \| "triadic" \| "tetradic" \| "square"` | yes      |             |
+| primaryColor | property | `string`                                                                                                           | yes      |             |
 
 ## ThemeNumericTokenOverrides
 
@@ -3716,7 +4146,7 @@ Source: `src/theme.ts:15:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:54:1`
+Source: `src/types.ts:56:1`
 
 ### Members
 
@@ -4023,7 +4453,7 @@ Source: `src/ui.ts:138:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:240:1`
+Source: `src/types.ts:251:1`
 
 ### Members
 
@@ -4041,7 +4471,7 @@ Source: `src/types.ts:240:1`
 
 Kind: `type`
 Module: `src/types.ts`
-Source: `src/types.ts:233:1`
+Source: `src/types.ts:244:1`
 
 ### Members
 

--- a/paradox/index.html
+++ b/paradox/index.html
@@ -198,7 +198,7 @@
             <li>
               <button class="nav-button" type="button" data-target="src/appManifest.ts">
                 src/appManifest.ts
-                <small>5 functions</small>
+                <small>6 functions</small>
               </button>
             </li>
             <li>
@@ -232,9 +232,15 @@
               </button>
             </li>
             <li>
+              <button class="nav-button" type="button" data-target="src/appManifest/icon.ts">
+                src/appManifest/icon.ts
+                <small>1 function</small>
+              </button>
+            </li>
+            <li>
               <button class="nav-button" type="button" data-target="src/appManifest/infra.ts">
                 src/appManifest/infra.ts
-                <small>15 functions</small>
+                <small>14 functions</small>
               </button>
             </li>
             <li>
@@ -244,9 +250,25 @@
               </button>
             </li>
             <li>
+              <button class="nav-button" type="button" data-target="src/appManifest/navigator.ts">
+                src/appManifest/navigator.ts
+                <small>11 functions</small>
+              </button>
+            </li>
+            <li>
+              <button
+                class="nav-button"
+                type="button"
+                data-target="src/appManifest/navigatorOptions.ts"
+              >
+                src/appManifest/navigatorOptions.ts
+                <small>19 functions</small>
+              </button>
+            </li>
+            <li>
               <button class="nav-button" type="button" data-target="src/appManifest/screens.ts">
                 src/appManifest/screens.ts
-                <small>14 functions</small>
+                <small>11 functions</small>
               </button>
             </li>
             <li>
@@ -281,9 +303,9 @@
           <section class="panel">
             <h2>Package overview</h2>
             <div class="summary">
-              <div><strong>388</strong><span class="muted">public exports</span></div>
+              <div><strong>437</strong><span class="muted">public exports</span></div>
               <div><strong>0</strong><span class="muted">components</span></div>
-              <div><strong>36</strong><span class="muted">modules</span></div>
+              <div><strong>41</strong><span class="muted">modules</span></div>
               <div><strong>1</strong><span class="muted">entrypoints</span></div>
             </div>
             <h3>Entrypoints</h3>
@@ -375,14 +397,26 @@
             </article>
             <article
               class="item"
-              data-search="src/appManifest/infra.ts src/appManifest/apis.ts src/appManifest/shared.ts src/auth.ts src/types.ts isInfraManifest"
+              data-search="src/appManifest/icon.ts src/appManifest/shared.ts src/media.ts isIconSpec"
+            >
+              <h3>src/appManifest/icon.ts</h3>
+              <p class="muted">Referenced module</p>
+              <p>
+                <strong>Dependencies:</strong> <code>src/appManifest/shared.ts</code>,
+                <code>src/media.ts</code>
+              </p>
+              <p><strong>Exports:</strong> <code>isIconSpec</code></p>
+            </article>
+            <article
+              class="item"
+              data-search="src/appManifest/infra.ts src/appManifest/apis.ts src/appManifest/icon.ts src/appManifest/shared.ts src/auth.ts src/types.ts isInfraManifest"
             >
               <h3>src/appManifest/infra.ts</h3>
               <p class="muted">Referenced module</p>
               <p>
                 <strong>Dependencies:</strong> <code>src/appManifest/apis.ts</code>,
-                <code>src/appManifest/shared.ts</code>, <code>src/auth.ts</code>,
-                <code>src/types.ts</code>
+                <code>src/appManifest/icon.ts</code>, <code>src/appManifest/shared.ts</code>,
+                <code>src/auth.ts</code>, <code>src/types.ts</code>
               </p>
               <p><strong>Exports:</strong> <code>isInfraManifest</code></p>
             </article>
@@ -400,7 +434,37 @@
             </article>
             <article
               class="item"
-              data-search="src/appManifest/screens.ts src/appManifest/bindings.ts src/appManifest/shared.ts src/types.ts isManifestMetadata isNavigatorSpec isScreenRegistry isSplashScreenSpec isThemeConfig"
+              data-search="src/appManifest/navigator.ts src/appManifest/icon.ts src/appManifest/navigatorOptions.ts src/appManifest/shared.ts src/navigator.ts isAppNavigatorManifest"
+            >
+              <h3>src/appManifest/navigator.ts</h3>
+              <p class="muted">Referenced module</p>
+              <p>
+                <strong>Dependencies:</strong> <code>src/appManifest/icon.ts</code>,
+                <code>src/appManifest/navigatorOptions.ts</code>,
+                <code>src/appManifest/shared.ts</code>, <code>src/navigator.ts</code>
+              </p>
+              <p><strong>Exports:</strong> <code>isAppNavigatorManifest</code></p>
+            </article>
+            <article
+              class="item"
+              data-search="src/appManifest/navigatorOptions.ts src/appManifest/shared.ts src/navigator.ts hasOnlyKeys isDrawerNavigatorOptions isNavigatorScreenReference isStackImplementationConfig isStackScreenOptions isTabsImplementationConfig"
+            >
+              <h3>src/appManifest/navigatorOptions.ts</h3>
+              <p class="muted">Referenced module</p>
+              <p>
+                <strong>Dependencies:</strong> <code>src/appManifest/shared.ts</code>,
+                <code>src/navigator.ts</code>
+              </p>
+              <p>
+                <strong>Exports:</strong> <code>hasOnlyKeys</code>,
+                <code>isDrawerNavigatorOptions</code>, <code>isNavigatorScreenReference</code>,
+                <code>isStackImplementationConfig</code>, <code>isStackScreenOptions</code>,
+                <code>isTabsImplementationConfig</code>
+              </p>
+            </article>
+            <article
+              class="item"
+              data-search="src/appManifest/screens.ts src/appManifest/bindings.ts src/appManifest/shared.ts src/types.ts isAppNavigatorManifest isManifestMetadata isScreenRegistry isSplashScreenSpec isThemeConfig"
             >
               <h3>src/appManifest/screens.ts</h3>
               <p class="muted">Referenced module</p>
@@ -409,8 +473,8 @@
                 <code>src/appManifest/shared.ts</code>, <code>src/types.ts</code>
               </p>
               <p>
-                <strong>Exports:</strong> <code>isManifestMetadata</code>,
-                <code>isNavigatorSpec</code>, <code>isScreenRegistry</code>,
+                <strong>Exports:</strong> <code>isAppNavigatorManifest</code>,
+                <code>isManifestMetadata</code>, <code>isScreenRegistry</code>,
                 <code>isSplashScreenSpec</code>, <code>isThemeConfig</code>
               </p>
             </article>
@@ -724,7 +788,7 @@
             </article>
             <article
               class="item"
-              data-search="src/index.ts Action ActionType AdapterId AdapterKind AdapterRef AlertAction AnkhCapabilityId AnkhCommandCategory AnkhCommandDescriptor AnkhCommandProviderManifest ANKHORAGE_CAPABILITY_NAMES ANKHORAGE_PERMISSION_NAMES AnkhorageCapabilityName AnkhoragePermissionName AnkhPackageMetadata AnkhProviderReference ApiBaseDefinition ApiDefinition ApiDefinitionList ApiId ApiOrigin ApiProtocol APP_CATEGORIES APP_DEPLOY_ENVIRONMENT_IDS APP_DEPLOY_TARGET_IDS AppCategory AppDeployAndroidTargetConfig AppDeployEnvironmentId AppDeployIosTargetConfig AppDeployManifest AppDeployProviderSelection AppDeployTargetId AppDeployTargets AppDeployWebTargetConfig AppManifest AppManifestParseResult AppSettings AUTH_IDENTIFIER_KINDS AUTH_OAUTH_CANCELLATION_REASONS AUTH_OAUTH_ERROR_CODES AUTH_OAUTH_ERROR_STAGES AUTH_OAUTH_PROVIDER_IDS AUTH_OAUTH_SETUP_CALLBACK_ROLES AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS AUTH_OAUTH_TRANSPORT_ERROR_CODES AUTH_OAUTH_TRANSPORT_IDS AUTH_PROFILE_CREATE_STRATEGIES AUTH_PROFILE_FIELDS AUTH_PROFILE_PRIMARY_KEY_STRATEGIES AUTH_PROFILE_UPDATE_STRATEGIES AUTH_PROVIDERS AUTH_SCOPES AUTH_SIGN_IN_IDENTIFIERS AUTH_SIGN_UP_FIELDS AUTH_SIGN_UP_POLICIES AuthAdapter AuthAdapterCapabilities AuthAdapterError AuthFlowConfig AuthIdentifier AuthIdentifierKind AuthOAuthAdapter AuthOAuthAuthorizationRequest AuthOAuthAuthorizationResponse AuthOAuthCancellationReason AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthConfig AuthOAuthError AuthOAuthErrorCode AuthOAuthErrorStage AuthOAuthProviderConfig AuthOAuthProviderId AuthOAuthSetupCallbackRequirement AuthOAuthSetupCallbackRole AuthOAuthSetupCapabilities AuthOAuthSetupFieldPersistence AuthOAuthSetupFieldRequirement AuthOAuthSetupFieldSensitivity AuthOAuthSetupPlan AuthOAuthSetupRequirement AuthOAuthStartResult AuthOAuthTransportCancellationReason AuthOAuthTransportError AuthOAuthTransportErrorCode AuthOAuthTransportId AuthProfileCreateStrategy AuthProfileField AuthProfilePrimaryKeyStrategy AuthProfileSpec AuthProfileUpdateStrategy AuthProvider AuthProviderConfig AuthResult AuthScope AuthSession AuthSignInConfig AuthSignInIdentifier AuthSignInSpec AuthSignUpConfig AuthSignUpField AuthSignUpPolicy AuthSignUpSpec AuthSpec AuthUser AUTHZ_ENGINES AUTHZ_KINDS AuthzEngine AuthzKind AuthzSpec BindingCondition BindingConditionOperator BindingDataPath BindingFallback BindingInputMap BindingInputValue BindingLifecycleBehavior BindingLifecycleState BindingOperationRef BindingValue BindingValueExpression BindingValueSource BindingValueTransform ButtonPressEventDto CollectionItemPressEventDto CollectionItemPressPayload CompleteOAuthAuthorizationInput ComponentDataBinding ComponentDataBindingRegistry ComponentEventDto ComponentEventDtoKind ComponentEventPayloadValue ComponentInstanceId ComponentRequirements ComponentTypeId ConsoleAction CredentialId CredentialKind CredentialRef DATABASE_PROVIDERS DATABASE_TIERS DatabaseAdapterRef DatabaseDataSourceConfig DatabaseProvider DatabaseSpec DatabaseTier DataContractValue DataDiagnosticCode DataDiagnosticSeverity DataEndpointConfig DataEndpointKind DataEndpointRegistry DataOperationConfig DataOperationIntent DataOperationMethod DataOperationPagination DataOperationParameter DataOperationParameterLocation DataOperationProtocol DataOperationRegistry DataOperationRequest DataOperationResponse DataPath DataSchema DataSchemaPrimitiveType DataSchemaProperty DataSchemaRef DataSchemaRegistry DataSchemaSlot DataSourceConfig DataSourceDiagnostic DataSourceDiagnosticResult DataSourceId DataSourceKind DataSourceRegistry DbAdapter DbAdapterCapabilities DbAdapterError DbAdminAdapter DbAdminAdapterCapabilities DbAdminResult DbChangeEvent DbChangeKind DbChangeListener DbCollectionDefinition DbCollectionReference DbCollectionSubscriptionInput DbDeleteInput DbFieldDefinition DbFieldType DbFilter DbFilterOperator DbFindByIdInput DbInsertInput DbPage DbRealtimeAdapter DbRecord DbRecordSubscriptionInput DbResult DbSelectInput DbSort DbSortDirection DbSubscription DbSuccess DbTableInput DbUpdateInput DEFAULT_AUTH_FLOW DEPLOYMENT_TARGETS DeploymentSpec DeploymentTarget EndpointId EventBinding EventBindingTarget ExternalGraphQlApiDefinition ExternalRestApiDefinition FilterAction findForbiddenInlineSecretFields FORBIDDEN_INLINE_SECRET_FIELDS FormSubmitEventDto FormSubmitValues GraphQlIntrospectionConfig IconSpec ImageAssetSource ImageMetadata InfraManifest InfraSecretStoreSpec InternalRestApiDefinition isAppDeployManifest isAppManifest isMediaAssetReference KnownAuthOAuthProviderId KnownAuthOAuthTransportId KnownAuthProfileField KnownAuthProvider KnownAuthSignUpField KnownComponentEventDto KnownDatabaseProvider KnownDeploymentTarget KnownSecretStoreProvider KnownStateProvider ManifestValue MEDIA_ASSET_KINDS MediaAsset MediaAssetKind MediaAssetMetadata MediaAssetReference MediaAssetRegistry MediaAssetSource MediaBundledSource MediaManifest MediaStorageAdapter MediaStorageSource MediaUrlSource NavigateAction NAVIGATOR_TYPES NavigatorSpec NavigatorType NetworkingSpec normalizeSecretRef normalizeSecretScope OpenApiDocumentRef OperationId OperationScreenDataLoaderDefinition parseAppManifest PasswordResetInput PropBinding resolveAuthFlow RouteDefinition RuntimeCallback RuntimeCallbackArgs RuntimeCallbackMap RuntimeNodePropsResolver RuntimeResolveNodePropsArgs SchemaId ScreenCapabilityRequirement ScreenDataLoaderDefinition ScreenPermissionRequirement ScreenRequirements ScreenSpec SearchAction SECRET_STORE_ERROR_CODES SECRET_STORE_PROVIDERS SecretCreateInput SecretGetMetadataInput SecretListInput SecretMetadata SecretPayload SecretRef SecretRemoveInput SecretReplaceInput SecretResolveInput SecretScope SecretStoreAdapter SecretStoreError SecretStoreErrorCode SecretStoreOkResult SecretStoreProvider SecretStoreResult SetLanguageAction SignInInput SignOutInput SignUpInput SplashScreenAssetSpec SplashScreenModeSpec SplashScreenResizeMode SplashScreenSpec StartOAuthAuthorizationInput STATE_PERSISTENCE_MODES STATE_PROVIDERS StateAdapter StateAdapterCapabilities StateAdapterError StateListener StatePath StatePersistenceMode StatePrimitive StateProvider StateResult StateSnapshot StateSpec StateSubscription StateSuccess StateValue STORAGE_PROVIDERS StorageAdapter StorageAdapterError StorageAssetReference StorageImageAssetSource StorageListAdapter StorageListInput StorageListResult StorageObjectMetadata StorageOkResult StorageProvider StoragePublicUrlInput StoragePublicUrlResult StorageRemoveInput StorageResolveAdapter StorageResolvedAccess StorageResolvedAsset StorageResolveInput StorageResolveResult StorageResult StorageSpec StorageUploadInput StorageUploadResult ThemeConfig ThemeGlobalTokenOverrides ThemeModeConfig ThemeNumericTokenOverrides ThemeRecipeFieldOverrides ThemeRecipeOverrides ThemeRecipeOverrideValue ThemeStringTokenOverrides ThemeTypographyHeadingOverrides ThemeTypographyTokenOverrides ToggleDarkModeAction UiBindableEventMeta UiBindableEventPayloadMeta UiBindablePropMeta UiBindableValueFieldMeta UiBindableValueMeta UiBindableValueType UiComponentBindingMeta UiComponentBlueprint UiComponentBlueprintIcon UiComponentCategory UiComponentEventMeta UiComponentEventPayloadFieldMeta UiComponentEventPayloadFieldType UiComponentEventPayloadKind UiComponentI18nFieldMeta UiComponentI18nMeta UiComponentMeta UiComponentMetaRegistry UiComponentPackageManifest UiComponentPropArrayItemSchema UiComponentPropSchema UiComponentPropType UiComponentPropValue UiComponentSlotMeta UiNode UiNodeRepeatSpec UrlImageAssetSource validateSecretPayload VerifyOtpInput"
+              data-search="src/index.ts Action ActionType AdapterId AdapterKind AdapterRef AdaptiveTabsConfig AlertAction AnkhCapabilityId AnkhCommandCategory AnkhCommandDescriptor AnkhCommandProviderManifest ANKHORAGE_CAPABILITY_NAMES ANKHORAGE_PERMISSION_NAMES AnkhorageCapabilityName AnkhoragePermissionName AnkhPackageMetadata AnkhProviderReference ApiBaseDefinition ApiDefinition ApiDefinitionList ApiId ApiOrigin ApiProtocol APP_CATEGORIES APP_DEPLOY_ENVIRONMENT_IDS APP_DEPLOY_TARGET_IDS AppCategory AppDeployAndroidTargetConfig AppDeployEnvironmentId AppDeployIosTargetConfig AppDeployManifest AppDeployProviderSelection AppDeployTargetId AppDeployTargets AppDeployWebTargetConfig AppManifest AppManifestParseResult AppNavigatorManifest AppSettings AUTH_IDENTIFIER_KINDS AUTH_OAUTH_CANCELLATION_REASONS AUTH_OAUTH_ERROR_CODES AUTH_OAUTH_ERROR_STAGES AUTH_OAUTH_PROVIDER_IDS AUTH_OAUTH_SETUP_CALLBACK_ROLES AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS AUTH_OAUTH_TRANSPORT_ERROR_CODES AUTH_OAUTH_TRANSPORT_IDS AUTH_PROFILE_CREATE_STRATEGIES AUTH_PROFILE_FIELDS AUTH_PROFILE_PRIMARY_KEY_STRATEGIES AUTH_PROFILE_UPDATE_STRATEGIES AUTH_PROVIDERS AUTH_SCOPES AUTH_SIGN_IN_IDENTIFIERS AUTH_SIGN_UP_FIELDS AUTH_SIGN_UP_POLICIES AuthAdapter AuthAdapterCapabilities AuthAdapterError AuthFlowConfig AuthIdentifier AuthIdentifierKind AuthOAuthAdapter AuthOAuthAuthorizationRequest AuthOAuthAuthorizationResponse AuthOAuthCancellationReason AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthConfig AuthOAuthError AuthOAuthErrorCode AuthOAuthErrorStage AuthOAuthProviderConfig AuthOAuthProviderId AuthOAuthSetupCallbackRequirement AuthOAuthSetupCallbackRole AuthOAuthSetupCapabilities AuthOAuthSetupFieldPersistence AuthOAuthSetupFieldRequirement AuthOAuthSetupFieldSensitivity AuthOAuthSetupPlan AuthOAuthSetupRequirement AuthOAuthStartResult AuthOAuthTransportCancellationReason AuthOAuthTransportError AuthOAuthTransportErrorCode AuthOAuthTransportId AuthProfileCreateStrategy AuthProfileField AuthProfilePrimaryKeyStrategy AuthProfileSpec AuthProfileUpdateStrategy AuthProvider AuthProviderConfig AuthResult AuthScope AuthSession AuthSignInConfig AuthSignInIdentifier AuthSignInSpec AuthSignUpConfig AuthSignUpField AuthSignUpPolicy AuthSignUpSpec AuthSpec AuthUser AUTHZ_ENGINES AUTHZ_KINDS AuthzEngine AuthzKind AuthzSpec BindingCondition BindingConditionOperator BindingDataPath BindingFallback BindingInputMap BindingInputValue BindingLifecycleBehavior BindingLifecycleState BindingOperationRef BindingValue BindingValueExpression BindingValueSource BindingValueTransform ButtonPressEventDto CollectionItemPressEventDto CollectionItemPressPayload CompleteOAuthAuthorizationInput ComponentDataBinding ComponentDataBindingRegistry ComponentEventDto ComponentEventDtoKind ComponentEventPayloadValue ComponentInstanceId ComponentRequirements ComponentTypeId ConsoleAction CredentialId CredentialKind CredentialRef CUSTOM_TABS_PRESENTATIONS CustomNavigatorNode CustomTabsConfig CustomTabsPresentation CustomTabsPresentationConfig CustomTabsWebConfig DATABASE_PROVIDERS DATABASE_TIERS DatabaseAdapterRef DatabaseDataSourceConfig DatabaseProvider DatabaseSpec DatabaseTier DataContractValue DataDiagnosticCode DataDiagnosticSeverity DataEndpointConfig DataEndpointKind DataEndpointRegistry DataOperationConfig DataOperationIntent DataOperationMethod DataOperationPagination DataOperationParameter DataOperationParameterLocation DataOperationProtocol DataOperationRegistry DataOperationRequest DataOperationResponse DataPath DataSchema DataSchemaPrimitiveType DataSchemaProperty DataSchemaRef DataSchemaRegistry DataSchemaSlot DataSourceConfig DataSourceDiagnostic DataSourceDiagnosticResult DataSourceId DataSourceKind DataSourceRegistry DbAdapter DbAdapterCapabilities DbAdapterError DbAdminAdapter DbAdminAdapterCapabilities DbAdminResult DbChangeEvent DbChangeKind DbChangeListener DbCollectionDefinition DbCollectionReference DbCollectionSubscriptionInput DbDeleteInput DbFieldDefinition DbFieldType DbFilter DbFilterOperator DbFindByIdInput DbInsertInput DbPage DbRealtimeAdapter DbRecord DbRecordSubscriptionInput DbResult DbSelectInput DbSort DbSortDirection DbSubscription DbSuccess DbTableInput DbUpdateInput DEFAULT_AUTH_FLOW DEPLOYMENT_TARGETS DeploymentSpec DeploymentTarget DRAWER_POSITIONS DRAWER_TYPES DrawerNavigatorNode DrawerNavigatorOptions DrawerPosition DrawerType EndpointId EventBinding EventBindingTarget ExternalGraphQlApiDefinition ExternalRestApiDefinition FilterAction findForbiddenInlineSecretFields FIXED_CUSTOM_TABS_PRESENTATIONS FixedCustomTabsPresentation FORBIDDEN_INLINE_SECRET_FIELDS FormSubmitEventDto FormSubmitValues GraphQlIntrospectionConfig IconSpec ImageAssetSource ImageMetadata InfraManifest InfraSecretStoreSpec InternalRestApiDefinition isAppDeployManifest isAppManifest isMediaAssetReference JAVASCRIPT_STACK_PRESENTATIONS JAVASCRIPT_TABS_PRESENTATIONS JavaScriptStackPresentation JavaScriptStackScreenOptions JavaScriptTabsConfig JavaScriptTabsPresentation KnownAuthOAuthProviderId KnownAuthOAuthTransportId KnownAuthProfileField KnownAuthProvider KnownAuthSignUpField KnownComponentEventDto KnownDatabaseProvider KnownDeploymentTarget KnownSecretStoreProvider KnownStateProvider ManifestValue MEDIA_ASSET_KINDS MediaAsset MediaAssetKind MediaAssetMetadata MediaAssetReference MediaAssetRegistry MediaAssetSource MediaBundledSource MediaManifest MediaStorageAdapter MediaStorageSource MediaUrlSource NamedIconSpec NATIVE_TABS_MINIMIZE_BEHAVIORS NativeTabsConfig NativeTabsMinimizeBehavior NavigateAction NAVIGATOR_PRESETS NAVIGATOR_TYPES NavigatorDefaults NavigatorFlows NavigatorNode NavigatorPlatformConfig NavigatorPlatforms NavigatorPreset NavigatorScreenReference NavigatorType NetworkingSpec normalizeSecretRef normalizeSecretScope OpenApiDocumentRef OperationId OperationScreenDataLoaderDefinition parseAppManifest PasswordResetInput PropBinding RepositoryManifest resolveAuthFlow ResponsiveTabsPresentation RouteDefinition RuntimeCallback RuntimeCallbackArgs RuntimeCallbackMap RuntimeNodePropsResolver RuntimeResolveNodePropsArgs SchemaId ScreenCapabilityRequirement ScreenDataLoaderDefinition ScreenPermissionRequirement ScreenRequirements ScreenSpec SearchAction SECRET_STORE_ERROR_CODES SECRET_STORE_PROVIDERS SecretCreateInput SecretGetMetadataInput SecretListInput SecretMetadata SecretPayload SecretRef SecretRemoveInput SecretReplaceInput SecretResolveInput SecretScope SecretStoreAdapter SecretStoreError SecretStoreErrorCode SecretStoreOkResult SecretStoreProvider SecretStoreResult SetLanguageAction SignInInput SignOutInput SignUpInput SlotNavigatorNode SplashScreenAssetSpec SplashScreenModeSpec SplashScreenResizeMode SplashScreenSpec SplitViewNavigatorNode STACK_IMPLEMENTATIONS STACK_PRESENTATIONS StackHeaderOptions StackImplementation StackImplementationConfig StackNavigatorNode StackPresentation StackScreenOptions StartOAuthAuthorizationInput STATE_PERSISTENCE_MODES STATE_PROVIDERS StateAdapter StateAdapterCapabilities StateAdapterError StateListener StatePath StatePersistenceMode StatePrimitive StateProvider StateResult StateSnapshot StateSpec StateSubscription StateSuccess StateValue STORAGE_PROVIDERS StorageAdapter StorageAdapterError StorageAssetReference StorageImageAssetSource StorageListAdapter StorageListInput StorageListResult StorageObjectMetadata StorageOkResult StorageProvider StoragePublicUrlInput StoragePublicUrlResult StorageRemoveInput StorageResolveAdapter StorageResolvedAccess StorageResolvedAsset StorageResolveInput StorageResolveResult StorageResult StorageSpec StorageUploadInput StorageUploadResult SvgIconSpec TabsImplementationConfig TabsNavigatorConfig TabsNavigatorNode ThemeConfig ThemeGlobalTokenOverrides ThemeModeConfig ThemeNumericTokenOverrides ThemeRecipeFieldOverrides ThemeRecipeOverrides ThemeRecipeOverrideValue ThemeStringTokenOverrides ThemeTypographyHeadingOverrides ThemeTypographyTokenOverrides ToggleDarkModeAction UiBindableEventMeta UiBindableEventPayloadMeta UiBindablePropMeta UiBindableValueFieldMeta UiBindableValueMeta UiBindableValueType UiComponentBindingMeta UiComponentBlueprint UiComponentBlueprintIcon UiComponentCategory UiComponentEventMeta UiComponentEventPayloadFieldMeta UiComponentEventPayloadFieldType UiComponentEventPayloadKind UiComponentI18nFieldMeta UiComponentI18nMeta UiComponentMeta UiComponentMetaRegistry UiComponentPackageManifest UiComponentPropArrayItemSchema UiComponentPropSchema UiComponentPropType UiComponentPropValue UiComponentSlotMeta UiNode UiNodeRepeatSpec UrlImageAssetSource validateSecretPayload VerifyOtpInput"
             >
               <h3>src/index.ts</h3>
               <p class="muted">Configured entrypoint</p>
@@ -732,24 +796,26 @@
               <p>
                 <strong>Exports:</strong> <code>Action</code>, <code>ActionType</code>,
                 <code>AdapterId</code>, <code>AdapterKind</code>, <code>AdapterRef</code>,
-                <code>AlertAction</code>, <code>AnkhCapabilityId</code>,
-                <code>AnkhCommandCategory</code>, <code>AnkhCommandDescriptor</code>,
-                <code>AnkhCommandProviderManifest</code>, <code>ANKHORAGE_CAPABILITY_NAMES</code>,
-                <code>ANKHORAGE_PERMISSION_NAMES</code>, <code>AnkhorageCapabilityName</code>,
-                <code>AnkhoragePermissionName</code>, <code>AnkhPackageMetadata</code>,
-                <code>AnkhProviderReference</code>, <code>ApiBaseDefinition</code>,
-                <code>ApiDefinition</code>, <code>ApiDefinitionList</code>, <code>ApiId</code>,
-                <code>ApiOrigin</code>, <code>ApiProtocol</code>, <code>APP_CATEGORIES</code>,
+                <code>AdaptiveTabsConfig</code>, <code>AlertAction</code>,
+                <code>AnkhCapabilityId</code>, <code>AnkhCommandCategory</code>,
+                <code>AnkhCommandDescriptor</code>, <code>AnkhCommandProviderManifest</code>,
+                <code>ANKHORAGE_CAPABILITY_NAMES</code>, <code>ANKHORAGE_PERMISSION_NAMES</code>,
+                <code>AnkhorageCapabilityName</code>, <code>AnkhoragePermissionName</code>,
+                <code>AnkhPackageMetadata</code>, <code>AnkhProviderReference</code>,
+                <code>ApiBaseDefinition</code>, <code>ApiDefinition</code>,
+                <code>ApiDefinitionList</code>, <code>ApiId</code>, <code>ApiOrigin</code>,
+                <code>ApiProtocol</code>, <code>APP_CATEGORIES</code>,
                 <code>APP_DEPLOY_ENVIRONMENT_IDS</code>, <code>APP_DEPLOY_TARGET_IDS</code>,
                 <code>AppCategory</code>, <code>AppDeployAndroidTargetConfig</code>,
                 <code>AppDeployEnvironmentId</code>, <code>AppDeployIosTargetConfig</code>,
                 <code>AppDeployManifest</code>, <code>AppDeployProviderSelection</code>,
                 <code>AppDeployTargetId</code>, <code>AppDeployTargets</code>,
                 <code>AppDeployWebTargetConfig</code>, <code>AppManifest</code>,
-                <code>AppManifestParseResult</code>, <code>AppSettings</code>,
-                <code>AUTH_IDENTIFIER_KINDS</code>, <code>AUTH_OAUTH_CANCELLATION_REASONS</code>,
-                <code>AUTH_OAUTH_ERROR_CODES</code>, <code>AUTH_OAUTH_ERROR_STAGES</code>,
-                <code>AUTH_OAUTH_PROVIDER_IDS</code>, <code>AUTH_OAUTH_SETUP_CALLBACK_ROLES</code>,
+                <code>AppManifestParseResult</code>, <code>AppNavigatorManifest</code>,
+                <code>AppSettings</code>, <code>AUTH_IDENTIFIER_KINDS</code>,
+                <code>AUTH_OAUTH_CANCELLATION_REASONS</code>, <code>AUTH_OAUTH_ERROR_CODES</code>,
+                <code>AUTH_OAUTH_ERROR_STAGES</code>, <code>AUTH_OAUTH_PROVIDER_IDS</code>,
+                <code>AUTH_OAUTH_SETUP_CALLBACK_ROLES</code>,
                 <code>AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS</code>,
                 <code>AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES</code>,
                 <code>AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS</code>,
@@ -800,6 +866,9 @@
                 <code>ComponentInstanceId</code>, <code>ComponentRequirements</code>,
                 <code>ComponentTypeId</code>, <code>ConsoleAction</code>, <code>CredentialId</code>,
                 <code>CredentialKind</code>, <code>CredentialRef</code>,
+                <code>CUSTOM_TABS_PRESENTATIONS</code>, <code>CustomNavigatorNode</code>,
+                <code>CustomTabsConfig</code>, <code>CustomTabsPresentation</code>,
+                <code>CustomTabsPresentationConfig</code>, <code>CustomTabsWebConfig</code>,
                 <code>DATABASE_PROVIDERS</code>, <code>DATABASE_TIERS</code>,
                 <code>DatabaseAdapterRef</code>, <code>DatabaseDataSourceConfig</code>,
                 <code>DatabaseProvider</code>, <code>DatabaseSpec</code>, <code>DatabaseTier</code>,
@@ -832,16 +901,25 @@
                 <code>DbSubscription</code>, <code>DbSuccess</code>, <code>DbTableInput</code>,
                 <code>DbUpdateInput</code>, <code>DEFAULT_AUTH_FLOW</code>,
                 <code>DEPLOYMENT_TARGETS</code>, <code>DeploymentSpec</code>,
-                <code>DeploymentTarget</code>, <code>EndpointId</code>, <code>EventBinding</code>,
+                <code>DeploymentTarget</code>, <code>DRAWER_POSITIONS</code>,
+                <code>DRAWER_TYPES</code>, <code>DrawerNavigatorNode</code>,
+                <code>DrawerNavigatorOptions</code>, <code>DrawerPosition</code>,
+                <code>DrawerType</code>, <code>EndpointId</code>, <code>EventBinding</code>,
                 <code>EventBindingTarget</code>, <code>ExternalGraphQlApiDefinition</code>,
                 <code>ExternalRestApiDefinition</code>, <code>FilterAction</code>,
                 <code>findForbiddenInlineSecretFields</code>,
+                <code>FIXED_CUSTOM_TABS_PRESENTATIONS</code>,
+                <code>FixedCustomTabsPresentation</code>,
                 <code>FORBIDDEN_INLINE_SECRET_FIELDS</code>, <code>FormSubmitEventDto</code>,
                 <code>FormSubmitValues</code>, <code>GraphQlIntrospectionConfig</code>,
                 <code>IconSpec</code>, <code>ImageAssetSource</code>, <code>ImageMetadata</code>,
                 <code>InfraManifest</code>, <code>InfraSecretStoreSpec</code>,
                 <code>InternalRestApiDefinition</code>, <code>isAppDeployManifest</code>,
                 <code>isAppManifest</code>, <code>isMediaAssetReference</code>,
+                <code>JAVASCRIPT_STACK_PRESENTATIONS</code>,
+                <code>JAVASCRIPT_TABS_PRESENTATIONS</code>,
+                <code>JavaScriptStackPresentation</code>, <code>JavaScriptStackScreenOptions</code>,
+                <code>JavaScriptTabsConfig</code>, <code>JavaScriptTabsPresentation</code>,
                 <code>KnownAuthOAuthProviderId</code>, <code>KnownAuthOAuthTransportId</code>,
                 <code>KnownAuthProfileField</code>, <code>KnownAuthProvider</code>,
                 <code>KnownAuthSignUpField</code>, <code>KnownComponentEventDto</code>,
@@ -853,13 +931,20 @@
                 <code>MediaAssetSource</code>, <code>MediaBundledSource</code>,
                 <code>MediaManifest</code>, <code>MediaStorageAdapter</code>,
                 <code>MediaStorageSource</code>, <code>MediaUrlSource</code>,
-                <code>NavigateAction</code>, <code>NAVIGATOR_TYPES</code>,
-                <code>NavigatorSpec</code>, <code>NavigatorType</code>, <code>NetworkingSpec</code>,
+                <code>NamedIconSpec</code>, <code>NATIVE_TABS_MINIMIZE_BEHAVIORS</code>,
+                <code>NativeTabsConfig</code>, <code>NativeTabsMinimizeBehavior</code>,
+                <code>NavigateAction</code>, <code>NAVIGATOR_PRESETS</code>,
+                <code>NAVIGATOR_TYPES</code>, <code>NavigatorDefaults</code>,
+                <code>NavigatorFlows</code>, <code>NavigatorNode</code>,
+                <code>NavigatorPlatformConfig</code>, <code>NavigatorPlatforms</code>,
+                <code>NavigatorPreset</code>, <code>NavigatorScreenReference</code>,
+                <code>NavigatorType</code>, <code>NetworkingSpec</code>,
                 <code>normalizeSecretRef</code>, <code>normalizeSecretScope</code>,
                 <code>OpenApiDocumentRef</code>, <code>OperationId</code>,
                 <code>OperationScreenDataLoaderDefinition</code>, <code>parseAppManifest</code>,
                 <code>PasswordResetInput</code>, <code>PropBinding</code>,
-                <code>resolveAuthFlow</code>, <code>RouteDefinition</code>,
+                <code>RepositoryManifest</code>, <code>resolveAuthFlow</code>,
+                <code>ResponsiveTabsPresentation</code>, <code>RouteDefinition</code>,
                 <code>RuntimeCallback</code>, <code>RuntimeCallbackArgs</code>,
                 <code>RuntimeCallbackMap</code>, <code>RuntimeNodePropsResolver</code>,
                 <code>RuntimeResolveNodePropsArgs</code>, <code>SchemaId</code>,
@@ -876,8 +961,13 @@
                 <code>SecretStoreOkResult</code>, <code>SecretStoreProvider</code>,
                 <code>SecretStoreResult</code>, <code>SetLanguageAction</code>,
                 <code>SignInInput</code>, <code>SignOutInput</code>, <code>SignUpInput</code>,
-                <code>SplashScreenAssetSpec</code>, <code>SplashScreenModeSpec</code>,
-                <code>SplashScreenResizeMode</code>, <code>SplashScreenSpec</code>,
+                <code>SlotNavigatorNode</code>, <code>SplashScreenAssetSpec</code>,
+                <code>SplashScreenModeSpec</code>, <code>SplashScreenResizeMode</code>,
+                <code>SplashScreenSpec</code>, <code>SplitViewNavigatorNode</code>,
+                <code>STACK_IMPLEMENTATIONS</code>, <code>STACK_PRESENTATIONS</code>,
+                <code>StackHeaderOptions</code>, <code>StackImplementation</code>,
+                <code>StackImplementationConfig</code>, <code>StackNavigatorNode</code>,
+                <code>StackPresentation</code>, <code>StackScreenOptions</code>,
                 <code>StartOAuthAuthorizationInput</code>, <code>STATE_PERSISTENCE_MODES</code>,
                 <code>STATE_PROVIDERS</code>, <code>StateAdapter</code>,
                 <code>StateAdapterCapabilities</code>, <code>StateAdapterError</code>,
@@ -897,6 +987,8 @@
                 <code>StorageResolveInput</code>, <code>StorageResolveResult</code>,
                 <code>StorageResult</code>, <code>StorageSpec</code>,
                 <code>StorageUploadInput</code>, <code>StorageUploadResult</code>,
+                <code>SvgIconSpec</code>, <code>TabsImplementationConfig</code>,
+                <code>TabsNavigatorConfig</code>, <code>TabsNavigatorNode</code>,
                 <code>ThemeConfig</code>, <code>ThemeGlobalTokenOverrides</code>,
                 <code>ThemeModeConfig</code>, <code>ThemeNumericTokenOverrides</code>,
                 <code>ThemeRecipeFieldOverrides</code>, <code>ThemeRecipeOverrides</code>,
@@ -936,6 +1028,49 @@
                 <code>MediaManifest</code>, <code>MediaStorageSource</code>,
                 <code>MediaUrlSource</code>
               </p>
+            </article>
+            <article
+              class="item"
+              data-search="src/navigator.ts src/types.ts AdaptiveTabsConfig AppNavigatorManifest CUSTOM_TABS_PRESENTATIONS CustomNavigatorNode CustomTabsConfig CustomTabsPresentation CustomTabsPresentationConfig CustomTabsWebConfig DRAWER_POSITIONS DRAWER_TYPES DrawerNavigatorNode DrawerNavigatorOptions DrawerPosition DrawerType FIXED_CUSTOM_TABS_PRESENTATIONS FixedCustomTabsPresentation JAVASCRIPT_STACK_PRESENTATIONS JAVASCRIPT_TABS_PRESENTATIONS JavaScriptStackPresentation JavaScriptStackScreenOptions JavaScriptTabsConfig JavaScriptTabsPresentation NATIVE_TABS_MINIMIZE_BEHAVIORS NativeTabsConfig NativeTabsMinimizeBehavior NAVIGATOR_PRESETS NAVIGATOR_TYPES NavigatorDefaults NavigatorFlows NavigatorNode NavigatorPlatformConfig NavigatorPlatforms NavigatorPreset NavigatorScreenReference NavigatorType ResponsiveTabsPresentation RouteDefinition SlotNavigatorNode SplitViewNavigatorNode STACK_IMPLEMENTATIONS STACK_PRESENTATIONS StackHeaderOptions StackImplementation StackImplementationConfig StackNavigatorNode StackPresentation StackScreenOptions TabsImplementationConfig TabsNavigatorConfig TabsNavigatorNode"
+            >
+              <h3>src/navigator.ts</h3>
+              <p class="muted">Referenced module</p>
+              <p><strong>Dependencies:</strong> <code>src/types.ts</code></p>
+              <p>
+                <strong>Exports:</strong> <code>AdaptiveTabsConfig</code>,
+                <code>AppNavigatorManifest</code>, <code>CUSTOM_TABS_PRESENTATIONS</code>,
+                <code>CustomNavigatorNode</code>, <code>CustomTabsConfig</code>,
+                <code>CustomTabsPresentation</code>, <code>CustomTabsPresentationConfig</code>,
+                <code>CustomTabsWebConfig</code>, <code>DRAWER_POSITIONS</code>,
+                <code>DRAWER_TYPES</code>, <code>DrawerNavigatorNode</code>,
+                <code>DrawerNavigatorOptions</code>, <code>DrawerPosition</code>,
+                <code>DrawerType</code>, <code>FIXED_CUSTOM_TABS_PRESENTATIONS</code>,
+                <code>FixedCustomTabsPresentation</code>,
+                <code>JAVASCRIPT_STACK_PRESENTATIONS</code>,
+                <code>JAVASCRIPT_TABS_PRESENTATIONS</code>,
+                <code>JavaScriptStackPresentation</code>, <code>JavaScriptStackScreenOptions</code>,
+                <code>JavaScriptTabsConfig</code>, <code>JavaScriptTabsPresentation</code>,
+                <code>NATIVE_TABS_MINIMIZE_BEHAVIORS</code>, <code>NativeTabsConfig</code>,
+                <code>NativeTabsMinimizeBehavior</code>, <code>NAVIGATOR_PRESETS</code>,
+                <code>NAVIGATOR_TYPES</code>, <code>NavigatorDefaults</code>,
+                <code>NavigatorFlows</code>, <code>NavigatorNode</code>,
+                <code>NavigatorPlatformConfig</code>, <code>NavigatorPlatforms</code>,
+                <code>NavigatorPreset</code>, <code>NavigatorScreenReference</code>,
+                <code>NavigatorType</code>, <code>ResponsiveTabsPresentation</code>,
+                <code>RouteDefinition</code>, <code>SlotNavigatorNode</code>,
+                <code>SplitViewNavigatorNode</code>, <code>STACK_IMPLEMENTATIONS</code>,
+                <code>STACK_PRESENTATIONS</code>, <code>StackHeaderOptions</code>,
+                <code>StackImplementation</code>, <code>StackImplementationConfig</code>,
+                <code>StackNavigatorNode</code>, <code>StackPresentation</code>,
+                <code>StackScreenOptions</code>, <code>TabsImplementationConfig</code>,
+                <code>TabsNavigatorConfig</code>, <code>TabsNavigatorNode</code>
+              </p>
+            </article>
+            <article class="item" data-search="src/repository.ts RepositoryManifest">
+              <h3>src/repository.ts</h3>
+              <p class="muted">Referenced module</p>
+              <p><strong>Dependencies:</strong> <span class="empty">None</span></p>
+              <p><strong>Exports:</strong> <code>RepositoryManifest</code></p>
             </article>
             <article
               class="item"
@@ -1051,7 +1186,7 @@
             </article>
             <article
               class="item"
-              data-search="src/types.ts src/auth.ts src/bindings.ts src/data/index.ts src/deploy.ts src/media.ts src/requirements.ts src/theme.ts Action ActionType AlertAction APP_CATEGORIES AppCategory AppManifest AppSettings AUTH_PROFILE_CREATE_STRATEGIES AUTH_PROFILE_FIELDS AUTH_PROFILE_PRIMARY_KEY_STRATEGIES AUTH_PROFILE_UPDATE_STRATEGIES AUTH_PROVIDERS AUTH_SCOPES AUTH_SIGN_IN_IDENTIFIERS AUTH_SIGN_UP_POLICIES AuthProfileCreateStrategy AuthProfileField AuthProfilePrimaryKeyStrategy AuthProfileSpec AuthProfileUpdateStrategy AuthProvider AuthScope AuthSignInIdentifier AuthSignInSpec AuthSignUpPolicy AuthSignUpSpec AuthSpec AUTHZ_ENGINES AUTHZ_KINDS AuthzEngine AuthzKind AuthzSpec ButtonPressEventDto CollectionItemPressEventDto CollectionItemPressPayload ComponentEventDto ComponentEventDtoKind ComponentEventPayloadValue ConsoleAction DATABASE_PROVIDERS DATABASE_TIERS DatabaseProvider DatabaseSpec DatabaseTier DEPLOYMENT_TARGETS DeploymentSpec DeploymentTarget FilterAction FormSubmitEventDto FormSubmitValues IconSpec InfraManifest KnownAuthProfileField KnownAuthProvider KnownComponentEventDto KnownDatabaseProvider KnownDeploymentTarget KnownStateProvider ManifestValue NavigateAction NAVIGATOR_TYPES NavigatorSpec NavigatorType NetworkingSpec RouteDefinition ScreenSpec SearchAction SetLanguageAction SplashScreenAssetSpec SplashScreenModeSpec SplashScreenResizeMode SplashScreenSpec STATE_PERSISTENCE_MODES STATE_PROVIDERS StatePersistenceMode StateProvider StateSpec STORAGE_PROVIDERS StorageProvider StorageSpec ThemeConfig ThemeModeConfig ToggleDarkModeAction UiNode UiNodeRepeatSpec"
+              data-search="src/types.ts src/auth.ts src/bindings.ts src/data/index.ts src/deploy.ts src/media.ts src/navigator.ts src/repository.ts src/requirements.ts src/theme.ts Action ActionType AlertAction APP_CATEGORIES AppCategory AppManifest AppSettings AUTH_PROFILE_CREATE_STRATEGIES AUTH_PROFILE_FIELDS AUTH_PROFILE_PRIMARY_KEY_STRATEGIES AUTH_PROFILE_UPDATE_STRATEGIES AUTH_PROVIDERS AUTH_SCOPES AUTH_SIGN_IN_IDENTIFIERS AUTH_SIGN_UP_POLICIES AuthProfileCreateStrategy AuthProfileField AuthProfilePrimaryKeyStrategy AuthProfileSpec AuthProfileUpdateStrategy AuthProvider AuthScope AuthSignInIdentifier AuthSignInSpec AuthSignUpPolicy AuthSignUpSpec AuthSpec AUTHZ_ENGINES AUTHZ_KINDS AuthzEngine AuthzKind AuthzSpec ButtonPressEventDto CollectionItemPressEventDto CollectionItemPressPayload ComponentEventDto ComponentEventDtoKind ComponentEventPayloadValue ConsoleAction DATABASE_PROVIDERS DATABASE_TIERS DatabaseProvider DatabaseSpec DatabaseTier DEPLOYMENT_TARGETS DeploymentSpec DeploymentTarget FilterAction FormSubmitEventDto FormSubmitValues IconSpec InfraManifest KnownAuthProfileField KnownAuthProvider KnownComponentEventDto KnownDatabaseProvider KnownDeploymentTarget KnownStateProvider ManifestValue NamedIconSpec NavigateAction NetworkingSpec ScreenSpec SearchAction SetLanguageAction SplashScreenAssetSpec SplashScreenModeSpec SplashScreenResizeMode SplashScreenSpec STATE_PERSISTENCE_MODES STATE_PROVIDERS StatePersistenceMode StateProvider StateSpec STORAGE_PROVIDERS StorageProvider StorageSpec SvgIconSpec ThemeConfig ThemeModeConfig ToggleDarkModeAction UiNode UiNodeRepeatSpec"
             >
               <h3>src/types.ts</h3>
               <p class="muted">Referenced module</p>
@@ -1059,6 +1194,7 @@
                 <strong>Dependencies:</strong> <code>src/auth.ts</code>,
                 <code>src/bindings.ts</code>, <code>src/data/index.ts</code>,
                 <code>src/deploy.ts</code>, <code>src/media.ts</code>,
+                <code>src/navigator.ts</code>, <code>src/repository.ts</code>,
                 <code>src/requirements.ts</code>, <code>src/theme.ts</code>
               </p>
               <p>
@@ -1089,18 +1225,17 @@
                 <code>KnownAuthProfileField</code>, <code>KnownAuthProvider</code>,
                 <code>KnownComponentEventDto</code>, <code>KnownDatabaseProvider</code>,
                 <code>KnownDeploymentTarget</code>, <code>KnownStateProvider</code>,
-                <code>ManifestValue</code>, <code>NavigateAction</code>,
-                <code>NAVIGATOR_TYPES</code>, <code>NavigatorSpec</code>,
-                <code>NavigatorType</code>, <code>NetworkingSpec</code>,
-                <code>RouteDefinition</code>, <code>ScreenSpec</code>, <code>SearchAction</code>,
+                <code>ManifestValue</code>, <code>NamedIconSpec</code>, <code>NavigateAction</code>,
+                <code>NetworkingSpec</code>, <code>ScreenSpec</code>, <code>SearchAction</code>,
                 <code>SetLanguageAction</code>, <code>SplashScreenAssetSpec</code>,
                 <code>SplashScreenModeSpec</code>, <code>SplashScreenResizeMode</code>,
                 <code>SplashScreenSpec</code>, <code>STATE_PERSISTENCE_MODES</code>,
                 <code>STATE_PROVIDERS</code>, <code>StatePersistenceMode</code>,
                 <code>StateProvider</code>, <code>StateSpec</code>, <code>STORAGE_PROVIDERS</code>,
-                <code>StorageProvider</code>, <code>StorageSpec</code>, <code>ThemeConfig</code>,
-                <code>ThemeModeConfig</code>, <code>ToggleDarkModeAction</code>,
-                <code>UiNode</code>, <code>UiNodeRepeatSpec</code>
+                <code>StorageProvider</code>, <code>StorageSpec</code>, <code>SvgIconSpec</code>,
+                <code>ThemeConfig</code>, <code>ThemeModeConfig</code>,
+                <code>ToggleDarkModeAction</code>, <code>UiNode</code>,
+                <code>UiNodeRepeatSpec</code>
               </p>
             </article>
             <article
@@ -1152,7 +1287,7 @@
                 data-search="isAppManifest function src/appManifest.ts  (value: unknown) =&gt; boolean"
               >
                 <h4>isAppManifest</h4>
-                <p class="muted">function • <code>src/appManifest.ts:50:1</code></p>
+                <p class="muted">function • <code>src/appManifest.ts:51:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -1186,7 +1321,7 @@
                 data-search="parseAppManifest function src/appManifest.ts  AppManifestParseResult (value: unknown) =&gt; AppManifestParseResult"
               >
                 <h4>parseAppManifest</h4>
-                <p class="muted">function • <code>src/appManifest.ts:43:1</code></p>
+                <p class="muted">function • <code>src/appManifest.ts:44:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -4284,7 +4419,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;./endpoints&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -4331,7 +4466,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;./schemas&quot;).DataSchema&gt;&gt; | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -4435,7 +4570,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;./endpoints&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -4496,7 +4631,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;./schemas&quot;).DataSchema&gt;&gt; | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -4563,7 +4698,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;./endpoints&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -4617,7 +4752,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;./schemas&quot;).DataSchema&gt;&gt; | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -4722,7 +4857,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;./endpoints&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -4769,7 +4904,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;./schemas&quot;).DataSchema&gt;&gt; | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -6191,7 +6326,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataEndpointConfig&gt;&gt;</code
+                          import(&quot;./endpoints&quot;).DataEndpointConfig&gt;&gt;</code
                         >
                       </td>
                       <td>yes</td>
@@ -6231,7 +6366,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DataSchema&gt;&gt; | undefined</code
+                          import(&quot;./schemas&quot;).DataSchema&gt;&gt; | undefined</code
                         >
                       </td>
                       <td>no</td>
@@ -8303,6 +8438,1333 @@
                       <td><code>kind</code></td>
                       <td>property</td>
                       <td><code>&quot;url&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>url</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+            </section>
+            <section>
+              <h3>src/navigator.ts</h3>
+              <article
+                class="item"
+                id="symbol-adaptivetabsconfig"
+                data-search="AdaptiveTabsConfig type src/navigator.ts  CustomTabsPresentationConfig NativeTabsConfig"
+              >
+                <h4>AdaptiveTabsConfig</h4>
+                <p class="muted">type • <code>src/navigator.ts:165:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">CustomTabsPresentationConfig</li>
+                    <li class="chip">NativeTabsConfig</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>implementation</code></td>
+                      <td>property</td>
+                      <td><code>&quot;adaptive&quot; | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>native</code></td>
+                      <td>property</td>
+                      <td><code>NativeTabsConfig | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>web</code></td>
+                      <td>property</td>
+                      <td><code>CustomTabsPresentationConfig | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-appnavigatormanifest"
+                data-search="AppNavigatorManifest unknown src/navigator.ts "
+              >
+                <h4>AppNavigatorManifest</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:267:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-custom-tabs-presentations"
+                data-search="CUSTOM_TABS_PRESENTATIONS value src/navigator.ts "
+              >
+                <h4>CUSTOM_TABS_PRESENTATIONS</h4>
+                <p class="muted">value • <code>src/navigator.ts:100:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-customnavigatornode"
+                data-search="CustomNavigatorNode type src/navigator.ts  ManifestValue RouteDefinition"
+              >
+                <h4>CustomNavigatorNode</h4>
+                <p class="muted">type • <code>src/navigator.ts:212:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">ManifestValue</li>
+                    <li class="chip">RouteDefinition</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>config</code></td>
+                      <td>property</td>
+                      <td>
+                        <code>Readonly&lt;Record&lt;string, ManifestValue&gt;&gt; | undefined</code>
+                      </td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>initialRouteName</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>navigatorId</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>routes</code></td>
+                      <td>property</td>
+                      <td><code>RouteDefinition[]</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>type</code></td>
+                      <td>property</td>
+                      <td><code>&quot;custom&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-customtabsconfig"
+                data-search="CustomTabsConfig unknown src/navigator.ts "
+              >
+                <h4>CustomTabsConfig</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:142:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-customtabspresentation"
+                data-search="CustomTabsPresentation unknown src/navigator.ts "
+              >
+                <h4>CustomTabsPresentation</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:105:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-customtabspresentationconfig"
+                data-search="CustomTabsPresentationConfig unknown src/navigator.ts "
+              >
+                <h4>CustomTabsPresentationConfig</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:124:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-customtabswebconfig"
+                data-search="CustomTabsWebConfig unknown src/navigator.ts "
+              >
+                <h4>CustomTabsWebConfig</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:146:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-drawer-positions"
+                data-search="DRAWER_POSITIONS value src/navigator.ts "
+              >
+                <h4>DRAWER_POSITIONS</h4>
+                <p class="muted">value • <code>src/navigator.ts:84:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-drawer-types"
+                data-search="DRAWER_TYPES value src/navigator.ts "
+              >
+                <h4>DRAWER_TYPES</h4>
+                <p class="muted">value • <code>src/navigator.ts:87:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-drawernavigatornode"
+                data-search="DrawerNavigatorNode type src/navigator.ts  DrawerNavigatorOptions RouteDefinition"
+              >
+                <h4>DrawerNavigatorNode</h4>
+                <p class="muted">type • <code>src/navigator.ts:190:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">DrawerNavigatorOptions</li>
+                    <li class="chip">RouteDefinition</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>initialRouteName</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>options</code></td>
+                      <td>property</td>
+                      <td><code>DrawerNavigatorOptions | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>routes</code></td>
+                      <td>property</td>
+                      <td><code>RouteDefinition[]</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>type</code></td>
+                      <td>property</td>
+                      <td><code>&quot;drawer&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-drawernavigatoroptions"
+                data-search="DrawerNavigatorOptions type src/navigator.ts "
+              >
+                <h4>DrawerNavigatorOptions</h4>
+                <p class="muted">type • <code>src/navigator.ts:90:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>drawerPosition</code></td>
+                      <td>property</td>
+                      <td><code>&quot;left&quot; | &quot;right&quot; | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>drawerType</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >&quot;front&quot; | &quot;back&quot; | &quot;slide&quot; |
+                          &quot;permanent&quot; | undefined</code
+                        >
+                      </td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>headerShown</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>swipeEnabled</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-drawerposition"
+                data-search="DrawerPosition unknown src/navigator.ts "
+              >
+                <h4>DrawerPosition</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:85:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-drawertype"
+                data-search="DrawerType unknown src/navigator.ts "
+              >
+                <h4>DrawerType</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:88:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-fixed-custom-tabs-presentations"
+                data-search="FIXED_CUSTOM_TABS_PRESENTATIONS value src/navigator.ts "
+              >
+                <h4>FIXED_CUSTOM_TABS_PRESENTATIONS</h4>
+                <p class="muted">value • <code>src/navigator.ts:97:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-fixedcustomtabspresentation"
+                data-search="FixedCustomTabsPresentation unknown src/navigator.ts "
+              >
+                <h4>FixedCustomTabsPresentation</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:98:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-javascript-stack-presentations"
+                data-search="JAVASCRIPT_STACK_PRESENTATIONS value src/navigator.ts "
+              >
+                <h4>JAVASCRIPT_STACK_PRESENTATIONS</h4>
+                <p class="muted">value • <code>src/navigator.ts:40:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-javascript-tabs-presentations"
+                data-search="JAVASCRIPT_TABS_PRESENTATIONS value src/navigator.ts "
+              >
+                <h4>JAVASCRIPT_TABS_PRESENTATIONS</h4>
+                <p class="muted">value • <code>src/navigator.ts:107:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-javascriptstackpresentation"
+                data-search="JavaScriptStackPresentation unknown src/navigator.ts "
+              >
+                <h4>JavaScriptStackPresentation</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:41:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-javascriptstackscreenoptions"
+                data-search="JavaScriptStackScreenOptions unknown src/navigator.ts "
+              >
+                <h4>JavaScriptStackScreenOptions</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:64:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-javascripttabsconfig"
+                data-search="JavaScriptTabsConfig type src/navigator.ts "
+              >
+                <h4>JavaScriptTabsConfig</h4>
+                <p class="muted">type • <code>src/navigator.ts:160:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>implementation</code></td>
+                      <td>property</td>
+                      <td><code>&quot;javascript&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>presentation</code></td>
+                      <td>property</td>
+                      <td><code>&quot;bottom&quot; | &quot;top&quot; | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-javascripttabspresentation"
+                data-search="JavaScriptTabsPresentation unknown src/navigator.ts "
+              >
+                <h4>JavaScriptTabsPresentation</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:108:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-native-tabs-minimize-behaviors"
+                data-search="NATIVE_TABS_MINIMIZE_BEHAVIORS value src/navigator.ts "
+              >
+                <h4>NATIVE_TABS_MINIMIZE_BEHAVIORS</h4>
+                <p class="muted">value • <code>src/navigator.ts:110:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-nativetabsconfig"
+                data-search="NativeTabsConfig type src/navigator.ts  NavigatorScreenReference"
+              >
+                <h4>NativeTabsConfig</h4>
+                <p class="muted">type • <code>src/navigator.ts:152:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">NavigatorScreenReference</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>bottomAccessory</code></td>
+                      <td>property</td>
+                      <td><code>NavigatorScreenReference | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>implementation</code></td>
+                      <td>property</td>
+                      <td><code>&quot;native&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>minimizeBehavior</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >&quot;automatic&quot; | &quot;never&quot; | &quot;onScrollDown&quot; |
+                          &quot;onScrollUp&quot; | undefined</code
+                        >
+                      </td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-nativetabsminimizebehavior"
+                data-search="NativeTabsMinimizeBehavior unknown src/navigator.ts "
+              >
+                <h4>NativeTabsMinimizeBehavior</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:116:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-navigator-presets"
+                data-search="NAVIGATOR_PRESETS value src/navigator.ts "
+              >
+                <h4>NAVIGATOR_PRESETS</h4>
+                <p class="muted">value • <code>src/navigator.ts:6:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-navigator-types"
+                data-search="NAVIGATOR_TYPES value src/navigator.ts "
+              >
+                <h4>NAVIGATOR_TYPES</h4>
+                <p class="muted">value • <code>src/navigator.ts:3:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-navigatordefaults"
+                data-search="NavigatorDefaults type src/navigator.ts  StackImplementationConfig TabsImplementationConfig"
+              >
+                <h4>NavigatorDefaults</h4>
+                <p class="muted">type • <code>src/navigator.ts:245:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">StackImplementationConfig</li>
+                    <li class="chip">TabsImplementationConfig</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>stack</code></td>
+                      <td>property</td>
+                      <td><code>StackImplementationConfig | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>tabs</code></td>
+                      <td>property</td>
+                      <td><code>TabsImplementationConfig | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-navigatorflows"
+                data-search="NavigatorFlows type src/navigator.ts "
+              >
+                <h4>NavigatorFlows</h4>
+                <p class="muted">type • <code>src/navigator.ts:240:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>authentication</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>onboarding</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-navigatornode"
+                data-search="NavigatorNode unknown src/navigator.ts "
+              >
+                <h4>NavigatorNode</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:218:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-navigatorplatformconfig"
+                data-search="NavigatorPlatformConfig type src/navigator.ts  StackImplementationConfig TabsImplementationConfig"
+              >
+                <h4>NavigatorPlatformConfig</h4>
+                <p class="muted">type • <code>src/navigator.ts:250:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">StackImplementationConfig</li>
+                    <li class="chip">TabsImplementationConfig</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>stack</code></td>
+                      <td>property</td>
+                      <td><code>StackImplementationConfig | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>tabs</code></td>
+                      <td>property</td>
+                      <td><code>TabsImplementationConfig | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-navigatorplatforms"
+                data-search="NavigatorPlatforms type src/navigator.ts  NavigatorPlatformConfig"
+              >
+                <h4>NavigatorPlatforms</h4>
+                <p class="muted">type • <code>src/navigator.ts:255:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">NavigatorPlatformConfig</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>android</code></td>
+                      <td>property</td>
+                      <td><code>NavigatorPlatformConfig | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>ios</code></td>
+                      <td>property</td>
+                      <td><code>NavigatorPlatformConfig | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>web</code></td>
+                      <td>property</td>
+                      <td><code>NavigatorPlatformConfig | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-navigatorpreset"
+                data-search="NavigatorPreset unknown src/navigator.ts "
+              >
+                <h4>NavigatorPreset</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:24:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-navigatorscreenreference"
+                data-search="NavigatorScreenReference type src/navigator.ts "
+              >
+                <h4>NavigatorScreenReference</h4>
+                <p class="muted">type • <code>src/navigator.ts:148:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>screenId</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-navigatortype"
+                data-search="NavigatorType unknown src/navigator.ts "
+              >
+                <h4>NavigatorType</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:4:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-responsivetabspresentation"
+                data-search="ResponsiveTabsPresentation type src/navigator.ts "
+              >
+                <h4>ResponsiveTabsPresentation</h4>
+                <p class="muted">type • <code>src/navigator.ts:118:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>compact</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >&quot;bottom&quot; | &quot;top&quot; | &quot;rail&quot; |
+                          &quot;sidebar&quot;</code
+                        >
+                      </td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>expanded</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >&quot;bottom&quot; | &quot;top&quot; | &quot;rail&quot; |
+                          &quot;sidebar&quot;</code
+                        >
+                      </td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>medium</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >&quot;bottom&quot; | &quot;top&quot; | &quot;rail&quot; |
+                          &quot;sidebar&quot; | undefined</code
+                        >
+                      </td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-routedefinition"
+                data-search="RouteDefinition type src/navigator.ts  IconSpec NavigatorNode StackScreenOptions"
+              >
+                <h4>RouteDefinition</h4>
+                <p class="muted">type • <code>src/navigator.ts:226:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">IconSpec</li>
+                    <li class="chip">NavigatorNode</li>
+                    <li class="chip">StackScreenOptions</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>guards</code></td>
+                      <td>property</td>
+                      <td><code>string[] | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>icon</code></td>
+                      <td>property</td>
+                      <td><code>IconSpec | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>label</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>name</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>navigator</code></td>
+                      <td>property</td>
+                      <td><code>NavigatorNode | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>path</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>screenId</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>showInPrimaryNavigation</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>stackOptions</code></td>
+                      <td>property</td>
+                      <td><code>StackScreenOptions | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-slotnavigatornode"
+                data-search="SlotNavigatorNode type src/navigator.ts  RouteDefinition"
+              >
+                <h4>SlotNavigatorNode</h4>
+                <p class="muted">type • <code>src/navigator.ts:182:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">RouteDefinition</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>initialRouteName</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>routes</code></td>
+                      <td>property</td>
+                      <td><code>RouteDefinition[]</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>type</code></td>
+                      <td>property</td>
+                      <td><code>&quot;slot&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-splitviewnavigatornode"
+                data-search="SplitViewNavigatorNode type src/navigator.ts  NavigatorScreenReference RouteDefinition"
+              >
+                <h4>SplitViewNavigatorNode</h4>
+                <p class="muted">type • <code>src/navigator.ts:201:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">NavigatorScreenReference</li>
+                    <li class="chip">RouteDefinition</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>columns</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >{ primary: NavigatorScreenReference; supplementary?:
+                          NavigatorScreenReference; }</code
+                        >
+                      </td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>initialRouteName</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>inspector</code></td>
+                      <td>property</td>
+                      <td><code>NavigatorScreenReference | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>routes</code></td>
+                      <td>property</td>
+                      <td><code>RouteDefinition[]</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>topColumnForCollapsing</code></td>
+                      <td>property</td>
+                      <td>
+                        <code
+                          >&quot;primary&quot; | &quot;supplementary&quot; | &quot;secondary&quot; |
+                          undefined</code
+                        >
+                      </td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>type</code></td>
+                      <td>property</td>
+                      <td><code>&quot;split-view&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-stack-implementations"
+                data-search="STACK_IMPLEMENTATIONS value src/navigator.ts "
+              >
+                <h4>STACK_IMPLEMENTATIONS</h4>
+                <p class="muted">value • <code>src/navigator.ts:26:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-stack-presentations"
+                data-search="STACK_PRESENTATIONS value src/navigator.ts "
+              >
+                <h4>STACK_PRESENTATIONS</h4>
+                <p class="muted">value • <code>src/navigator.ts:29:14</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-stackheaderoptions"
+                data-search="StackHeaderOptions type src/navigator.ts "
+              >
+                <h4>StackHeaderOptions</h4>
+                <p class="muted">type • <code>src/navigator.ts:43:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>headerBackVisible</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>headerShown</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>headerTransparent</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>title</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-stackimplementation"
+                data-search="StackImplementation unknown src/navigator.ts "
+              >
+                <h4>StackImplementation</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:27:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-stackimplementationconfig"
+                data-search="StackImplementationConfig unknown src/navigator.ts "
+              >
+                <h4>StackImplementationConfig</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:68:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-stacknavigatornode"
+                data-search="StackNavigatorNode unknown src/navigator.ts "
+              >
+                <h4>StackNavigatorNode</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:186:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-stackpresentation"
+                data-search="StackPresentation unknown src/navigator.ts "
+              >
+                <h4>StackPresentation</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:38:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-stackscreenoptions"
+                data-search="StackScreenOptions unknown src/navigator.ts "
+              >
+                <h4>StackScreenOptions</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:50:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-tabsimplementationconfig"
+                data-search="TabsImplementationConfig unknown src/navigator.ts "
+              >
+                <h4>TabsImplementationConfig</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:174:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-tabsnavigatorconfig"
+                data-search="TabsNavigatorConfig unknown src/navigator.ts "
+              >
+                <h4>TabsNavigatorConfig</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:195:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-tabsnavigatornode"
+                data-search="TabsNavigatorNode unknown src/navigator.ts "
+              >
+                <h4>TabsNavigatorNode</h4>
+                <p class="muted">unknown • <code>src/navigator.ts:199:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+            </section>
+            <section>
+              <h3>src/repository.ts</h3>
+              <article
+                class="item"
+                id="symbol-repositorymanifest"
+                data-search="RepositoryManifest type src/repository.ts "
+              >
+                <h4>RepositoryManifest</h4>
+                <p class="muted">type • <code>src/repository.ts:1:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>defaultBranch</code></td>
+                      <td>property</td>
+                      <td><code>&quot;main&quot;</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>name</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>owner</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>provider</code></td>
+                      <td>property</td>
+                      <td><code>&quot;github&quot;</code></td>
                       <td>yes</td>
                       <td></td>
                     </tr>
@@ -10955,7 +12417,7 @@
                     <tr>
                       <td><code>body</code></td>
                       <td>property</td>
-                      <td><code>Uint8Array</code></td>
+                      <td><code>Uint8Array&lt;ArrayBufferLike&gt;</code></td>
                       <td>yes</td>
                       <td></td>
                     </tr>
@@ -11386,7 +12848,7 @@
               <h3>src/types.ts</h3>
               <article class="item" id="symbol-action" data-search="Action unknown src/types.ts ">
                 <h4>Action</h4>
-                <p class="muted">unknown • <code>src/types.ts:82:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:84:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11397,7 +12859,7 @@
                 data-search="ActionType unknown src/types.ts "
               >
                 <h4>ActionType</h4>
-                <p class="muted">unknown • <code>src/types.ts:31:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:33:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11408,7 +12870,7 @@
                 data-search="AlertAction type src/types.ts "
               >
                 <h4>AlertAction</h4>
-                <p class="muted">type • <code>src/types.ts:42:1</code></p>
+                <p class="muted">type • <code>src/types.ts:44:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11447,7 +12909,7 @@
                 data-search="APP_CATEGORIES value src/types.ts "
               >
                 <h4>APP_CATEGORIES</h4>
-                <p class="muted">value • <code>src/types.ts:140:14</code></p>
+                <p class="muted">value • <code>src/types.ts:139:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11458,7 +12920,7 @@
                 data-search="AppCategory unknown src/types.ts "
               >
                 <h4>AppCategory</h4>
-                <p class="muted">unknown • <code>src/types.ts:165:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:164:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11466,10 +12928,10 @@
               <article
                 class="item"
                 id="symbol-appmanifest"
-                data-search="AppManifest type src/types.ts  AppCategory AppDeployManifest AppSettings ComponentDataBinding DatabaseDataSourceConfig InfraManifest MediaManifest NavigatorSpec ScreenSpec SplashScreenSpec ThemeConfig"
+                data-search="AppManifest type src/types.ts  AppCategory AppDeployManifest AppNavigatorManifest AppSettings ComponentDataBinding DatabaseDataSourceConfig InfraManifest MediaManifest RepositoryManifest ScreenSpec SplashScreenSpec ThemeConfig"
               >
                 <h4>AppManifest</h4>
-                <p class="muted">type • <code>src/types.ts:379:1</code></p>
+                <p class="muted">type • <code>src/types.ts:365:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -11477,12 +12939,13 @@
                   <ul class="chips">
                     <li class="chip">AppCategory</li>
                     <li class="chip">AppDeployManifest</li>
+                    <li class="chip">AppNavigatorManifest</li>
                     <li class="chip">AppSettings</li>
                     <li class="chip">ComponentDataBinding</li>
                     <li class="chip">DatabaseDataSourceConfig</li>
                     <li class="chip">InfraManifest</li>
                     <li class="chip">MediaManifest</li>
-                    <li class="chip">NavigatorSpec</li>
+                    <li class="chip">RepositoryManifest</li>
                     <li class="chip">ScreenSpec</li>
                     <li class="chip">SplashScreenSpec</li>
                     <li class="chip">ThemeConfig</li>
@@ -11520,7 +12983,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/bindings&quot;).ComponentDataBinding&gt;&gt; |
+                          import(&quot;./bindings&quot;).ComponentDataBinding&gt;&gt; |
                           undefined</code
                         >
                       </td>
@@ -11533,7 +12996,7 @@
                       <td>
                         <code
                           >Readonly&lt;Record&lt;string,
-                          import(&quot;./src/index&quot;).DatabaseDataSourceConfig&gt;&gt; |
+                          import(&quot;./data&quot;).DatabaseDataSourceConfig&gt;&gt; |
                           undefined</code
                         >
                       </td>
@@ -11576,8 +13039,15 @@
                     <tr>
                       <td><code>navigator</code></td>
                       <td>property</td>
-                      <td><code>NavigatorSpec</code></td>
+                      <td><code>AppNavigatorManifest</code></td>
                       <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>repository</code></td>
+                      <td>property</td>
+                      <td><code>RepositoryManifest | undefined</code></td>
+                      <td>no</td>
                       <td></td>
                     </tr>
                     <tr>
@@ -11617,7 +13087,7 @@
                 data-search="AppSettings type src/types.ts "
               >
                 <h4>AppSettings</h4>
-                <p class="muted">type • <code>src/types.ts:372:1</code></p>
+                <p class="muted">type • <code>src/types.ts:358:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11649,7 +13119,7 @@
                 data-search="AUTH_PROFILE_CREATE_STRATEGIES value src/types.ts "
               >
                 <h4>AUTH_PROFILE_CREATE_STRATEGIES</h4>
-                <p class="muted">value • <code>src/types.ts:220:14</code></p>
+                <p class="muted">value • <code>src/types.ts:219:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11660,7 +13130,7 @@
                 data-search="AUTH_PROFILE_FIELDS value src/types.ts "
               >
                 <h4>AUTH_PROFILE_FIELDS</h4>
-                <p class="muted">value • <code>src/types.ts:207:14</code></p>
+                <p class="muted">value • <code>src/types.ts:206:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11671,7 +13141,7 @@
                 data-search="AUTH_PROFILE_PRIMARY_KEY_STRATEGIES value src/types.ts "
               >
                 <h4>AUTH_PROFILE_PRIMARY_KEY_STRATEGIES</h4>
-                <p class="muted">value • <code>src/types.ts:217:14</code></p>
+                <p class="muted">value • <code>src/types.ts:216:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11682,7 +13152,7 @@
                 data-search="AUTH_PROFILE_UPDATE_STRATEGIES value src/types.ts "
               >
                 <h4>AUTH_PROFILE_UPDATE_STRATEGIES</h4>
-                <p class="muted">value • <code>src/types.ts:223:14</code></p>
+                <p class="muted">value • <code>src/types.ts:222:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11693,7 +13163,7 @@
                 data-search="AUTH_PROVIDERS value src/types.ts "
               >
                 <h4>AUTH_PROVIDERS</h4>
-                <p class="muted">value • <code>src/types.ts:197:14</code></p>
+                <p class="muted">value • <code>src/types.ts:196:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11704,7 +13174,7 @@
                 data-search="AUTH_SCOPES value src/types.ts "
               >
                 <h4>AUTH_SCOPES</h4>
-                <p class="muted">value • <code>src/types.ts:194:14</code></p>
+                <p class="muted">value • <code>src/types.ts:193:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11715,7 +13185,7 @@
                 data-search="AUTH_SIGN_IN_IDENTIFIERS value src/types.ts "
               >
                 <h4>AUTH_SIGN_IN_IDENTIFIERS</h4>
-                <p class="muted">value • <code>src/types.ts:201:14</code></p>
+                <p class="muted">value • <code>src/types.ts:200:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11726,7 +13196,7 @@
                 data-search="AUTH_SIGN_UP_POLICIES value src/types.ts "
               >
                 <h4>AUTH_SIGN_UP_POLICIES</h4>
-                <p class="muted">value • <code>src/types.ts:204:14</code></p>
+                <p class="muted">value • <code>src/types.ts:203:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11737,7 +13207,7 @@
                 data-search="AuthProfileCreateStrategy unknown src/types.ts "
               >
                 <h4>AuthProfileCreateStrategy</h4>
-                <p class="muted">unknown • <code>src/types.ts:221:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:220:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11748,7 +13218,7 @@
                 data-search="AuthProfileField unknown src/types.ts "
               >
                 <h4>AuthProfileField</h4>
-                <p class="muted">unknown • <code>src/types.ts:215:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:214:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11759,7 +13229,7 @@
                 data-search="AuthProfilePrimaryKeyStrategy unknown src/types.ts "
               >
                 <h4>AuthProfilePrimaryKeyStrategy</h4>
-                <p class="muted">unknown • <code>src/types.ts:218:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:217:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11770,7 +13240,7 @@
                 data-search="AuthProfileSpec type src/types.ts  AuthProfileField"
               >
                 <h4>AuthProfileSpec</h4>
-                <p class="muted">type • <code>src/types.ts:336:1</code></p>
+                <p class="muted">type • <code>src/types.ts:322:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -11839,7 +13309,7 @@
                 data-search="AuthProfileUpdateStrategy unknown src/types.ts "
               >
                 <h4>AuthProfileUpdateStrategy</h4>
-                <p class="muted">unknown • <code>src/types.ts:224:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:223:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11850,7 +13320,7 @@
                 data-search="AuthProvider unknown src/types.ts "
               >
                 <h4>AuthProvider</h4>
-                <p class="muted">unknown • <code>src/types.ts:199:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:198:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11861,7 +13331,7 @@
                 data-search="AuthScope unknown src/types.ts "
               >
                 <h4>AuthScope</h4>
-                <p class="muted">unknown • <code>src/types.ts:195:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:194:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11872,7 +13342,7 @@
                 data-search="AuthSignInIdentifier unknown src/types.ts "
               >
                 <h4>AuthSignInIdentifier</h4>
-                <p class="muted">unknown • <code>src/types.ts:202:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:201:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11883,7 +13353,7 @@
                 data-search="AuthSignInSpec type src/types.ts "
               >
                 <h4>AuthSignInSpec</h4>
-                <p class="muted">type • <code>src/types.ts:326:1</code></p>
+                <p class="muted">type • <code>src/types.ts:312:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11919,7 +13389,7 @@
                 data-search="AuthSignUpPolicy unknown src/types.ts "
               >
                 <h4>AuthSignUpPolicy</h4>
-                <p class="muted">unknown • <code>src/types.ts:205:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:204:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -11930,7 +13400,7 @@
                 data-search="AuthSignUpSpec type src/types.ts  AuthSignUpField"
               >
                 <h4>AuthSignUpSpec</h4>
-                <p class="muted">type • <code>src/types.ts:330:1</code></p>
+                <p class="muted">type • <code>src/types.ts:316:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -11986,7 +13456,7 @@
                 data-search="AuthSpec type src/types.ts  AuthFlowConfig AuthOAuthConfig AuthProfileSpec AuthProvider AuthSignInSpec AuthSignUpSpec AuthzSpec"
               >
                 <h4>AuthSpec</h4>
-                <p class="muted">type • <code>src/types.ts:344:1</code></p>
+                <p class="muted">type • <code>src/types.ts:330:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -12080,7 +13550,7 @@
                 data-search="AUTHZ_ENGINES value src/types.ts "
               >
                 <h4>AUTHZ_ENGINES</h4>
-                <p class="muted">value • <code>src/types.ts:191:14</code></p>
+                <p class="muted">value • <code>src/types.ts:190:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12091,7 +13561,7 @@
                 data-search="AUTHZ_KINDS value src/types.ts "
               >
                 <h4>AUTHZ_KINDS</h4>
-                <p class="muted">value • <code>src/types.ts:188:14</code></p>
+                <p class="muted">value • <code>src/types.ts:187:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12102,7 +13572,7 @@
                 data-search="AuthzEngine unknown src/types.ts "
               >
                 <h4>AuthzEngine</h4>
-                <p class="muted">unknown • <code>src/types.ts:192:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:191:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12113,7 +13583,7 @@
                 data-search="AuthzKind unknown src/types.ts "
               >
                 <h4>AuthzKind</h4>
-                <p class="muted">unknown • <code>src/types.ts:189:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:188:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12124,7 +13594,7 @@
                 data-search="AuthzSpec type src/types.ts "
               >
                 <h4>AuthzSpec</h4>
-                <p class="muted">type • <code>src/types.ts:321:1</code></p>
+                <p class="muted">type • <code>src/types.ts:307:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12163,7 +13633,7 @@
                 data-search="ButtonPressEventDto unknown src/types.ts "
               >
                 <h4>ButtonPressEventDto</h4>
-                <p class="muted">unknown • <code>src/types.ts:119:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:121:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12174,7 +13644,7 @@
                 data-search="CollectionItemPressEventDto unknown src/types.ts "
               >
                 <h4>CollectionItemPressEventDto</h4>
-                <p class="muted">unknown • <code>src/types.ts:126:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:128:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12185,7 +13655,7 @@
                 data-search="CollectionItemPressPayload type src/types.ts  ManifestValue"
               >
                 <h4>CollectionItemPressPayload</h4>
-                <p class="muted">type • <code>src/types.ts:121:1</code></p>
+                <p class="muted">type • <code>src/types.ts:123:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -12229,7 +13699,7 @@
                 data-search="ComponentEventDto type src/types.ts "
               >
                 <h4>ComponentEventDto</h4>
-                <p class="muted">type • <code>src/types.ts:101:1</code></p>
+                <p class="muted">type • <code>src/types.ts:103:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12275,7 +13745,7 @@
                 data-search="ComponentEventDtoKind unknown src/types.ts "
               >
                 <h4>ComponentEventDtoKind</h4>
-                <p class="muted">unknown • <code>src/types.ts:131:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:133:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12286,7 +13756,7 @@
                 data-search="ComponentEventPayloadValue unknown src/types.ts "
               >
                 <h4>ComponentEventPayloadValue</h4>
-                <p class="muted">unknown • <code>src/types.ts:99:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:101:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12297,7 +13767,7 @@
                 data-search="ConsoleAction type src/types.ts "
               >
                 <h4>ConsoleAction</h4>
-                <p class="muted">type • <code>src/types.ts:49:1</code></p>
+                <p class="muted">type • <code>src/types.ts:51:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12336,7 +13806,7 @@
                 data-search="DATABASE_PROVIDERS value src/types.ts "
               >
                 <h4>DATABASE_PROVIDERS</h4>
-                <p class="muted">value • <code>src/types.ts:171:14</code></p>
+                <p class="muted">value • <code>src/types.ts:170:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12347,7 +13817,7 @@
                 data-search="DATABASE_TIERS value src/types.ts "
               >
                 <h4>DATABASE_TIERS</h4>
-                <p class="muted">value • <code>src/types.ts:175:14</code></p>
+                <p class="muted">value • <code>src/types.ts:174:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12358,7 +13828,7 @@
                 data-search="DatabaseProvider unknown src/types.ts "
               >
                 <h4>DatabaseProvider</h4>
-                <p class="muted">unknown • <code>src/types.ts:173:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:172:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12369,7 +13839,7 @@
                 data-search="DatabaseSpec type src/types.ts  DatabaseProvider"
               >
                 <h4>DatabaseSpec</h4>
-                <p class="muted">type • <code>src/types.ts:306:1</code></p>
+                <p class="muted">type • <code>src/types.ts:292:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -12413,7 +13883,7 @@
                 data-search="DatabaseTier unknown src/types.ts "
               >
                 <h4>DatabaseTier</h4>
-                <p class="muted">unknown • <code>src/types.ts:176:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:175:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12424,7 +13894,7 @@
                 data-search="DEPLOYMENT_TARGETS value src/types.ts "
               >
                 <h4>DEPLOYMENT_TARGETS</h4>
-                <p class="muted">value • <code>src/types.ts:167:14</code></p>
+                <p class="muted">value • <code>src/types.ts:166:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12435,7 +13905,7 @@
                 data-search="DeploymentSpec type src/types.ts  DeploymentTarget"
               >
                 <h4>DeploymentSpec</h4>
-                <p class="muted">type • <code>src/types.ts:301:1</code></p>
+                <p class="muted">type • <code>src/types.ts:287:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -12479,7 +13949,7 @@
                 data-search="DeploymentTarget unknown src/types.ts "
               >
                 <h4>DeploymentTarget</h4>
-                <p class="muted">unknown • <code>src/types.ts:169:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:168:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12490,7 +13960,7 @@
                 data-search="FilterAction type src/types.ts "
               >
                 <h4>FilterAction</h4>
-                <p class="muted">type • <code>src/types.ts:74:1</code></p>
+                <p class="muted">type • <code>src/types.ts:76:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12529,7 +13999,7 @@
                 data-search="FormSubmitEventDto unknown src/types.ts "
               >
                 <h4>FormSubmitEventDto</h4>
-                <p class="muted">unknown • <code>src/types.ts:112:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:114:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12540,59 +14010,21 @@
                 data-search="FormSubmitValues unknown src/types.ts "
               >
                 <h4>FormSubmitValues</h4>
-                <p class="muted">unknown • <code>src/types.ts:110:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:112:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
               </article>
-              <article class="item" id="symbol-iconspec" data-search="IconSpec type src/types.ts ">
+              <article
+                class="item"
+                id="symbol-iconspec"
+                data-search="IconSpec unknown src/types.ts "
+              >
                 <h4>IconSpec</h4>
-                <p class="muted">type • <code>src/types.ts:226:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:242:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Member</th>
-                      <th>Kind</th>
-                      <th>Type</th>
-                      <th>Required</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>color</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>name</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>provider</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>size</code></td>
-                      <td>property</td>
-                      <td><code>string | number | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                  </tbody>
-                </table>
               </article>
               <article
                 class="item"
@@ -12600,7 +14032,7 @@
                 data-search="InfraManifest type src/types.ts  ApiDefinitionList AuthSpec DatabaseSpec DeploymentSpec InfraSecretStoreSpec NetworkingSpec StateSpec StorageSpec"
               >
                 <h4>InfraManifest</h4>
-                <p class="muted">type • <code>src/types.ts:360:1</code></p>
+                <p class="muted">type • <code>src/types.ts:346:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -12707,7 +14139,7 @@
                 data-search="KnownAuthProfileField unknown src/types.ts "
               >
                 <h4>KnownAuthProfileField</h4>
-                <p class="muted">unknown • <code>src/types.ts:214:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:213:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12718,7 +14150,7 @@
                 data-search="KnownAuthProvider unknown src/types.ts "
               >
                 <h4>KnownAuthProvider</h4>
-                <p class="muted">unknown • <code>src/types.ts:198:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:197:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12729,7 +14161,7 @@
                 data-search="KnownComponentEventDto unknown src/types.ts "
               >
                 <h4>KnownComponentEventDto</h4>
-                <p class="muted">unknown • <code>src/types.ts:134:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:136:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12740,7 +14172,7 @@
                 data-search="KnownDatabaseProvider unknown src/types.ts "
               >
                 <h4>KnownDatabaseProvider</h4>
-                <p class="muted">unknown • <code>src/types.ts:172:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:171:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12751,7 +14183,7 @@
                 data-search="KnownDeploymentTarget unknown src/types.ts "
               >
                 <h4>KnownDeploymentTarget</h4>
-                <p class="muted">unknown • <code>src/types.ts:168:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:167:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12762,7 +14194,7 @@
                 data-search="KnownStateProvider unknown src/types.ts "
               >
                 <h4>KnownStateProvider</h4>
-                <p class="muted">unknown • <code>src/types.ts:182:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:181:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12773,10 +14205,70 @@
                 data-search="ManifestValue unknown src/types.ts "
               >
                 <h4>ManifestValue</h4>
-                <p class="muted">unknown • <code>src/types.ts:91:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:93:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+              <article
+                class="item"
+                id="symbol-namediconspec"
+                data-search="NamedIconSpec type src/types.ts "
+              >
+                <h4>NamedIconSpec</h4>
+                <p class="muted">type • <code>src/types.ts:230:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>color</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>name</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>provider</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>size</code></td>
+                      <td>property</td>
+                      <td><code>string | number | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>source</code></td>
+                      <td>property</td>
+                      <td><code>undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
               </article>
               <article
                 class="item"
@@ -12784,7 +14276,7 @@
                 data-search="NavigateAction type src/types.ts "
               >
                 <h4>NavigateAction</h4>
-                <p class="muted">type • <code>src/types.ts:34:1</code></p>
+                <p class="muted">type • <code>src/types.ts:36:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12823,93 +14315,11 @@
               </article>
               <article
                 class="item"
-                id="symbol-navigator-types"
-                data-search="NAVIGATOR_TYPES value src/types.ts "
-              >
-                <h4>NAVIGATOR_TYPES</h4>
-                <p class="muted">value • <code>src/types.ts:137:14</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
-                id="symbol-navigatorspec"
-                data-search="NavigatorSpec type src/types.ts  RouteDefinition"
-              >
-                <h4>NavigatorSpec</h4>
-                <p class="muted">type • <code>src/types.ts:260:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div>
-                  <strong>Related symbols:</strong>
-                  <ul class="chips">
-                    <li class="chip">RouteDefinition</li>
-                  </ul>
-                </div>
-
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Member</th>
-                      <th>Kind</th>
-                      <th>Type</th>
-                      <th>Required</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>initialRouteName</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>options</code></td>
-                      <td>property</td>
-                      <td><code>Record&lt;string, unknown&gt; | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>routes</code></td>
-                      <td>property</td>
-                      <td><code>RouteDefinition[]</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>type</code></td>
-                      <td>property</td>
-                      <td>
-                        <code>&quot;stack&quot; | &quot;tabs&quot; | &quot;drawer&quot;</code>
-                      </td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </article>
-              <article
-                class="item"
-                id="symbol-navigatortype"
-                data-search="NavigatorType unknown src/types.ts "
-              >
-                <h4>NavigatorType</h4>
-                <p class="muted">unknown • <code>src/types.ts:138:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
-              </article>
-              <article
-                class="item"
                 id="symbol-networkingspec"
                 data-search="NetworkingSpec type src/types.ts "
               >
                 <h4>NetworkingSpec</h4>
-                <p class="muted">type • <code>src/types.ts:355:1</code></p>
+                <p class="muted">type • <code>src/types.ts:341:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -12944,98 +14354,11 @@
               </article>
               <article
                 class="item"
-                id="symbol-routedefinition"
-                data-search="RouteDefinition type src/types.ts  IconSpec NavigatorSpec"
-              >
-                <h4>RouteDefinition</h4>
-                <p class="muted">type • <code>src/types.ts:267:1</code></p>
-
-                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
-                <div>
-                  <strong>Related symbols:</strong>
-                  <ul class="chips">
-                    <li class="chip">IconSpec</li>
-                    <li class="chip">NavigatorSpec</li>
-                  </ul>
-                </div>
-
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Member</th>
-                      <th>Kind</th>
-                      <th>Type</th>
-                      <th>Required</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>guards</code></td>
-                      <td>property</td>
-                      <td><code>string[] | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>icon</code></td>
-                      <td>property</td>
-                      <td><code>IconSpec | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>label</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>name</code></td>
-                      <td>property</td>
-                      <td><code>string</code></td>
-                      <td>yes</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>navigator</code></td>
-                      <td>property</td>
-                      <td><code>NavigatorSpec | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>path</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>screenId</code></td>
-                      <td>property</td>
-                      <td><code>string | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                    <tr>
-                      <td><code>showInPrimaryNavigation</code></td>
-                      <td>property</td>
-                      <td><code>boolean | undefined</code></td>
-                      <td>no</td>
-                      <td></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </article>
-              <article
-                class="item"
                 id="symbol-screenspec"
                 data-search="ScreenSpec type src/types.ts  OperationScreenDataLoaderDefinition ScreenRequirements UiNode"
               >
                 <h4>ScreenSpec</h4>
-                <p class="muted">type • <code>src/types.ts:250:1</code></p>
+                <p class="muted">type • <code>src/types.ts:261:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13064,7 +14387,7 @@
                       <td>
                         <code
                           >readonly
-                          import(&quot;./src/bindings&quot;).OperationScreenDataLoaderDefinition[] |
+                          import(&quot;./bindings&quot;).OperationScreenDataLoaderDefinition[] |
                           undefined</code
                         >
                       </td>
@@ -13122,7 +14445,7 @@
                 data-search="SearchAction type src/types.ts "
               >
                 <h4>SearchAction</h4>
-                <p class="muted">type • <code>src/types.ts:66:1</code></p>
+                <p class="muted">type • <code>src/types.ts:68:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13161,7 +14484,7 @@
                 data-search="SetLanguageAction type src/types.ts "
               >
                 <h4>SetLanguageAction</h4>
-                <p class="muted">type • <code>src/types.ts:59:1</code></p>
+                <p class="muted">type • <code>src/types.ts:61:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13200,7 +14523,7 @@
                 data-search="SplashScreenAssetSpec type src/types.ts  SplashScreenResizeMode"
               >
                 <h4>SplashScreenAssetSpec</h4>
-                <p class="muted">type • <code>src/types.ts:287:1</code></p>
+                <p class="muted">type • <code>src/types.ts:273:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13251,7 +14574,7 @@
                 data-search="SplashScreenModeSpec type src/types.ts  SplashScreenResizeMode"
               >
                 <h4>SplashScreenModeSpec</h4>
-                <p class="muted">type • <code>src/types.ts:293:1</code></p>
+                <p class="muted">type • <code>src/types.ts:279:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13309,7 +14632,7 @@
                 data-search="SplashScreenResizeMode unknown src/types.ts "
               >
                 <h4>SplashScreenResizeMode</h4>
-                <p class="muted">unknown • <code>src/types.ts:285:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:271:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13320,7 +14643,7 @@
                 data-search="SplashScreenSpec type src/types.ts  SplashScreenModeSpec SplashScreenResizeMode"
               >
                 <h4>SplashScreenSpec</h4>
-                <p class="muted">type • <code>src/types.ts:297:1</code></p>
+                <p class="muted">type • <code>src/types.ts:283:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13386,7 +14709,7 @@
                 data-search="STATE_PERSISTENCE_MODES value src/types.ts "
               >
                 <h4>STATE_PERSISTENCE_MODES</h4>
-                <p class="muted">value • <code>src/types.ts:185:14</code></p>
+                <p class="muted">value • <code>src/types.ts:184:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13397,7 +14720,7 @@
                 data-search="STATE_PROVIDERS value src/types.ts "
               >
                 <h4>STATE_PROVIDERS</h4>
-                <p class="muted">value • <code>src/types.ts:181:14</code></p>
+                <p class="muted">value • <code>src/types.ts:180:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13408,7 +14731,7 @@
                 data-search="StatePersistenceMode unknown src/types.ts "
               >
                 <h4>StatePersistenceMode</h4>
-                <p class="muted">unknown • <code>src/types.ts:186:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:185:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13419,7 +14742,7 @@
                 data-search="StateProvider unknown src/types.ts "
               >
                 <h4>StateProvider</h4>
-                <p class="muted">unknown • <code>src/types.ts:183:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:182:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13430,7 +14753,7 @@
                 data-search="StateSpec type src/types.ts  StateProvider"
               >
                 <h4>StateSpec</h4>
-                <p class="muted">type • <code>src/types.ts:316:1</code></p>
+                <p class="muted">type • <code>src/types.ts:302:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13479,7 +14802,7 @@
                 data-search="STORAGE_PROVIDERS value src/types.ts "
               >
                 <h4>STORAGE_PROVIDERS</h4>
-                <p class="muted">value • <code>src/types.ts:178:14</code></p>
+                <p class="muted">value • <code>src/types.ts:177:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13490,7 +14813,7 @@
                 data-search="StorageProvider unknown src/types.ts "
               >
                 <h4>StorageProvider</h4>
-                <p class="muted">unknown • <code>src/types.ts:179:1</code></p>
+                <p class="muted">unknown • <code>src/types.ts:178:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13501,7 +14824,7 @@
                 data-search="StorageSpec type src/types.ts "
               >
                 <h4>StorageSpec</h4>
-                <p class="muted">type • <code>src/types.ts:311:1</code></p>
+                <p class="muted">type • <code>src/types.ts:297:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13536,11 +14859,76 @@
               </article>
               <article
                 class="item"
+                id="symbol-svgiconspec"
+                data-search="SvgIconSpec type src/types.ts  MediaAssetReference"
+              >
+                <h4>SvgIconSpec</h4>
+                <p class="muted">type • <code>src/types.ts:236:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">MediaAssetReference</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>color</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>name</code></td>
+                      <td>property</td>
+                      <td><code>undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>provider</code></td>
+                      <td>property</td>
+                      <td><code>undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>size</code></td>
+                      <td>property</td>
+                      <td><code>string | number | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>source</code></td>
+                      <td>property</td>
+                      <td><code>MediaAssetReference</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
                 id="symbol-themeconfig"
                 data-search="ThemeConfig type src/types.ts  ThemeGlobalTokenOverrides ThemeModeConfig ThemeRecipeOverrides"
               >
                 <h4>ThemeConfig</h4>
-                <p class="muted">type • <code>src/types.ts:20:1</code></p>
+                <p class="muted">type • <code>src/types.ts:22:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13614,7 +15002,7 @@
                 data-search="ThemeModeConfig type src/types.ts "
               >
                 <h4>ThemeModeConfig</h4>
-                <p class="muted">type • <code>src/types.ts:15:1</code></p>
+                <p class="muted">type • <code>src/types.ts:17:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13636,8 +15024,8 @@
                       <td>
                         <code
                           >&quot;monochromatic&quot; | &quot;analogous&quot; |
-                          &quot;complementary&quot; | &quot;triadic&quot; | &quot;tetradic&quot; |
-                          &quot;splitComplementary&quot;</code
+                          &quot;complementary&quot; | &quot;splitComplementary&quot; |
+                          &quot;triadic&quot; | &quot;tetradic&quot; | &quot;square&quot;</code
                         >
                       </td>
                       <td>yes</td>
@@ -13659,7 +15047,7 @@
                 data-search="ToggleDarkModeAction type src/types.ts "
               >
                 <h4>ToggleDarkModeAction</h4>
-                <p class="muted">type • <code>src/types.ts:54:1</code></p>
+                <p class="muted">type • <code>src/types.ts:56:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -13698,7 +15086,7 @@
                 data-search="UiNode type src/types.ts  UiNodeRepeatSpec"
               >
                 <h4>UiNode</h4>
-                <p class="muted">type • <code>src/types.ts:240:1</code></p>
+                <p class="muted">type • <code>src/types.ts:251:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -13777,7 +15165,7 @@
                 data-search="UiNodeRepeatSpec type src/types.ts  BindingValueSource UiNode"
               >
                 <h4>UiNodeRepeatSpec</h4>
-                <p class="muted">type • <code>src/types.ts:233:1</code></p>
+                <p class="muted">type • <code>src/types.ts:244:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -14952,9 +16340,14 @@
                 package__ankhorage_contracts -.-&gt; module_src_appManifest_deploy_ts
                 module_src_appManifest_deploy_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_deploy_ts --&gt; module_src_deploy_ts
+                module_src_appManifest_icon_ts[&quot;src/appManifest/icon.ts&quot;]
+                package__ankhorage_contracts -.-&gt; module_src_appManifest_icon_ts
+                module_src_appManifest_icon_ts --&gt; module_src_appManifest_shared_ts
+                module_src_appManifest_icon_ts --&gt; module_src_media_ts
                 module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
                 package__ankhorage_contracts -.-&gt; module_src_appManifest_infra_ts
                 module_src_appManifest_infra_ts --&gt; module_src_appManifest_apis_ts
+                module_src_appManifest_infra_ts --&gt; module_src_appManifest_icon_ts
                 module_src_appManifest_infra_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_infra_ts --&gt; module_src_auth_ts
                 module_src_appManifest_infra_ts --&gt; module_src_types_ts
@@ -14962,6 +16355,17 @@
                 package__ankhorage_contracts -.-&gt; module_src_appManifest_media_ts
                 module_src_appManifest_media_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_media_ts --&gt; module_src_media_ts
+                module_src_appManifest_navigator_ts[&quot;src/appManifest/navigator.ts&quot;]
+                package__ankhorage_contracts -.-&gt; module_src_appManifest_navigator_ts
+                module_src_appManifest_navigator_ts --&gt; module_src_appManifest_icon_ts
+                module_src_appManifest_navigator_ts --&gt;
+                module_src_appManifest_navigatorOptions_ts module_src_appManifest_navigator_ts
+                --&gt; module_src_appManifest_shared_ts module_src_appManifest_navigator_ts --&gt;
+                module_src_navigator_ts
+                module_src_appManifest_navigatorOptions_ts[&quot;src/appManifest/navigatorOptions.ts&quot;]
+                package__ankhorage_contracts -.-&gt; module_src_appManifest_navigatorOptions_ts
+                module_src_appManifest_navigatorOptions_ts --&gt; module_src_appManifest_shared_ts
+                module_src_appManifest_navigatorOptions_ts --&gt; module_src_navigator_ts
                 module_src_appManifest_screens_ts[&quot;src/appManifest/screens.ts&quot;]
                 package__ankhorage_contracts -.-&gt; module_src_appManifest_screens_ts
                 module_src_appManifest_screens_ts --&gt; module_src_appManifest_bindings_ts
@@ -15021,7 +16425,11 @@
                 package__ankhorage_contracts -.-&gt; module_src_deploy_ts
                 module_src_index_ts[&quot;src/index.ts&quot;]
                 module_src_media_ts[&quot;src/media.ts&quot;] package__ankhorage_contracts -.-&gt;
-                module_src_media_ts module_src_requirements_ts[&quot;src/requirements.ts&quot;]
+                module_src_media_ts module_src_navigator_ts[&quot;src/navigator.ts&quot;]
+                package__ankhorage_contracts -.-&gt; module_src_navigator_ts module_src_navigator_ts
+                --&gt; module_src_types_ts module_src_repository_ts[&quot;src/repository.ts&quot;]
+                package__ankhorage_contracts -.-&gt; module_src_repository_ts
+                module_src_requirements_ts[&quot;src/requirements.ts&quot;]
                 package__ankhorage_contracts -.-&gt; module_src_requirements_ts
                 module_src_runtimeCallbacks_ts[&quot;src/runtimeCallbacks.ts&quot;]
                 package__ankhorage_contracts -.-&gt; module_src_runtimeCallbacks_ts
@@ -15040,10 +16448,11 @@
                 module_src_types_ts --&gt; module_src_bindings_ts module_src_types_ts --&gt;
                 module_src_data_index_ts module_src_types_ts --&gt; module_src_deploy_ts
                 module_src_types_ts --&gt; module_src_media_ts module_src_types_ts --&gt;
-                module_src_requirements_ts module_src_types_ts --&gt; module_src_theme_ts
-                module_src_ui_ts[&quot;src/ui.ts&quot;] package__ankhorage_contracts -.-&gt;
-                module_src_ui_ts module_src_ui_ts --&gt; module_src_media_ts module_src_ui_ts --&gt;
-                module_src_types_ts
+                module_src_navigator_ts module_src_types_ts --&gt; module_src_repository_ts
+                module_src_types_ts --&gt; module_src_requirements_ts module_src_types_ts --&gt;
+                module_src_theme_ts module_src_ui_ts[&quot;src/ui.ts&quot;]
+                package__ankhorage_contracts -.-&gt; module_src_ui_ts module_src_ui_ts --&gt;
+                module_src_media_ts module_src_ui_ts --&gt; module_src_types_ts
               </div>
               <details>
                 <summary>View Mermaid source</summary>
@@ -15081,9 +16490,14 @@ graph TD
   package__ankhorage_contracts -.-&gt; module_src_appManifest_deploy_ts
   module_src_appManifest_deploy_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --&gt; module_src_deploy_ts
+  module_src_appManifest_icon_ts[&quot;src/appManifest/icon.ts&quot;]
+  package__ankhorage_contracts -.-&gt; module_src_appManifest_icon_ts
+  module_src_appManifest_icon_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_icon_ts --&gt; module_src_media_ts
   module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_appManifest_infra_ts
   module_src_appManifest_infra_ts --&gt; module_src_appManifest_apis_ts
+  module_src_appManifest_infra_ts --&gt; module_src_appManifest_icon_ts
   module_src_appManifest_infra_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_infra_ts --&gt; module_src_auth_ts
   module_src_appManifest_infra_ts --&gt; module_src_types_ts
@@ -15091,6 +16505,16 @@ graph TD
   package__ankhorage_contracts -.-&gt; module_src_appManifest_media_ts
   module_src_appManifest_media_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_media_ts --&gt; module_src_media_ts
+  module_src_appManifest_navigator_ts[&quot;src/appManifest/navigator.ts&quot;]
+  package__ankhorage_contracts -.-&gt; module_src_appManifest_navigator_ts
+  module_src_appManifest_navigator_ts --&gt; module_src_appManifest_icon_ts
+  module_src_appManifest_navigator_ts --&gt; module_src_appManifest_navigatorOptions_ts
+  module_src_appManifest_navigator_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_navigator_ts --&gt; module_src_navigator_ts
+  module_src_appManifest_navigatorOptions_ts[&quot;src/appManifest/navigatorOptions.ts&quot;]
+  package__ankhorage_contracts -.-&gt; module_src_appManifest_navigatorOptions_ts
+  module_src_appManifest_navigatorOptions_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_navigatorOptions_ts --&gt; module_src_navigator_ts
   module_src_appManifest_screens_ts[&quot;src/appManifest/screens.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_appManifest_screens_ts
   module_src_appManifest_screens_ts --&gt; module_src_appManifest_bindings_ts
@@ -15158,6 +16582,11 @@ graph TD
   module_src_index_ts[&quot;src/index.ts&quot;]
   module_src_media_ts[&quot;src/media.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_media_ts
+  module_src_navigator_ts[&quot;src/navigator.ts&quot;]
+  package__ankhorage_contracts -.-&gt; module_src_navigator_ts
+  module_src_navigator_ts --&gt; module_src_types_ts
+  module_src_repository_ts[&quot;src/repository.ts&quot;]
+  package__ankhorage_contracts -.-&gt; module_src_repository_ts
   module_src_requirements_ts[&quot;src/requirements.ts&quot;]
   package__ankhorage_contracts -.-&gt; module_src_requirements_ts
   module_src_runtimeCallbacks_ts[&quot;src/runtimeCallbacks.ts&quot;]
@@ -15181,6 +16610,8 @@ graph TD
   module_src_types_ts --&gt; module_src_data_index_ts
   module_src_types_ts --&gt; module_src_deploy_ts
   module_src_types_ts --&gt; module_src_media_ts
+  module_src_types_ts --&gt; module_src_navigator_ts
+  module_src_types_ts --&gt; module_src_repository_ts
   module_src_types_ts --&gt; module_src_requirements_ts
   module_src_types_ts --&gt; module_src_theme_ts
   module_src_ui_ts[&quot;src/ui.ts&quot;]
@@ -15203,8 +16634,11 @@ graph TD
                 module_src_appManifest_data_ts[&quot;src/appManifest/data.ts&quot;]
                 module_src_appManifest_dataSources_ts[&quot;src/appManifest/dataSources.ts&quot;]
                 module_src_appManifest_deploy_ts[&quot;src/appManifest/deploy.ts&quot;]
+                module_src_appManifest_icon_ts[&quot;src/appManifest/icon.ts&quot;]
                 module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
                 module_src_appManifest_media_ts[&quot;src/appManifest/media.ts&quot;]
+                module_src_appManifest_navigator_ts[&quot;src/appManifest/navigator.ts&quot;]
+                module_src_appManifest_navigatorOptions_ts[&quot;src/appManifest/navigatorOptions.ts&quot;]
                 module_src_appManifest_screens_ts[&quot;src/appManifest/screens.ts&quot;]
                 module_src_appManifest_shared_ts[&quot;src/appManifest/shared.ts&quot;]
                 module_src_auth_ts[&quot;src/auth.ts&quot;]
@@ -15224,6 +16658,8 @@ graph TD
                 module_src_deploy_ts[&quot;src/deploy.ts&quot;]
                 module_src_index_ts[&quot;src/index.ts&quot;]
                 module_src_media_ts[&quot;src/media.ts&quot;]
+                module_src_navigator_ts[&quot;src/navigator.ts&quot;]
+                module_src_repository_ts[&quot;src/repository.ts&quot;]
                 module_src_requirements_ts[&quot;src/requirements.ts&quot;]
                 module_src_runtimeCallbacks_ts[&quot;src/runtimeCallbacks.ts&quot;]
                 module_src_secretManifest_ts[&quot;src/secretManifest.ts&quot;]
@@ -15249,23 +16685,32 @@ graph TD
                 module_src_appManifest_data_ts module_src_appManifest_dataSources_ts --&gt;
                 module_src_appManifest_shared_ts module_src_appManifest_deploy_ts --&gt;
                 module_src_appManifest_shared_ts module_src_appManifest_deploy_ts --&gt;
-                module_src_deploy_ts module_src_appManifest_infra_ts --&gt;
+                module_src_deploy_ts module_src_appManifest_icon_ts --&gt;
+                module_src_appManifest_shared_ts module_src_appManifest_icon_ts --&gt;
+                module_src_media_ts module_src_appManifest_infra_ts --&gt;
                 module_src_appManifest_apis_ts module_src_appManifest_infra_ts --&gt;
+                module_src_appManifest_icon_ts module_src_appManifest_infra_ts --&gt;
                 module_src_appManifest_shared_ts module_src_appManifest_infra_ts --&gt;
                 module_src_auth_ts module_src_appManifest_infra_ts --&gt; module_src_types_ts
                 module_src_appManifest_media_ts --&gt; module_src_appManifest_shared_ts
                 module_src_appManifest_media_ts --&gt; module_src_media_ts
-                module_src_appManifest_screens_ts --&gt; module_src_appManifest_bindings_ts
-                module_src_appManifest_screens_ts --&gt; module_src_appManifest_shared_ts
-                module_src_appManifest_screens_ts --&gt; module_src_types_ts module_src_auth_ts
-                --&gt; module_src_deploy_ts module_src_auth_ts --&gt; module_src_secrets_ts
-                module_src_auth_ts --&gt; module_src_types_ts module_src_bindings_ts --&gt;
-                module_src_data_index_ts module_src_data_apis_ts --&gt; module_src_data_endpoints_ts
-                module_src_data_apis_ts --&gt; module_src_data_ids_ts module_src_data_apis_ts --&gt;
-                module_src_data_refs_ts module_src_data_apis_ts --&gt; module_src_data_schemas_ts
-                module_src_data_apis_ts --&gt; module_src_data_values_ts
-                module_src_data_diagnostics_ts --&gt; module_src_data_ids_ts
-                module_src_data_endpoints_ts --&gt; module_src_data_ids_ts
+                module_src_appManifest_navigator_ts --&gt; module_src_appManifest_icon_ts
+                module_src_appManifest_navigator_ts --&gt;
+                module_src_appManifest_navigatorOptions_ts module_src_appManifest_navigator_ts
+                --&gt; module_src_appManifest_shared_ts module_src_appManifest_navigator_ts --&gt;
+                module_src_navigator_ts module_src_appManifest_navigatorOptions_ts --&gt;
+                module_src_appManifest_shared_ts module_src_appManifest_navigatorOptions_ts --&gt;
+                module_src_navigator_ts module_src_appManifest_screens_ts --&gt;
+                module_src_appManifest_bindings_ts module_src_appManifest_screens_ts --&gt;
+                module_src_appManifest_shared_ts module_src_appManifest_screens_ts --&gt;
+                module_src_types_ts module_src_auth_ts --&gt; module_src_deploy_ts
+                module_src_auth_ts --&gt; module_src_secrets_ts module_src_auth_ts --&gt;
+                module_src_types_ts module_src_bindings_ts --&gt; module_src_data_index_ts
+                module_src_data_apis_ts --&gt; module_src_data_endpoints_ts module_src_data_apis_ts
+                --&gt; module_src_data_ids_ts module_src_data_apis_ts --&gt; module_src_data_refs_ts
+                module_src_data_apis_ts --&gt; module_src_data_schemas_ts module_src_data_apis_ts
+                --&gt; module_src_data_values_ts module_src_data_diagnostics_ts --&gt;
+                module_src_data_ids_ts module_src_data_endpoints_ts --&gt; module_src_data_ids_ts
                 module_src_data_endpoints_ts --&gt; module_src_data_operations_ts
                 module_src_data_endpoints_ts --&gt; module_src_data_refs_ts
                 module_src_data_endpoints_ts --&gt; module_src_data_values_ts
@@ -15280,14 +16725,16 @@ graph TD
                 module_src_data_sources_ts --&gt; module_src_data_ids_ts module_src_data_sources_ts
                 --&gt; module_src_data_refs_ts module_src_data_sources_ts --&gt;
                 module_src_data_schemas_ts module_src_data_sources_ts --&gt;
-                module_src_data_values_ts module_src_runtimeCallbacks_ts --&gt; module_src_types_ts
+                module_src_data_values_ts module_src_navigator_ts --&gt; module_src_types_ts
+                module_src_runtimeCallbacks_ts --&gt; module_src_types_ts
                 module_src_secretManifest_ts --&gt; module_src_secrets_ts module_src_types_ts --&gt;
                 module_src_auth_ts module_src_types_ts --&gt; module_src_bindings_ts
                 module_src_types_ts --&gt; module_src_data_index_ts module_src_types_ts --&gt;
                 module_src_deploy_ts module_src_types_ts --&gt; module_src_media_ts
-                module_src_types_ts --&gt; module_src_requirements_ts module_src_types_ts --&gt;
-                module_src_theme_ts module_src_ui_ts --&gt; module_src_media_ts module_src_ui_ts
-                --&gt; module_src_types_ts
+                module_src_types_ts --&gt; module_src_navigator_ts module_src_types_ts --&gt;
+                module_src_repository_ts module_src_types_ts --&gt; module_src_requirements_ts
+                module_src_types_ts --&gt; module_src_theme_ts module_src_ui_ts --&gt;
+                module_src_media_ts module_src_ui_ts --&gt; module_src_types_ts
               </div>
               <details>
                 <summary>View Mermaid source</summary>
@@ -15299,8 +16746,11 @@ graph LR
   module_src_appManifest_data_ts[&quot;src/appManifest/data.ts&quot;]
   module_src_appManifest_dataSources_ts[&quot;src/appManifest/dataSources.ts&quot;]
   module_src_appManifest_deploy_ts[&quot;src/appManifest/deploy.ts&quot;]
+  module_src_appManifest_icon_ts[&quot;src/appManifest/icon.ts&quot;]
   module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
   module_src_appManifest_media_ts[&quot;src/appManifest/media.ts&quot;]
+  module_src_appManifest_navigator_ts[&quot;src/appManifest/navigator.ts&quot;]
+  module_src_appManifest_navigatorOptions_ts[&quot;src/appManifest/navigatorOptions.ts&quot;]
   module_src_appManifest_screens_ts[&quot;src/appManifest/screens.ts&quot;]
   module_src_appManifest_shared_ts[&quot;src/appManifest/shared.ts&quot;]
   module_src_auth_ts[&quot;src/auth.ts&quot;]
@@ -15320,6 +16770,8 @@ graph LR
   module_src_deploy_ts[&quot;src/deploy.ts&quot;]
   module_src_index_ts[&quot;src/index.ts&quot;]
   module_src_media_ts[&quot;src/media.ts&quot;]
+  module_src_navigator_ts[&quot;src/navigator.ts&quot;]
+  module_src_repository_ts[&quot;src/repository.ts&quot;]
   module_src_requirements_ts[&quot;src/requirements.ts&quot;]
   module_src_runtimeCallbacks_ts[&quot;src/runtimeCallbacks.ts&quot;]
   module_src_secretManifest_ts[&quot;src/secretManifest.ts&quot;]
@@ -15346,12 +16798,21 @@ graph LR
   module_src_appManifest_dataSources_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_deploy_ts --&gt; module_src_deploy_ts
+  module_src_appManifest_icon_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_icon_ts --&gt; module_src_media_ts
   module_src_appManifest_infra_ts --&gt; module_src_appManifest_apis_ts
+  module_src_appManifest_infra_ts --&gt; module_src_appManifest_icon_ts
   module_src_appManifest_infra_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_infra_ts --&gt; module_src_auth_ts
   module_src_appManifest_infra_ts --&gt; module_src_types_ts
   module_src_appManifest_media_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_media_ts --&gt; module_src_media_ts
+  module_src_appManifest_navigator_ts --&gt; module_src_appManifest_icon_ts
+  module_src_appManifest_navigator_ts --&gt; module_src_appManifest_navigatorOptions_ts
+  module_src_appManifest_navigator_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_navigator_ts --&gt; module_src_navigator_ts
+  module_src_appManifest_navigatorOptions_ts --&gt; module_src_appManifest_shared_ts
+  module_src_appManifest_navigatorOptions_ts --&gt; module_src_navigator_ts
   module_src_appManifest_screens_ts --&gt; module_src_appManifest_bindings_ts
   module_src_appManifest_screens_ts --&gt; module_src_appManifest_shared_ts
   module_src_appManifest_screens_ts --&gt; module_src_types_ts
@@ -15382,6 +16843,7 @@ graph LR
   module_src_data_sources_ts --&gt; module_src_data_refs_ts
   module_src_data_sources_ts --&gt; module_src_data_schemas_ts
   module_src_data_sources_ts --&gt; module_src_data_values_ts
+  module_src_navigator_ts --&gt; module_src_types_ts
   module_src_runtimeCallbacks_ts --&gt; module_src_types_ts
   module_src_secretManifest_ts --&gt; module_src_secrets_ts
   module_src_types_ts --&gt; module_src_auth_ts
@@ -15389,6 +16851,8 @@ graph LR
   module_src_types_ts --&gt; module_src_data_index_ts
   module_src_types_ts --&gt; module_src_deploy_ts
   module_src_types_ts --&gt; module_src_media_ts
+  module_src_types_ts --&gt; module_src_navigator_ts
+  module_src_types_ts --&gt; module_src_repository_ts
   module_src_types_ts --&gt; module_src_requirements_ts
   module_src_types_ts --&gt; module_src_theme_ts
   module_src_ui_ts --&gt; module_src_media_ts
@@ -15406,8 +16870,11 @@ graph LR
                 module_src_appManifest_data_ts[&quot;src/appManifest/data.ts&quot;]
                 module_src_appManifest_dataSources_ts[&quot;src/appManifest/dataSources.ts&quot;]
                 module_src_appManifest_deploy_ts[&quot;src/appManifest/deploy.ts&quot;]
+                module_src_appManifest_icon_ts[&quot;src/appManifest/icon.ts&quot;]
                 module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
                 module_src_appManifest_media_ts[&quot;src/appManifest/media.ts&quot;]
+                module_src_appManifest_navigator_ts[&quot;src/appManifest/navigator.ts&quot;]
+                module_src_appManifest_navigatorOptions_ts[&quot;src/appManifest/navigatorOptions.ts&quot;]
                 module_src_appManifest_screens_ts[&quot;src/appManifest/screens.ts&quot;]
                 module_src_appManifest_shared_ts[&quot;src/appManifest/shared.ts&quot;]
                 module_src_auth_ts[&quot;src/auth.ts&quot;]
@@ -15427,6 +16894,8 @@ graph LR
                 module_src_deploy_ts[&quot;src/deploy.ts&quot;]
                 module_src_index_ts[&quot;src/index.ts&quot;]
                 module_src_media_ts[&quot;src/media.ts&quot;]
+                module_src_navigator_ts[&quot;src/navigator.ts&quot;]
+                module_src_repository_ts[&quot;src/repository.ts&quot;]
                 module_src_requirements_ts[&quot;src/requirements.ts&quot;]
                 module_src_runtimeCallbacks_ts[&quot;src/runtimeCallbacks.ts&quot;]
                 module_src_secretManifest_ts[&quot;src/secretManifest.ts&quot;]
@@ -15443,11 +16912,14 @@ graph LR
                 export_AdapterKind export_AdapterRef[&quot;AdapterRef&quot;] module_src_data_refs_ts
                 --&gt; export_AdapterRef export_AdapterRef -.-&gt; export_AdapterKind
                 export_AdapterRef -.-&gt; export_DataContractValue
-                export_AlertAction[&quot;AlertAction&quot;] module_src_types_ts --&gt;
-                export_AlertAction export_AnkhCapabilityId[&quot;AnkhCapabilityId&quot;]
-                module_src_cli_index_ts --&gt; export_AnkhCapabilityId
-                export_AnkhCommandCategory[&quot;AnkhCommandCategory&quot;] module_src_cli_index_ts
-                --&gt; export_AnkhCommandCategory
+                export_AdaptiveTabsConfig[&quot;AdaptiveTabsConfig&quot;] module_src_navigator_ts
+                --&gt; export_AdaptiveTabsConfig export_AdaptiveTabsConfig -.-&gt;
+                export_CustomTabsPresentationConfig export_AdaptiveTabsConfig -.-&gt;
+                export_NativeTabsConfig export_AlertAction[&quot;AlertAction&quot;]
+                module_src_types_ts --&gt; export_AlertAction
+                export_AnkhCapabilityId[&quot;AnkhCapabilityId&quot;] module_src_cli_index_ts --&gt;
+                export_AnkhCapabilityId export_AnkhCommandCategory[&quot;AnkhCommandCategory&quot;]
+                module_src_cli_index_ts --&gt; export_AnkhCommandCategory
                 export_AnkhCommandDescriptor[&quot;AnkhCommandDescriptor&quot;]
                 module_src_cli_index_ts --&gt; export_AnkhCommandDescriptor
                 export_AnkhCommandProviderManifest[&quot;AnkhCommandProviderManifest&quot;]
@@ -15507,14 +16979,17 @@ graph LR
                 export_AppDeployWebTargetConfig -.-&gt; export_AppDeployProviderSelection
                 export_AppManifest[&quot;AppManifest&quot;] module_src_types_ts --&gt;
                 export_AppManifest export_AppManifest -.-&gt; export_AppCategory export_AppManifest
-                -.-&gt; export_AppDeployManifest export_AppManifest -.-&gt; export_AppSettings
+                -.-&gt; export_AppDeployManifest export_AppManifest -.-&gt;
+                export_AppNavigatorManifest export_AppManifest -.-&gt; export_AppSettings
                 export_AppManifest -.-&gt; export_ComponentDataBinding export_AppManifest -.-&gt;
                 export_DatabaseDataSourceConfig export_AppManifest -.-&gt; export_InfraManifest
                 export_AppManifest -.-&gt; export_MediaManifest export_AppManifest -.-&gt;
-                export_NavigatorSpec export_AppManifest -.-&gt; export_ScreenSpec export_AppManifest
-                -.-&gt; export_SplashScreenSpec export_AppManifest -.-&gt; export_ThemeConfig
-                export_AppManifestParseResult[&quot;AppManifestParseResult&quot;]
+                export_RepositoryManifest export_AppManifest -.-&gt; export_ScreenSpec
+                export_AppManifest -.-&gt; export_SplashScreenSpec export_AppManifest -.-&gt;
+                export_ThemeConfig export_AppManifestParseResult[&quot;AppManifestParseResult&quot;]
                 module_src_appManifest_ts --&gt; export_AppManifestParseResult
+                export_AppNavigatorManifest[&quot;AppNavigatorManifest&quot;]
+                module_src_navigator_ts --&gt; export_AppNavigatorManifest
                 export_AppSettings[&quot;AppSettings&quot;] module_src_types_ts --&gt;
                 export_AppSettings export_AUTH_IDENTIFIER_KINDS[&quot;AUTH_IDENTIFIER_KINDS&quot;]
                 module_src_auth_ts --&gt; export_AUTH_IDENTIFIER_KINDS
@@ -15742,6 +17217,19 @@ graph LR
                 module_src_data_refs_ts --&gt; export_CredentialKind
                 export_CredentialRef[&quot;CredentialRef&quot;] module_src_data_refs_ts --&gt;
                 export_CredentialRef export_CredentialRef -.-&gt; export_CredentialKind
+                export_CUSTOM_TABS_PRESENTATIONS[&quot;CUSTOM_TABS_PRESENTATIONS&quot;]
+                module_src_navigator_ts --&gt; export_CUSTOM_TABS_PRESENTATIONS
+                export_CustomNavigatorNode[&quot;CustomNavigatorNode&quot;] module_src_navigator_ts
+                --&gt; export_CustomNavigatorNode export_CustomNavigatorNode -.-&gt;
+                export_ManifestValue export_CustomNavigatorNode -.-&gt; export_RouteDefinition
+                export_CustomTabsConfig[&quot;CustomTabsConfig&quot;] module_src_navigator_ts --&gt;
+                export_CustomTabsConfig
+                export_CustomTabsPresentation[&quot;CustomTabsPresentation&quot;]
+                module_src_navigator_ts --&gt; export_CustomTabsPresentation
+                export_CustomTabsPresentationConfig[&quot;CustomTabsPresentationConfig&quot;]
+                module_src_navigator_ts --&gt; export_CustomTabsPresentationConfig
+                export_CustomTabsWebConfig[&quot;CustomTabsWebConfig&quot;] module_src_navigator_ts
+                --&gt; export_CustomTabsWebConfig
                 export_DATABASE_PROVIDERS[&quot;DATABASE_PROVIDERS&quot;] module_src_types_ts --&gt;
                 export_DATABASE_PROVIDERS export_DATABASE_TIERS[&quot;DATABASE_TIERS&quot;]
                 module_src_types_ts --&gt; export_DATABASE_TIERS
@@ -15909,13 +17397,25 @@ graph LR
                 export_DeploymentSpec[&quot;DeploymentSpec&quot;] module_src_types_ts --&gt;
                 export_DeploymentSpec export_DeploymentSpec -.-&gt; export_DeploymentTarget
                 export_DeploymentTarget[&quot;DeploymentTarget&quot;] module_src_types_ts --&gt;
-                export_DeploymentTarget export_EndpointId[&quot;EndpointId&quot;]
-                module_src_data_ids_ts --&gt; export_EndpointId
-                export_EventBinding[&quot;EventBinding&quot;] module_src_bindings_ts --&gt;
-                export_EventBinding export_EventBinding -.-&gt; export_BindingCondition
-                export_EventBinding -.-&gt; export_BindingInputValue export_EventBinding -.-&gt;
-                export_EventBindingTarget export_EventBindingTarget[&quot;EventBindingTarget&quot;]
-                module_src_bindings_ts --&gt; export_EventBindingTarget
+                export_DeploymentTarget export_DRAWER_POSITIONS[&quot;DRAWER_POSITIONS&quot;]
+                module_src_navigator_ts --&gt; export_DRAWER_POSITIONS
+                export_DRAWER_TYPES[&quot;DRAWER_TYPES&quot;] module_src_navigator_ts --&gt;
+                export_DRAWER_TYPES export_DrawerNavigatorNode[&quot;DrawerNavigatorNode&quot;]
+                module_src_navigator_ts --&gt; export_DrawerNavigatorNode export_DrawerNavigatorNode
+                -.-&gt; export_DrawerNavigatorOptions export_DrawerNavigatorNode -.-&gt;
+                export_RouteDefinition
+                export_DrawerNavigatorOptions[&quot;DrawerNavigatorOptions&quot;]
+                module_src_navigator_ts --&gt; export_DrawerNavigatorOptions
+                export_DrawerPosition[&quot;DrawerPosition&quot;] module_src_navigator_ts --&gt;
+                export_DrawerPosition export_DrawerType[&quot;DrawerType&quot;]
+                module_src_navigator_ts --&gt; export_DrawerType
+                export_EndpointId[&quot;EndpointId&quot;] module_src_data_ids_ts --&gt;
+                export_EndpointId export_EventBinding[&quot;EventBinding&quot;]
+                module_src_bindings_ts --&gt; export_EventBinding export_EventBinding -.-&gt;
+                export_BindingCondition export_EventBinding -.-&gt; export_BindingInputValue
+                export_EventBinding -.-&gt; export_EventBindingTarget
+                export_EventBindingTarget[&quot;EventBindingTarget&quot;] module_src_bindings_ts
+                --&gt; export_EventBindingTarget
                 export_ExternalGraphQlApiDefinition[&quot;ExternalGraphQlApiDefinition&quot;]
                 module_src_data_apis_ts --&gt; export_ExternalGraphQlApiDefinition
                 export_ExternalGraphQlApiDefinition -.-&gt; export_CredentialRef
@@ -15934,6 +17434,10 @@ graph LR
                 export_FilterAction
                 export_findForbiddenInlineSecretFields[&quot;findForbiddenInlineSecretFields&quot;]
                 module_src_secrets_ts --&gt; export_findForbiddenInlineSecretFields
+                export_FIXED_CUSTOM_TABS_PRESENTATIONS[&quot;FIXED_CUSTOM_TABS_PRESENTATIONS&quot;]
+                module_src_navigator_ts --&gt; export_FIXED_CUSTOM_TABS_PRESENTATIONS
+                export_FixedCustomTabsPresentation[&quot;FixedCustomTabsPresentation&quot;]
+                module_src_navigator_ts --&gt; export_FixedCustomTabsPresentation
                 export_FORBIDDEN_INLINE_SECRET_FIELDS[&quot;FORBIDDEN_INLINE_SECRET_FIELDS&quot;]
                 module_src_secrets_ts --&gt; export_FORBIDDEN_INLINE_SECRET_FIELDS
                 export_FormSubmitEventDto[&quot;FormSubmitEventDto&quot;] module_src_types_ts --&gt;
@@ -15966,6 +17470,18 @@ graph LR
                 export_isAppManifest[&quot;isAppManifest&quot;] module_src_appManifest_ts --&gt;
                 export_isAppManifest export_isMediaAssetReference[&quot;isMediaAssetReference&quot;]
                 module_src_media_ts --&gt; export_isMediaAssetReference
+                export_JAVASCRIPT_STACK_PRESENTATIONS[&quot;JAVASCRIPT_STACK_PRESENTATIONS&quot;]
+                module_src_navigator_ts --&gt; export_JAVASCRIPT_STACK_PRESENTATIONS
+                export_JAVASCRIPT_TABS_PRESENTATIONS[&quot;JAVASCRIPT_TABS_PRESENTATIONS&quot;]
+                module_src_navigator_ts --&gt; export_JAVASCRIPT_TABS_PRESENTATIONS
+                export_JavaScriptStackPresentation[&quot;JavaScriptStackPresentation&quot;]
+                module_src_navigator_ts --&gt; export_JavaScriptStackPresentation
+                export_JavaScriptStackScreenOptions[&quot;JavaScriptStackScreenOptions&quot;]
+                module_src_navigator_ts --&gt; export_JavaScriptStackScreenOptions
+                export_JavaScriptTabsConfig[&quot;JavaScriptTabsConfig&quot;]
+                module_src_navigator_ts --&gt; export_JavaScriptTabsConfig
+                export_JavaScriptTabsPresentation[&quot;JavaScriptTabsPresentation&quot;]
+                module_src_navigator_ts --&gt; export_JavaScriptTabsPresentation
                 export_KnownAuthOAuthProviderId[&quot;KnownAuthOAuthProviderId&quot;]
                 module_src_auth_ts --&gt; export_KnownAuthOAuthProviderId
                 export_KnownAuthOAuthTransportId[&quot;KnownAuthOAuthTransportId&quot;]
@@ -16017,17 +17533,42 @@ graph LR
                 export_StorageUploadResult export_MediaStorageSource[&quot;MediaStorageSource&quot;]
                 module_src_media_ts --&gt; export_MediaStorageSource
                 export_MediaUrlSource[&quot;MediaUrlSource&quot;] module_src_media_ts --&gt;
-                export_MediaUrlSource export_NavigateAction[&quot;NavigateAction&quot;]
-                module_src_types_ts --&gt; export_NavigateAction
-                export_NAVIGATOR_TYPES[&quot;NAVIGATOR_TYPES&quot;] module_src_types_ts --&gt;
-                export_NAVIGATOR_TYPES export_NavigatorSpec[&quot;NavigatorSpec&quot;]
-                module_src_types_ts --&gt; export_NavigatorSpec export_NavigatorSpec -.-&gt;
-                export_RouteDefinition export_NavigatorType[&quot;NavigatorType&quot;]
-                module_src_types_ts --&gt; export_NavigatorType
-                export_NetworkingSpec[&quot;NetworkingSpec&quot;] module_src_types_ts --&gt;
-                export_NetworkingSpec export_normalizeSecretRef[&quot;normalizeSecretRef&quot;]
-                module_src_secrets_ts --&gt; export_normalizeSecretRef export_normalizeSecretRef
-                -.-&gt; export_SecretStoreResult
+                export_MediaUrlSource export_NamedIconSpec[&quot;NamedIconSpec&quot;]
+                module_src_types_ts --&gt; export_NamedIconSpec
+                export_NATIVE_TABS_MINIMIZE_BEHAVIORS[&quot;NATIVE_TABS_MINIMIZE_BEHAVIORS&quot;]
+                module_src_navigator_ts --&gt; export_NATIVE_TABS_MINIMIZE_BEHAVIORS
+                export_NativeTabsConfig[&quot;NativeTabsConfig&quot;] module_src_navigator_ts --&gt;
+                export_NativeTabsConfig export_NativeTabsConfig -.-&gt;
+                export_NavigatorScreenReference
+                export_NativeTabsMinimizeBehavior[&quot;NativeTabsMinimizeBehavior&quot;]
+                module_src_navigator_ts --&gt; export_NativeTabsMinimizeBehavior
+                export_NavigateAction[&quot;NavigateAction&quot;] module_src_types_ts --&gt;
+                export_NavigateAction export_NAVIGATOR_PRESETS[&quot;NAVIGATOR_PRESETS&quot;]
+                module_src_navigator_ts --&gt; export_NAVIGATOR_PRESETS
+                export_NAVIGATOR_TYPES[&quot;NAVIGATOR_TYPES&quot;] module_src_navigator_ts --&gt;
+                export_NAVIGATOR_TYPES export_NavigatorDefaults[&quot;NavigatorDefaults&quot;]
+                module_src_navigator_ts --&gt; export_NavigatorDefaults export_NavigatorDefaults
+                -.-&gt; export_StackImplementationConfig export_NavigatorDefaults -.-&gt;
+                export_TabsImplementationConfig export_NavigatorFlows[&quot;NavigatorFlows&quot;]
+                module_src_navigator_ts --&gt; export_NavigatorFlows
+                export_NavigatorNode[&quot;NavigatorNode&quot;] module_src_navigator_ts --&gt;
+                export_NavigatorNode
+                export_NavigatorPlatformConfig[&quot;NavigatorPlatformConfig&quot;]
+                module_src_navigator_ts --&gt; export_NavigatorPlatformConfig
+                export_NavigatorPlatformConfig -.-&gt; export_StackImplementationConfig
+                export_NavigatorPlatformConfig -.-&gt; export_TabsImplementationConfig
+                export_NavigatorPlatforms[&quot;NavigatorPlatforms&quot;] module_src_navigator_ts
+                --&gt; export_NavigatorPlatforms export_NavigatorPlatforms -.-&gt;
+                export_NavigatorPlatformConfig export_NavigatorPreset[&quot;NavigatorPreset&quot;]
+                module_src_navigator_ts --&gt; export_NavigatorPreset
+                export_NavigatorScreenReference[&quot;NavigatorScreenReference&quot;]
+                module_src_navigator_ts --&gt; export_NavigatorScreenReference
+                export_NavigatorType[&quot;NavigatorType&quot;] module_src_navigator_ts --&gt;
+                export_NavigatorType export_NetworkingSpec[&quot;NetworkingSpec&quot;]
+                module_src_types_ts --&gt; export_NetworkingSpec
+                export_normalizeSecretRef[&quot;normalizeSecretRef&quot;] module_src_secrets_ts
+                --&gt; export_normalizeSecretRef export_normalizeSecretRef -.-&gt;
+                export_SecretStoreResult
                 export_normalizeSecretScope[&quot;normalizeSecretScope&quot;] module_src_secrets_ts
                 --&gt; export_normalizeSecretScope export_normalizeSecretScope -.-&gt;
                 export_SecretScope export_normalizeSecretScope -.-&gt; export_SecretStoreResult
@@ -16047,13 +17588,18 @@ graph LR
                 export_PropBinding export_PropBinding -.-&gt; export_BindingFallback
                 export_PropBinding -.-&gt; export_BindingLifecycleBehavior export_PropBinding
                 -.-&gt; export_BindingValueSource export_PropBinding -.-&gt;
-                export_BindingValueTransform export_resolveAuthFlow[&quot;resolveAuthFlow&quot;]
+                export_BindingValueTransform
+                export_RepositoryManifest[&quot;RepositoryManifest&quot;] module_src_repository_ts
+                --&gt; export_RepositoryManifest export_resolveAuthFlow[&quot;resolveAuthFlow&quot;]
                 module_src_auth_ts --&gt; export_resolveAuthFlow export_resolveAuthFlow -.-&gt;
-                export_AuthFlowConfig export_RouteDefinition[&quot;RouteDefinition&quot;]
-                module_src_types_ts --&gt; export_RouteDefinition export_RouteDefinition -.-&gt;
-                export_IconSpec export_RouteDefinition -.-&gt; export_NavigatorSpec
-                export_RuntimeCallback[&quot;RuntimeCallback&quot;] module_src_runtimeCallbacks_ts
-                --&gt; export_RuntimeCallback
+                export_AuthFlowConfig
+                export_ResponsiveTabsPresentation[&quot;ResponsiveTabsPresentation&quot;]
+                module_src_navigator_ts --&gt; export_ResponsiveTabsPresentation
+                export_RouteDefinition[&quot;RouteDefinition&quot;] module_src_navigator_ts --&gt;
+                export_RouteDefinition export_RouteDefinition -.-&gt; export_IconSpec
+                export_RouteDefinition -.-&gt; export_NavigatorNode export_RouteDefinition -.-&gt;
+                export_StackScreenOptions export_RuntimeCallback[&quot;RuntimeCallback&quot;]
+                module_src_runtimeCallbacks_ts --&gt; export_RuntimeCallback
                 export_RuntimeCallbackArgs[&quot;RuntimeCallbackArgs&quot;]
                 module_src_runtimeCallbacks_ts --&gt; export_RuntimeCallbackArgs
                 export_RuntimeCallbackArgs -.-&gt; export_UiNode
@@ -16128,6 +17674,9 @@ graph LR
                 export_SignOutInput[&quot;SignOutInput&quot;] module_src_auth_ts --&gt;
                 export_SignOutInput export_SignUpInput[&quot;SignUpInput&quot;] module_src_auth_ts
                 --&gt; export_SignUpInput export_SignUpInput -.-&gt; export_AuthIdentifier
+                export_SlotNavigatorNode[&quot;SlotNavigatorNode&quot;] module_src_navigator_ts
+                --&gt; export_SlotNavigatorNode export_SlotNavigatorNode -.-&gt;
+                export_RouteDefinition
                 export_SplashScreenAssetSpec[&quot;SplashScreenAssetSpec&quot;] module_src_types_ts
                 --&gt; export_SplashScreenAssetSpec export_SplashScreenAssetSpec -.-&gt;
                 export_SplashScreenResizeMode
@@ -16139,6 +17688,26 @@ graph LR
                 export_SplashScreenSpec[&quot;SplashScreenSpec&quot;] module_src_types_ts --&gt;
                 export_SplashScreenSpec export_SplashScreenSpec -.-&gt; export_SplashScreenModeSpec
                 export_SplashScreenSpec -.-&gt; export_SplashScreenResizeMode
+                export_SplitViewNavigatorNode[&quot;SplitViewNavigatorNode&quot;]
+                module_src_navigator_ts --&gt; export_SplitViewNavigatorNode
+                export_SplitViewNavigatorNode -.-&gt; export_NavigatorScreenReference
+                export_SplitViewNavigatorNode -.-&gt; export_RouteDefinition
+                export_STACK_IMPLEMENTATIONS[&quot;STACK_IMPLEMENTATIONS&quot;]
+                module_src_navigator_ts --&gt; export_STACK_IMPLEMENTATIONS
+                export_STACK_PRESENTATIONS[&quot;STACK_PRESENTATIONS&quot;] module_src_navigator_ts
+                --&gt; export_STACK_PRESENTATIONS
+                export_StackHeaderOptions[&quot;StackHeaderOptions&quot;] module_src_navigator_ts
+                --&gt; export_StackHeaderOptions
+                export_StackImplementation[&quot;StackImplementation&quot;] module_src_navigator_ts
+                --&gt; export_StackImplementation
+                export_StackImplementationConfig[&quot;StackImplementationConfig&quot;]
+                module_src_navigator_ts --&gt; export_StackImplementationConfig
+                export_StackNavigatorNode[&quot;StackNavigatorNode&quot;] module_src_navigator_ts
+                --&gt; export_StackNavigatorNode
+                export_StackPresentation[&quot;StackPresentation&quot;] module_src_navigator_ts
+                --&gt; export_StackPresentation
+                export_StackScreenOptions[&quot;StackScreenOptions&quot;] module_src_navigator_ts
+                --&gt; export_StackScreenOptions
                 export_StartOAuthAuthorizationInput[&quot;StartOAuthAuthorizationInput&quot;]
                 module_src_auth_ts --&gt; export_StartOAuthAuthorizationInput
                 export_StartOAuthAuthorizationInput -.-&gt; export_AuthOAuthProviderId
@@ -16228,7 +17797,15 @@ graph LR
                 module_src_storage_ts --&gt; export_StorageUploadInput
                 export_StorageUploadResult[&quot;StorageUploadResult&quot;] module_src_storage_ts
                 --&gt; export_StorageUploadResult export_StorageUploadResult -.-&gt;
-                export_StorageAssetReference export_ThemeConfig[&quot;ThemeConfig&quot;]
+                export_StorageAssetReference export_SvgIconSpec[&quot;SvgIconSpec&quot;]
+                module_src_types_ts --&gt; export_SvgIconSpec export_SvgIconSpec -.-&gt;
+                export_MediaAssetReference
+                export_TabsImplementationConfig[&quot;TabsImplementationConfig&quot;]
+                module_src_navigator_ts --&gt; export_TabsImplementationConfig
+                export_TabsNavigatorConfig[&quot;TabsNavigatorConfig&quot;] module_src_navigator_ts
+                --&gt; export_TabsNavigatorConfig
+                export_TabsNavigatorNode[&quot;TabsNavigatorNode&quot;] module_src_navigator_ts
+                --&gt; export_TabsNavigatorNode export_ThemeConfig[&quot;ThemeConfig&quot;]
                 module_src_types_ts --&gt; export_ThemeConfig export_ThemeConfig -.-&gt;
                 export_ThemeGlobalTokenOverrides export_ThemeConfig -.-&gt; export_ThemeModeConfig
                 export_ThemeConfig -.-&gt; export_ThemeRecipeOverrides
@@ -16352,8 +17929,11 @@ graph LR
   module_src_appManifest_data_ts[&quot;src/appManifest/data.ts&quot;]
   module_src_appManifest_dataSources_ts[&quot;src/appManifest/dataSources.ts&quot;]
   module_src_appManifest_deploy_ts[&quot;src/appManifest/deploy.ts&quot;]
+  module_src_appManifest_icon_ts[&quot;src/appManifest/icon.ts&quot;]
   module_src_appManifest_infra_ts[&quot;src/appManifest/infra.ts&quot;]
   module_src_appManifest_media_ts[&quot;src/appManifest/media.ts&quot;]
+  module_src_appManifest_navigator_ts[&quot;src/appManifest/navigator.ts&quot;]
+  module_src_appManifest_navigatorOptions_ts[&quot;src/appManifest/navigatorOptions.ts&quot;]
   module_src_appManifest_screens_ts[&quot;src/appManifest/screens.ts&quot;]
   module_src_appManifest_shared_ts[&quot;src/appManifest/shared.ts&quot;]
   module_src_auth_ts[&quot;src/auth.ts&quot;]
@@ -16373,6 +17953,8 @@ graph LR
   module_src_deploy_ts[&quot;src/deploy.ts&quot;]
   module_src_index_ts[&quot;src/index.ts&quot;]
   module_src_media_ts[&quot;src/media.ts&quot;]
+  module_src_navigator_ts[&quot;src/navigator.ts&quot;]
+  module_src_repository_ts[&quot;src/repository.ts&quot;]
   module_src_requirements_ts[&quot;src/requirements.ts&quot;]
   module_src_runtimeCallbacks_ts[&quot;src/runtimeCallbacks.ts&quot;]
   module_src_secretManifest_ts[&quot;src/secretManifest.ts&quot;]
@@ -16394,6 +17976,10 @@ graph LR
   module_src_data_refs_ts --&gt; export_AdapterRef
   export_AdapterRef -.-&gt; export_AdapterKind
   export_AdapterRef -.-&gt; export_DataContractValue
+  export_AdaptiveTabsConfig[&quot;AdaptiveTabsConfig&quot;]
+  module_src_navigator_ts --&gt; export_AdaptiveTabsConfig
+  export_AdaptiveTabsConfig -.-&gt; export_CustomTabsPresentationConfig
+  export_AdaptiveTabsConfig -.-&gt; export_NativeTabsConfig
   export_AlertAction[&quot;AlertAction&quot;]
   module_src_types_ts --&gt; export_AlertAction
   export_AnkhCapabilityId[&quot;AnkhCapabilityId&quot;]
@@ -16470,17 +18056,20 @@ graph LR
   module_src_types_ts --&gt; export_AppManifest
   export_AppManifest -.-&gt; export_AppCategory
   export_AppManifest -.-&gt; export_AppDeployManifest
+  export_AppManifest -.-&gt; export_AppNavigatorManifest
   export_AppManifest -.-&gt; export_AppSettings
   export_AppManifest -.-&gt; export_ComponentDataBinding
   export_AppManifest -.-&gt; export_DatabaseDataSourceConfig
   export_AppManifest -.-&gt; export_InfraManifest
   export_AppManifest -.-&gt; export_MediaManifest
-  export_AppManifest -.-&gt; export_NavigatorSpec
+  export_AppManifest -.-&gt; export_RepositoryManifest
   export_AppManifest -.-&gt; export_ScreenSpec
   export_AppManifest -.-&gt; export_SplashScreenSpec
   export_AppManifest -.-&gt; export_ThemeConfig
   export_AppManifestParseResult[&quot;AppManifestParseResult&quot;]
   module_src_appManifest_ts --&gt; export_AppManifestParseResult
+  export_AppNavigatorManifest[&quot;AppNavigatorManifest&quot;]
+  module_src_navigator_ts --&gt; export_AppNavigatorManifest
   export_AppSettings[&quot;AppSettings&quot;]
   module_src_types_ts --&gt; export_AppSettings
   export_AUTH_IDENTIFIER_KINDS[&quot;AUTH_IDENTIFIER_KINDS&quot;]
@@ -16747,6 +18336,20 @@ graph LR
   export_CredentialRef[&quot;CredentialRef&quot;]
   module_src_data_refs_ts --&gt; export_CredentialRef
   export_CredentialRef -.-&gt; export_CredentialKind
+  export_CUSTOM_TABS_PRESENTATIONS[&quot;CUSTOM_TABS_PRESENTATIONS&quot;]
+  module_src_navigator_ts --&gt; export_CUSTOM_TABS_PRESENTATIONS
+  export_CustomNavigatorNode[&quot;CustomNavigatorNode&quot;]
+  module_src_navigator_ts --&gt; export_CustomNavigatorNode
+  export_CustomNavigatorNode -.-&gt; export_ManifestValue
+  export_CustomNavigatorNode -.-&gt; export_RouteDefinition
+  export_CustomTabsConfig[&quot;CustomTabsConfig&quot;]
+  module_src_navigator_ts --&gt; export_CustomTabsConfig
+  export_CustomTabsPresentation[&quot;CustomTabsPresentation&quot;]
+  module_src_navigator_ts --&gt; export_CustomTabsPresentation
+  export_CustomTabsPresentationConfig[&quot;CustomTabsPresentationConfig&quot;]
+  module_src_navigator_ts --&gt; export_CustomTabsPresentationConfig
+  export_CustomTabsWebConfig[&quot;CustomTabsWebConfig&quot;]
+  module_src_navigator_ts --&gt; export_CustomTabsWebConfig
   export_DATABASE_PROVIDERS[&quot;DATABASE_PROVIDERS&quot;]
   module_src_types_ts --&gt; export_DATABASE_PROVIDERS
   export_DATABASE_TIERS[&quot;DATABASE_TIERS&quot;]
@@ -16953,6 +18556,20 @@ graph LR
   export_DeploymentSpec -.-&gt; export_DeploymentTarget
   export_DeploymentTarget[&quot;DeploymentTarget&quot;]
   module_src_types_ts --&gt; export_DeploymentTarget
+  export_DRAWER_POSITIONS[&quot;DRAWER_POSITIONS&quot;]
+  module_src_navigator_ts --&gt; export_DRAWER_POSITIONS
+  export_DRAWER_TYPES[&quot;DRAWER_TYPES&quot;]
+  module_src_navigator_ts --&gt; export_DRAWER_TYPES
+  export_DrawerNavigatorNode[&quot;DrawerNavigatorNode&quot;]
+  module_src_navigator_ts --&gt; export_DrawerNavigatorNode
+  export_DrawerNavigatorNode -.-&gt; export_DrawerNavigatorOptions
+  export_DrawerNavigatorNode -.-&gt; export_RouteDefinition
+  export_DrawerNavigatorOptions[&quot;DrawerNavigatorOptions&quot;]
+  module_src_navigator_ts --&gt; export_DrawerNavigatorOptions
+  export_DrawerPosition[&quot;DrawerPosition&quot;]
+  module_src_navigator_ts --&gt; export_DrawerPosition
+  export_DrawerType[&quot;DrawerType&quot;]
+  module_src_navigator_ts --&gt; export_DrawerType
   export_EndpointId[&quot;EndpointId&quot;]
   module_src_data_ids_ts --&gt; export_EndpointId
   export_EventBinding[&quot;EventBinding&quot;]
@@ -16980,6 +18597,10 @@ graph LR
   module_src_types_ts --&gt; export_FilterAction
   export_findForbiddenInlineSecretFields[&quot;findForbiddenInlineSecretFields&quot;]
   module_src_secrets_ts --&gt; export_findForbiddenInlineSecretFields
+  export_FIXED_CUSTOM_TABS_PRESENTATIONS[&quot;FIXED_CUSTOM_TABS_PRESENTATIONS&quot;]
+  module_src_navigator_ts --&gt; export_FIXED_CUSTOM_TABS_PRESENTATIONS
+  export_FixedCustomTabsPresentation[&quot;FixedCustomTabsPresentation&quot;]
+  module_src_navigator_ts --&gt; export_FixedCustomTabsPresentation
   export_FORBIDDEN_INLINE_SECRET_FIELDS[&quot;FORBIDDEN_INLINE_SECRET_FIELDS&quot;]
   module_src_secrets_ts --&gt; export_FORBIDDEN_INLINE_SECRET_FIELDS
   export_FormSubmitEventDto[&quot;FormSubmitEventDto&quot;]
@@ -17019,6 +18640,18 @@ graph LR
   module_src_appManifest_ts --&gt; export_isAppManifest
   export_isMediaAssetReference[&quot;isMediaAssetReference&quot;]
   module_src_media_ts --&gt; export_isMediaAssetReference
+  export_JAVASCRIPT_STACK_PRESENTATIONS[&quot;JAVASCRIPT_STACK_PRESENTATIONS&quot;]
+  module_src_navigator_ts --&gt; export_JAVASCRIPT_STACK_PRESENTATIONS
+  export_JAVASCRIPT_TABS_PRESENTATIONS[&quot;JAVASCRIPT_TABS_PRESENTATIONS&quot;]
+  module_src_navigator_ts --&gt; export_JAVASCRIPT_TABS_PRESENTATIONS
+  export_JavaScriptStackPresentation[&quot;JavaScriptStackPresentation&quot;]
+  module_src_navigator_ts --&gt; export_JavaScriptStackPresentation
+  export_JavaScriptStackScreenOptions[&quot;JavaScriptStackScreenOptions&quot;]
+  module_src_navigator_ts --&gt; export_JavaScriptStackScreenOptions
+  export_JavaScriptTabsConfig[&quot;JavaScriptTabsConfig&quot;]
+  module_src_navigator_ts --&gt; export_JavaScriptTabsConfig
+  export_JavaScriptTabsPresentation[&quot;JavaScriptTabsPresentation&quot;]
+  module_src_navigator_ts --&gt; export_JavaScriptTabsPresentation
   export_KnownAuthOAuthProviderId[&quot;KnownAuthOAuthProviderId&quot;]
   module_src_auth_ts --&gt; export_KnownAuthOAuthProviderId
   export_KnownAuthOAuthTransportId[&quot;KnownAuthOAuthTransportId&quot;]
@@ -17080,15 +18713,42 @@ graph LR
   module_src_media_ts --&gt; export_MediaStorageSource
   export_MediaUrlSource[&quot;MediaUrlSource&quot;]
   module_src_media_ts --&gt; export_MediaUrlSource
+  export_NamedIconSpec[&quot;NamedIconSpec&quot;]
+  module_src_types_ts --&gt; export_NamedIconSpec
+  export_NATIVE_TABS_MINIMIZE_BEHAVIORS[&quot;NATIVE_TABS_MINIMIZE_BEHAVIORS&quot;]
+  module_src_navigator_ts --&gt; export_NATIVE_TABS_MINIMIZE_BEHAVIORS
+  export_NativeTabsConfig[&quot;NativeTabsConfig&quot;]
+  module_src_navigator_ts --&gt; export_NativeTabsConfig
+  export_NativeTabsConfig -.-&gt; export_NavigatorScreenReference
+  export_NativeTabsMinimizeBehavior[&quot;NativeTabsMinimizeBehavior&quot;]
+  module_src_navigator_ts --&gt; export_NativeTabsMinimizeBehavior
   export_NavigateAction[&quot;NavigateAction&quot;]
   module_src_types_ts --&gt; export_NavigateAction
+  export_NAVIGATOR_PRESETS[&quot;NAVIGATOR_PRESETS&quot;]
+  module_src_navigator_ts --&gt; export_NAVIGATOR_PRESETS
   export_NAVIGATOR_TYPES[&quot;NAVIGATOR_TYPES&quot;]
-  module_src_types_ts --&gt; export_NAVIGATOR_TYPES
-  export_NavigatorSpec[&quot;NavigatorSpec&quot;]
-  module_src_types_ts --&gt; export_NavigatorSpec
-  export_NavigatorSpec -.-&gt; export_RouteDefinition
+  module_src_navigator_ts --&gt; export_NAVIGATOR_TYPES
+  export_NavigatorDefaults[&quot;NavigatorDefaults&quot;]
+  module_src_navigator_ts --&gt; export_NavigatorDefaults
+  export_NavigatorDefaults -.-&gt; export_StackImplementationConfig
+  export_NavigatorDefaults -.-&gt; export_TabsImplementationConfig
+  export_NavigatorFlows[&quot;NavigatorFlows&quot;]
+  module_src_navigator_ts --&gt; export_NavigatorFlows
+  export_NavigatorNode[&quot;NavigatorNode&quot;]
+  module_src_navigator_ts --&gt; export_NavigatorNode
+  export_NavigatorPlatformConfig[&quot;NavigatorPlatformConfig&quot;]
+  module_src_navigator_ts --&gt; export_NavigatorPlatformConfig
+  export_NavigatorPlatformConfig -.-&gt; export_StackImplementationConfig
+  export_NavigatorPlatformConfig -.-&gt; export_TabsImplementationConfig
+  export_NavigatorPlatforms[&quot;NavigatorPlatforms&quot;]
+  module_src_navigator_ts --&gt; export_NavigatorPlatforms
+  export_NavigatorPlatforms -.-&gt; export_NavigatorPlatformConfig
+  export_NavigatorPreset[&quot;NavigatorPreset&quot;]
+  module_src_navigator_ts --&gt; export_NavigatorPreset
+  export_NavigatorScreenReference[&quot;NavigatorScreenReference&quot;]
+  module_src_navigator_ts --&gt; export_NavigatorScreenReference
   export_NavigatorType[&quot;NavigatorType&quot;]
-  module_src_types_ts --&gt; export_NavigatorType
+  module_src_navigator_ts --&gt; export_NavigatorType
   export_NetworkingSpec[&quot;NetworkingSpec&quot;]
   module_src_types_ts --&gt; export_NetworkingSpec
   export_normalizeSecretRef[&quot;normalizeSecretRef&quot;]
@@ -17118,13 +18778,18 @@ graph LR
   export_PropBinding -.-&gt; export_BindingLifecycleBehavior
   export_PropBinding -.-&gt; export_BindingValueSource
   export_PropBinding -.-&gt; export_BindingValueTransform
+  export_RepositoryManifest[&quot;RepositoryManifest&quot;]
+  module_src_repository_ts --&gt; export_RepositoryManifest
   export_resolveAuthFlow[&quot;resolveAuthFlow&quot;]
   module_src_auth_ts --&gt; export_resolveAuthFlow
   export_resolveAuthFlow -.-&gt; export_AuthFlowConfig
+  export_ResponsiveTabsPresentation[&quot;ResponsiveTabsPresentation&quot;]
+  module_src_navigator_ts --&gt; export_ResponsiveTabsPresentation
   export_RouteDefinition[&quot;RouteDefinition&quot;]
-  module_src_types_ts --&gt; export_RouteDefinition
+  module_src_navigator_ts --&gt; export_RouteDefinition
   export_RouteDefinition -.-&gt; export_IconSpec
-  export_RouteDefinition -.-&gt; export_NavigatorSpec
+  export_RouteDefinition -.-&gt; export_NavigatorNode
+  export_RouteDefinition -.-&gt; export_StackScreenOptions
   export_RuntimeCallback[&quot;RuntimeCallback&quot;]
   module_src_runtimeCallbacks_ts --&gt; export_RuntimeCallback
   export_RuntimeCallbackArgs[&quot;RuntimeCallbackArgs&quot;]
@@ -17218,6 +18883,9 @@ graph LR
   export_SignUpInput[&quot;SignUpInput&quot;]
   module_src_auth_ts --&gt; export_SignUpInput
   export_SignUpInput -.-&gt; export_AuthIdentifier
+  export_SlotNavigatorNode[&quot;SlotNavigatorNode&quot;]
+  module_src_navigator_ts --&gt; export_SlotNavigatorNode
+  export_SlotNavigatorNode -.-&gt; export_RouteDefinition
   export_SplashScreenAssetSpec[&quot;SplashScreenAssetSpec&quot;]
   module_src_types_ts --&gt; export_SplashScreenAssetSpec
   export_SplashScreenAssetSpec -.-&gt; export_SplashScreenResizeMode
@@ -17230,6 +18898,26 @@ graph LR
   module_src_types_ts --&gt; export_SplashScreenSpec
   export_SplashScreenSpec -.-&gt; export_SplashScreenModeSpec
   export_SplashScreenSpec -.-&gt; export_SplashScreenResizeMode
+  export_SplitViewNavigatorNode[&quot;SplitViewNavigatorNode&quot;]
+  module_src_navigator_ts --&gt; export_SplitViewNavigatorNode
+  export_SplitViewNavigatorNode -.-&gt; export_NavigatorScreenReference
+  export_SplitViewNavigatorNode -.-&gt; export_RouteDefinition
+  export_STACK_IMPLEMENTATIONS[&quot;STACK_IMPLEMENTATIONS&quot;]
+  module_src_navigator_ts --&gt; export_STACK_IMPLEMENTATIONS
+  export_STACK_PRESENTATIONS[&quot;STACK_PRESENTATIONS&quot;]
+  module_src_navigator_ts --&gt; export_STACK_PRESENTATIONS
+  export_StackHeaderOptions[&quot;StackHeaderOptions&quot;]
+  module_src_navigator_ts --&gt; export_StackHeaderOptions
+  export_StackImplementation[&quot;StackImplementation&quot;]
+  module_src_navigator_ts --&gt; export_StackImplementation
+  export_StackImplementationConfig[&quot;StackImplementationConfig&quot;]
+  module_src_navigator_ts --&gt; export_StackImplementationConfig
+  export_StackNavigatorNode[&quot;StackNavigatorNode&quot;]
+  module_src_navigator_ts --&gt; export_StackNavigatorNode
+  export_StackPresentation[&quot;StackPresentation&quot;]
+  module_src_navigator_ts --&gt; export_StackPresentation
+  export_StackScreenOptions[&quot;StackScreenOptions&quot;]
+  module_src_navigator_ts --&gt; export_StackScreenOptions
   export_StartOAuthAuthorizationInput[&quot;StartOAuthAuthorizationInput&quot;]
   module_src_auth_ts --&gt; export_StartOAuthAuthorizationInput
   export_StartOAuthAuthorizationInput -.-&gt; export_AuthOAuthProviderId
@@ -17339,6 +19027,15 @@ graph LR
   export_StorageUploadResult[&quot;StorageUploadResult&quot;]
   module_src_storage_ts --&gt; export_StorageUploadResult
   export_StorageUploadResult -.-&gt; export_StorageAssetReference
+  export_SvgIconSpec[&quot;SvgIconSpec&quot;]
+  module_src_types_ts --&gt; export_SvgIconSpec
+  export_SvgIconSpec -.-&gt; export_MediaAssetReference
+  export_TabsImplementationConfig[&quot;TabsImplementationConfig&quot;]
+  module_src_navigator_ts --&gt; export_TabsImplementationConfig
+  export_TabsNavigatorConfig[&quot;TabsNavigatorConfig&quot;]
+  module_src_navigator_ts --&gt; export_TabsNavigatorConfig
+  export_TabsNavigatorNode[&quot;TabsNavigatorNode&quot;]
+  module_src_navigator_ts --&gt; export_TabsNavigatorNode
   export_ThemeConfig[&quot;ThemeConfig&quot;]
   module_src_types_ts --&gt; export_ThemeConfig
   export_ThemeConfig -.-&gt; export_ThemeGlobalTokenOverrides
@@ -17468,27 +19165,32 @@ graph LR
             <h2>src/appManifest.ts</h2>
             <article class="item" data-search="parseAppManifest src/appManifest.ts ">
               <h3>parseAppManifest</h3>
-              <p class="muted"><code>src/appManifest.ts:43:1</code></p>
+              <p class="muted"><code>src/appManifest.ts:44:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAppManifest src/appManifest.ts ">
               <h3>isAppManifest</h3>
-              <p class="muted"><code>src/appManifest.ts:50:1</code></p>
+              <p class="muted"><code>src/appManifest.ts:51:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="hasRequiredManifestKeys src/appManifest.ts ">
               <h3>hasRequiredManifestKeys</h3>
-              <p class="muted"><code>src/appManifest.ts:72:1</code></p>
+              <p class="muted"><code>src/appManifest.ts:74:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isActiveThemeMode src/appManifest.ts ">
               <h3>isActiveThemeMode</h3>
-              <p class="muted"><code>src/appManifest.ts:78:1</code></p>
+              <p class="muted"><code>src/appManifest.ts:80:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article class="item" data-search="isRepositoryManifest src/appManifest.ts ">
+              <h3>isRepositoryManifest</h3>
+              <p class="muted"><code>src/appManifest.ts:84:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAppSettings src/appManifest.ts ">
               <h3>isAppSettings</h3>
-              <p class="muted"><code>src/appManifest.ts:82:1</code></p>
+              <p class="muted"><code>src/appManifest.ts:98:1</code></p>
               <p class="empty">No description available.</p>
             </article>
           </section>
@@ -17833,6 +19535,26 @@ graph LR
           </section>
         </section>
         <section
+          id="view-src-appmanifest-icon-ts"
+          class="view"
+          data-view="src/appManifest/icon.ts"
+          hidden
+        >
+          <section class="panel">
+            <h2>src/appManifest/icon.ts</h2>
+            <article
+              class="item"
+              data-search="isIconSpec src/appManifest/icon.ts Validate a serializable icon as either a named font glyph or an SVG media reference."
+            >
+              <h3>isIconSpec</h3>
+              <p class="muted"><code>src/appManifest/icon.ts:5:1</code></p>
+              <p>
+                Validate a serializable icon as either a named font glyph or an SVG media reference.
+              </p>
+            </article>
+          </section>
+        </section>
+        <section
           id="view-src-appmanifest-infra-ts"
           class="view"
           data-view="src/appManifest/infra.ts"
@@ -17842,77 +19564,72 @@ graph LR
             <h2>src/appManifest/infra.ts</h2>
             <article class="item" data-search="isInfraManifest src/appManifest/infra.ts ">
               <h3>isInfraManifest</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:37:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:38:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isDeploymentSpec src/appManifest/infra.ts ">
               <h3>isDeploymentSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:55:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:56:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isDatabaseSpec src/appManifest/infra.ts ">
               <h3>isDatabaseSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:61:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:62:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isStorageSpec src/appManifest/infra.ts ">
               <h3>isStorageSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:70:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:71:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isStateSpec src/appManifest/infra.ts ">
               <h3>isStateSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:79:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:80:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isNetworkingSpec src/appManifest/infra.ts ">
               <h3>isNetworkingSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:88:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:89:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthSpec src/appManifest/infra.ts ">
               <h3>isAuthSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:92:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:93:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthzSpec src/appManifest/infra.ts ">
               <h3>isAuthzSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:107:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:108:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthFlow src/appManifest/infra.ts ">
               <h3>isAuthFlow</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:117:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:118:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthSignInSpec src/appManifest/infra.ts ">
               <h3>isAuthSignInSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:130:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:131:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthSignUpSpec src/appManifest/infra.ts ">
               <h3>isAuthSignUpSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:140:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:141:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthOAuthConfig src/appManifest/infra.ts ">
               <h3>isAuthOAuthConfig</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:150:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:151:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthOAuthProviderConfig src/appManifest/infra.ts ">
               <h3>isAuthOAuthProviderConfig</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:160:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:161:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isAuthProfileSpec src/appManifest/infra.ts ">
               <h3>isAuthProfileSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:174:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isIconSpec src/appManifest/infra.ts ">
-              <h3>isIconSpec</h3>
-              <p class="muted"><code>src/appManifest/infra.ts:191:1</code></p>
+              <p class="muted"><code>src/appManifest/infra.ts:175:1</code></p>
               <p class="empty">No description available.</p>
             </article>
           </section>
@@ -17984,6 +19701,277 @@ graph LR
           </section>
         </section>
         <section
+          id="view-src-appmanifest-navigator-ts"
+          class="view"
+          data-view="src/appManifest/navigator.ts"
+          hidden
+        >
+          <section class="panel">
+            <h2>src/appManifest/navigator.ts</h2>
+            <article
+              class="item"
+              data-search="isAppNavigatorManifest src/appManifest/navigator.ts Validate the complete serialized `AppManifest.navigator` slice."
+            >
+              <h3>isAppNavigatorManifest</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:17:1</code></p>
+              <p>Validate the complete serialized `AppManifest.navigator` slice.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isNavigatorNode src/appManifest/navigator.ts Validate one nested navigator node independently from app-level authoring metadata."
+            >
+              <h3>isNavigatorNode</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:30:1</code></p>
+              <p>
+                Validate one nested navigator node independently from app-level authoring metadata.
+              </p>
+            </article>
+            <article
+              class="item"
+              data-search="isRouteDefinition src/appManifest/navigator.ts Validate one route and preserve its portable metadata and nested navigator."
+            >
+              <h3>isRouteDefinition</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:64:1</code></p>
+              <p>Validate one route and preserve its portable metadata and nested navigator.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isSplitViewNavigatorNode src/appManifest/navigator.ts Validate Split View screen references without duplicating the routed secondary tree."
+            >
+              <h3>isSplitViewNavigatorNode</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:80:1</code></p>
+              <p>
+                Validate Split View screen references without duplicating the routed secondary tree.
+              </p>
+            </article>
+            <article
+              class="item"
+              data-search="isCustomNavigatorNode src/appManifest/navigator.ts Validate a registered custom navigator with JSON-safe configuration only."
+            >
+              <h3>isCustomNavigatorNode</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:98:1</code></p>
+              <p>Validate a registered custom navigator with JSON-safe configuration only.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isNavigatorJsonRecord src/appManifest/navigator.ts Validate an acyclic, finite JSON object used by a custom navigator adapter."
+            >
+              <h3>isNavigatorJsonRecord</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:108:1</code></p>
+              <p>Validate an acyclic, finite JSON object used by a custom navigator adapter.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isNavigatorJsonValue src/appManifest/navigator.ts Recursively validate the portable manifest value domain and reject cycles."
+            >
+              <h3>isNavigatorJsonValue</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:113:1</code></p>
+              <p>Recursively validate the portable manifest value domain and reject cycles.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isNavigatorFlows src/appManifest/navigator.ts Validate optional app-level navigator flow intent."
+            >
+              <h3>isNavigatorFlows</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:138:1</code></p>
+              <p>Validate optional app-level navigator flow intent.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isNavigatorDefaults src/appManifest/navigator.ts Validate package-owned navigator defaults without requiring a navigator node type."
+            >
+              <h3>isNavigatorDefaults</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:147:1</code></p>
+              <p>
+                Validate package-owned navigator defaults without requiring a navigator node type.
+              </p>
+            </article>
+            <article
+              class="item"
+              data-search="isNavigatorPlatforms src/appManifest/navigator.ts Validate per-platform navigator implementation overrides."
+            >
+              <h3>isNavigatorPlatforms</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:159:1</code></p>
+              <p>Validate per-platform navigator implementation overrides.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isNavigatorPlatformConfig src/appManifest/navigator.ts Validate one platform-specific navigator override slice."
+            >
+              <h3>isNavigatorPlatformConfig</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:170:1</code></p>
+              <p>Validate one platform-specific navigator override slice.</p>
+            </article>
+          </section>
+        </section>
+        <section
+          id="view-src-appmanifest-navigatoroptions-ts"
+          class="view"
+          data-view="src/appManifest/navigatorOptions.ts"
+          hidden
+        >
+          <section class="panel">
+            <h2>src/appManifest/navigatorOptions.ts</h2>
+            <article
+              class="item"
+              data-search="isStackImplementationConfig src/appManifest/navigatorOptions.ts Validate stable native, JavaScript, or alpha Experimental Stack desired state."
+            >
+              <h3>isStackImplementationConfig</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:23:1</code></p>
+              <p>Validate stable native, JavaScript, or alpha Experimental Stack desired state.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isStackScreenOptions src/appManifest/navigatorOptions.ts Validate the serializable native-stack screen option subset."
+            >
+              <h3>isStackScreenOptions</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:37:1</code></p>
+              <p>Validate the serializable native-stack screen option subset.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isDrawerNavigatorOptions src/appManifest/navigatorOptions.ts Validate the finite serializable Drawer option subset."
+            >
+              <h3>isDrawerNavigatorOptions</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:66:1</code></p>
+              <p>Validate the finite serializable Drawer option subset.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isTabsImplementationConfig src/appManifest/navigatorOptions.ts Validate tabs implementation desired state, with omitted implementation meaning adaptive."
+            >
+              <h3>isTabsImplementationConfig</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:81:1</code></p>
+              <p>
+                Validate tabs implementation desired state, with omitted implementation meaning
+                adaptive.
+              </p>
+            </article>
+            <article
+              class="item"
+              data-search="isNavigatorScreenReference src/appManifest/navigatorOptions.ts Validate a reference into the app-owned screen registry."
+            >
+              <h3>isNavigatorScreenReference</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:95:1</code></p>
+              <p>Validate a reference into the app-owned screen registry.</p>
+            </article>
+            <article
+              class="item"
+              data-search="hasOnlyKeys src/appManifest/navigatorOptions.ts Check that a finite configuration object contains no unsupported keys."
+            >
+              <h3>hasOnlyKeys</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:100:1</code></p>
+              <p>Check that a finite configuration object contains no unsupported keys.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isJavaScriptStackScreenOptions src/appManifest/navigatorOptions.ts Validate JavaScript Stack options without accepting native-only presentations."
+            >
+              <h3>isJavaScriptStackScreenOptions</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:109:1</code></p>
+              <p>Validate JavaScript Stack options without accepting native-only presentations.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isStackHeaderOptions src/appManifest/navigatorOptions.ts Validate the portable header subset supported by Experimental Stack."
+            >
+              <h3>isStackHeaderOptions</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:127:1</code></p>
+              <p>Validate the portable header subset supported by Experimental Stack.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isStackHeaderOptionsShape src/appManifest/navigatorOptions.ts Validate shared stack header field values after branch-specific key filtering."
+            >
+              <h3>isStackHeaderOptionsShape</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:136:1</code></p>
+              <p>Validate shared stack header field values after branch-specific key filtering.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isSheetAllowedDetents src/appManifest/navigatorOptions.ts Validate sorted, finite native sheet detents or the fit-to-content sentinel."
+            >
+              <h3>isSheetAllowedDetents</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:146:1</code></p>
+              <p>Validate sorted, finite native sheet detents or the fit-to-content sentinel.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isAdaptiveTabsConfig src/appManifest/navigatorOptions.ts Validate an adaptive tabs branch and reject implementation-specific conflicts."
+            >
+              <h3>isAdaptiveTabsConfig</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:160:1</code></p>
+              <p>Validate an adaptive tabs branch and reject implementation-specific conflicts.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isFullNativeTabsConfig src/appManifest/navigatorOptions.ts Validate the top-level native tabs implementation."
+            >
+              <h3>isFullNativeTabsConfig</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:176:1</code></p>
+              <p>Validate the top-level native tabs implementation.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isJavaScriptTabsConfig src/appManifest/navigatorOptions.ts Validate the top-level JavaScript tabs implementation."
+            >
+              <h3>isJavaScriptTabsConfig</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:190:1</code></p>
+              <p>Validate the top-level JavaScript tabs implementation.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isNativeTabsConfig src/appManifest/navigatorOptions.ts Validate the native branch used by adaptive tabs."
+            >
+              <h3>isNativeTabsConfig</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:208:1</code></p>
+              <p>Validate the native branch used by adaptive tabs.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isNativeTabsFields src/appManifest/navigatorOptions.ts Validate fields supported by the native tabs branch."
+            >
+              <h3>isNativeTabsFields</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:218:1</code></p>
+              <p>Validate fields supported by the native tabs branch.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isCustomTabsWebConfig src/appManifest/navigatorOptions.ts Validate the implementation-free custom-tabs Web branch inside adaptive tabs."
+            >
+              <h3>isCustomTabsWebConfig</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:228:1</code></p>
+              <p>Validate the implementation-free custom-tabs Web branch inside adaptive tabs.</p>
+            </article>
+            <article
+              class="item"
+              data-search="isCustomTabsPresentationConfig src/appManifest/navigatorOptions.ts Validate custom-tab presentation and its conditional serializable configuration."
+            >
+              <h3>isCustomTabsPresentationConfig</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:237:1</code></p>
+              <p>
+                Validate custom-tab presentation and its conditional serializable configuration.
+              </p>
+            </article>
+            <article
+              class="item"
+              data-search="isResponsiveTabsPresentation src/appManifest/navigatorOptions.ts Validate semantic compact/medium/expanded custom-tab presentation mapping."
+            >
+              <h3>isResponsiveTabsPresentation</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:262:1</code></p>
+              <p>Validate semantic compact/medium/expanded custom-tab presentation mapping.</p>
+            </article>
+            <article
+              class="item"
+              data-search="hasNoDefinedKeys src/appManifest/navigatorOptions.ts Check that mutually exclusive branch fields are absent."
+            >
+              <h3>hasNoDefinedKeys</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:276:1</code></p>
+              <p>Check that mutually exclusive branch fields are absent.</p>
+            </article>
+          </section>
+        </section>
+        <section
           id="view-src-appmanifest-screens-ts"
           class="view"
           data-view="src/appManifest/screens.ts"
@@ -17993,72 +19981,57 @@ graph LR
             <h2>src/appManifest/screens.ts</h2>
             <article class="item" data-search="isManifestMetadata src/appManifest/screens.ts ">
               <h3>isManifestMetadata</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:18:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:13:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isThemeConfig src/appManifest/screens.ts ">
               <h3>isThemeConfig</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:32:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isNavigatorSpec src/appManifest/screens.ts ">
-              <h3>isNavigatorSpec</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:42:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:27:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isScreenRegistry src/appManifest/screens.ts ">
               <h3>isScreenRegistry</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:54:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:37:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isSplashScreenSpec src/appManifest/screens.ts ">
               <h3>isSplashScreenSpec</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:64:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:47:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isThemeModeConfig src/appManifest/screens.ts ">
               <h3>isThemeModeConfig</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:72:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:55:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isUiNode src/appManifest/screens.ts ">
               <h3>isUiNode</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:81:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:64:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isUiNodeRepeatSpec src/appManifest/screens.ts ">
               <h3>isUiNodeRepeatSpec</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:95:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:78:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isScreenSpec src/appManifest/screens.ts ">
               <h3>isScreenSpec</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:105:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isRouteDefinition src/appManifest/screens.ts ">
-              <h3>isRouteDefinition</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:120:1</code></p>
-              <p class="empty">No description available.</p>
-            </article>
-            <article class="item" data-search="isIconSpec src/appManifest/screens.ts ">
-              <h3>isIconSpec</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:134:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:88:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isSplashScreenModeSpec src/appManifest/screens.ts ">
               <h3>isSplashScreenModeSpec</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:146:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:103:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isScreenRequirements src/appManifest/screens.ts ">
               <h3>isScreenRequirements</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:158:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:115:1</code></p>
               <p class="empty">No description available.</p>
             </article>
             <article class="item" data-search="isRequirementArray src/appManifest/screens.ts ">
               <h3>isRequirementArray</h3>
-              <p class="muted"><code>src/appManifest/screens.ts:166:1</code></p>
+              <p class="muted"><code>src/appManifest/screens.ts:123:1</code></p>
               <p class="empty">No description available.</p>
             </article>
           </section>

--- a/paradox/paradox.json
+++ b/paradox/paradox.json
@@ -2,6 +2,8 @@
   "packageName": "CONTRACTS",
   "packageId": "@ankhorage/contracts",
   "description": "Serializable app, action, theme, auth, and secret-store contracts for Ankhorage.",
+  "collaborators": null,
+  "donation": null,
   "badges": [
     {
       "id": "license",
@@ -12,7 +14,7 @@
     {
       "id": "npm",
       "label": "npm",
-      "value": "v8.0.1",
+      "value": "v10.1.0",
       "color": "cb3837"
     },
     {
@@ -121,10 +123,17 @@
       "exports": ["isAppDeployManifest"]
     },
     {
+      "path": "src/appManifest/icon.ts",
+      "isEntrypoint": false,
+      "dependencies": ["src/appManifest/shared.ts", "src/media.ts"],
+      "exports": ["isIconSpec"]
+    },
+    {
       "path": "src/appManifest/infra.ts",
       "isEntrypoint": false,
       "dependencies": [
         "src/appManifest/apis.ts",
+        "src/appManifest/icon.ts",
         "src/appManifest/shared.ts",
         "src/auth.ts",
         "src/types.ts"
@@ -138,12 +147,36 @@
       "exports": ["isMediaManifest"]
     },
     {
+      "path": "src/appManifest/navigator.ts",
+      "isEntrypoint": false,
+      "dependencies": [
+        "src/appManifest/icon.ts",
+        "src/appManifest/navigatorOptions.ts",
+        "src/appManifest/shared.ts",
+        "src/navigator.ts"
+      ],
+      "exports": ["isAppNavigatorManifest"]
+    },
+    {
+      "path": "src/appManifest/navigatorOptions.ts",
+      "isEntrypoint": false,
+      "dependencies": ["src/appManifest/shared.ts", "src/navigator.ts"],
+      "exports": [
+        "hasOnlyKeys",
+        "isDrawerNavigatorOptions",
+        "isNavigatorScreenReference",
+        "isStackImplementationConfig",
+        "isStackScreenOptions",
+        "isTabsImplementationConfig"
+      ]
+    },
+    {
       "path": "src/appManifest/screens.ts",
       "isEntrypoint": false,
       "dependencies": ["src/appManifest/bindings.ts", "src/appManifest/shared.ts", "src/types.ts"],
       "exports": [
+        "isAppNavigatorManifest",
         "isManifestMetadata",
-        "isNavigatorSpec",
         "isScreenRegistry",
         "isSplashScreenSpec",
         "isThemeConfig"
@@ -527,6 +560,7 @@
         "AdapterId",
         "AdapterKind",
         "AdapterRef",
+        "AdaptiveTabsConfig",
         "AlertAction",
         "AnkhCapabilityId",
         "AnkhCommandCategory",
@@ -558,6 +592,7 @@
         "AppDeployWebTargetConfig",
         "AppManifest",
         "AppManifestParseResult",
+        "AppNavigatorManifest",
         "AppSettings",
         "AUTH_IDENTIFIER_KINDS",
         "AUTH_OAUTH_CANCELLATION_REASONS",
@@ -663,6 +698,12 @@
         "CredentialId",
         "CredentialKind",
         "CredentialRef",
+        "CUSTOM_TABS_PRESENTATIONS",
+        "CustomNavigatorNode",
+        "CustomTabsConfig",
+        "CustomTabsPresentation",
+        "CustomTabsPresentationConfig",
+        "CustomTabsWebConfig",
         "DATABASE_PROVIDERS",
         "DATABASE_TIERS",
         "DatabaseAdapterRef",
@@ -734,6 +775,12 @@
         "DEPLOYMENT_TARGETS",
         "DeploymentSpec",
         "DeploymentTarget",
+        "DRAWER_POSITIONS",
+        "DRAWER_TYPES",
+        "DrawerNavigatorNode",
+        "DrawerNavigatorOptions",
+        "DrawerPosition",
+        "DrawerType",
         "EndpointId",
         "EventBinding",
         "EventBindingTarget",
@@ -741,6 +788,8 @@
         "ExternalRestApiDefinition",
         "FilterAction",
         "findForbiddenInlineSecretFields",
+        "FIXED_CUSTOM_TABS_PRESENTATIONS",
+        "FixedCustomTabsPresentation",
         "FORBIDDEN_INLINE_SECRET_FIELDS",
         "FormSubmitEventDto",
         "FormSubmitValues",
@@ -754,6 +803,12 @@
         "isAppDeployManifest",
         "isAppManifest",
         "isMediaAssetReference",
+        "JAVASCRIPT_STACK_PRESENTATIONS",
+        "JAVASCRIPT_TABS_PRESENTATIONS",
+        "JavaScriptStackPresentation",
+        "JavaScriptStackScreenOptions",
+        "JavaScriptTabsConfig",
+        "JavaScriptTabsPresentation",
         "KnownAuthOAuthProviderId",
         "KnownAuthOAuthTransportId",
         "KnownAuthProfileField",
@@ -777,9 +832,20 @@
         "MediaStorageAdapter",
         "MediaStorageSource",
         "MediaUrlSource",
+        "NamedIconSpec",
+        "NATIVE_TABS_MINIMIZE_BEHAVIORS",
+        "NativeTabsConfig",
+        "NativeTabsMinimizeBehavior",
         "NavigateAction",
+        "NAVIGATOR_PRESETS",
         "NAVIGATOR_TYPES",
-        "NavigatorSpec",
+        "NavigatorDefaults",
+        "NavigatorFlows",
+        "NavigatorNode",
+        "NavigatorPlatformConfig",
+        "NavigatorPlatforms",
+        "NavigatorPreset",
+        "NavigatorScreenReference",
         "NavigatorType",
         "NetworkingSpec",
         "normalizeSecretRef",
@@ -790,7 +856,9 @@
         "parseAppManifest",
         "PasswordResetInput",
         "PropBinding",
+        "RepositoryManifest",
         "resolveAuthFlow",
+        "ResponsiveTabsPresentation",
         "RouteDefinition",
         "RuntimeCallback",
         "RuntimeCallbackArgs",
@@ -826,10 +894,20 @@
         "SignInInput",
         "SignOutInput",
         "SignUpInput",
+        "SlotNavigatorNode",
         "SplashScreenAssetSpec",
         "SplashScreenModeSpec",
         "SplashScreenResizeMode",
         "SplashScreenSpec",
+        "SplitViewNavigatorNode",
+        "STACK_IMPLEMENTATIONS",
+        "STACK_PRESENTATIONS",
+        "StackHeaderOptions",
+        "StackImplementation",
+        "StackImplementationConfig",
+        "StackNavigatorNode",
+        "StackPresentation",
+        "StackScreenOptions",
         "StartOAuthAuthorizationInput",
         "STATE_PERSISTENCE_MODES",
         "STATE_PROVIDERS",
@@ -870,6 +948,10 @@
         "StorageSpec",
         "StorageUploadInput",
         "StorageUploadResult",
+        "SvgIconSpec",
+        "TabsImplementationConfig",
+        "TabsNavigatorConfig",
+        "TabsNavigatorNode",
         "ThemeConfig",
         "ThemeGlobalTokenOverrides",
         "ThemeModeConfig",
@@ -930,6 +1012,69 @@
         "MediaStorageSource",
         "MediaUrlSource"
       ]
+    },
+    {
+      "path": "src/navigator.ts",
+      "isEntrypoint": false,
+      "dependencies": ["src/types.ts"],
+      "exports": [
+        "AdaptiveTabsConfig",
+        "AppNavigatorManifest",
+        "CUSTOM_TABS_PRESENTATIONS",
+        "CustomNavigatorNode",
+        "CustomTabsConfig",
+        "CustomTabsPresentation",
+        "CustomTabsPresentationConfig",
+        "CustomTabsWebConfig",
+        "DRAWER_POSITIONS",
+        "DRAWER_TYPES",
+        "DrawerNavigatorNode",
+        "DrawerNavigatorOptions",
+        "DrawerPosition",
+        "DrawerType",
+        "FIXED_CUSTOM_TABS_PRESENTATIONS",
+        "FixedCustomTabsPresentation",
+        "JAVASCRIPT_STACK_PRESENTATIONS",
+        "JAVASCRIPT_TABS_PRESENTATIONS",
+        "JavaScriptStackPresentation",
+        "JavaScriptStackScreenOptions",
+        "JavaScriptTabsConfig",
+        "JavaScriptTabsPresentation",
+        "NATIVE_TABS_MINIMIZE_BEHAVIORS",
+        "NativeTabsConfig",
+        "NativeTabsMinimizeBehavior",
+        "NAVIGATOR_PRESETS",
+        "NAVIGATOR_TYPES",
+        "NavigatorDefaults",
+        "NavigatorFlows",
+        "NavigatorNode",
+        "NavigatorPlatformConfig",
+        "NavigatorPlatforms",
+        "NavigatorPreset",
+        "NavigatorScreenReference",
+        "NavigatorType",
+        "ResponsiveTabsPresentation",
+        "RouteDefinition",
+        "SlotNavigatorNode",
+        "SplitViewNavigatorNode",
+        "STACK_IMPLEMENTATIONS",
+        "STACK_PRESENTATIONS",
+        "StackHeaderOptions",
+        "StackImplementation",
+        "StackImplementationConfig",
+        "StackNavigatorNode",
+        "StackPresentation",
+        "StackScreenOptions",
+        "TabsImplementationConfig",
+        "TabsNavigatorConfig",
+        "TabsNavigatorNode"
+      ]
+    },
+    {
+      "path": "src/repository.ts",
+      "isEntrypoint": false,
+      "dependencies": [],
+      "exports": ["RepositoryManifest"]
     },
     {
       "path": "src/requirements.ts",
@@ -1068,6 +1213,8 @@
         "src/data/index.ts",
         "src/deploy.ts",
         "src/media.ts",
+        "src/navigator.ts",
+        "src/repository.ts",
         "src/requirements.ts",
         "src/theme.ts"
       ],
@@ -1131,12 +1278,9 @@
         "KnownDeploymentTarget",
         "KnownStateProvider",
         "ManifestValue",
+        "NamedIconSpec",
         "NavigateAction",
-        "NAVIGATOR_TYPES",
-        "NavigatorSpec",
-        "NavigatorType",
         "NetworkingSpec",
-        "RouteDefinition",
         "ScreenSpec",
         "SearchAction",
         "SetLanguageAction",
@@ -1152,6 +1296,7 @@
         "STORAGE_PROVIDERS",
         "StorageProvider",
         "StorageSpec",
+        "SvgIconSpec",
         "ThemeConfig",
         "ThemeModeConfig",
         "ToggleDarkModeAction",
@@ -1201,7 +1346,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 82,
+        "line": 84,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1219,7 +1364,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 31,
+        "line": 33,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1319,6 +1464,46 @@
       "structuredRows": []
     },
     {
+      "name": "AdaptiveTabsConfig",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 165,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["CustomTabsPresentationConfig", "NativeTabsConfig"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "implementation",
+          "kind": "property",
+          "type": "\"adaptive\" | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "native",
+          "kind": "property",
+          "type": "NativeTabsConfig | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "web",
+          "kind": "property",
+          "type": "CustomTabsPresentationConfig | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
       "name": "AlertAction",
       "description": null,
       "isReadme": false,
@@ -1327,7 +1512,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 42,
+        "line": 44,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -1665,7 +1850,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"./endpoints\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -1707,7 +1892,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"./schemas\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -1813,7 +1998,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 140,
+        "line": 139,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -1867,7 +2052,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 165,
+        "line": 164,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2151,19 +2336,20 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 379,
+        "line": 365,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
       "relatedSymbols": [
         "AppCategory",
         "AppDeployManifest",
+        "AppNavigatorManifest",
         "AppSettings",
         "ComponentDataBinding",
         "DatabaseDataSourceConfig",
         "InfraManifest",
         "MediaManifest",
-        "NavigatorSpec",
+        "RepositoryManifest",
         "ScreenSpec",
         "SplashScreenSpec",
         "ThemeConfig"
@@ -2187,14 +2373,14 @@
         {
           "name": "dataBindings",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/bindings\").ComponentDataBinding>> | undefined",
+          "type": "Readonly<Record<string, import(\"./bindings\").ComponentDataBinding>> | undefined",
           "required": false,
           "description": null
         },
         {
           "name": "dataSources",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DatabaseDataSourceConfig>> | undefined",
+          "type": "Readonly<Record<string, import(\"./data\").DatabaseDataSourceConfig>> | undefined",
           "required": false,
           "description": null
         },
@@ -2229,8 +2415,15 @@
         {
           "name": "navigator",
           "kind": "property",
-          "type": "NavigatorSpec",
+          "type": "AppNavigatorManifest",
           "required": true,
+          "description": null
+        },
+        {
+          "name": "repository",
+          "kind": "property",
+          "type": "RepositoryManifest | undefined",
+          "required": false,
           "description": null
         },
         {
@@ -2283,6 +2476,24 @@
       "structuredRows": []
     },
     {
+      "name": "AppNavigatorManifest",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 267,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
       "name": "AppSettings",
       "description": null,
       "isReadme": false,
@@ -2291,7 +2502,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 372,
+        "line": 358,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2515,7 +2726,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 220,
+        "line": 219,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2533,7 +2744,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 207,
+        "line": 206,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2551,7 +2762,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 217,
+        "line": 216,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2569,7 +2780,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 223,
+        "line": 222,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2587,7 +2798,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 197,
+        "line": 196,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2605,7 +2816,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 194,
+        "line": 193,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2623,7 +2834,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 201,
+        "line": 200,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -2659,7 +2870,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 204,
+        "line": 203,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -3790,7 +4001,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 221,
+        "line": 220,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3808,7 +4019,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 215,
+        "line": 214,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3826,7 +4037,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 218,
+        "line": 217,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3844,7 +4055,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 336,
+        "line": 322,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3898,7 +4109,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 224,
+        "line": 223,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -3916,7 +4127,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 199,
+        "line": 198,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4013,7 +4224,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 195,
+        "line": 194,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4111,7 +4322,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 202,
+        "line": 201,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4129,7 +4340,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 326,
+        "line": 312,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4206,7 +4417,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 205,
+        "line": 204,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4224,7 +4435,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 330,
+        "line": 316,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4264,7 +4475,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 344,
+        "line": 330,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4415,7 +4626,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 191,
+        "line": 190,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -4433,7 +4644,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 188,
+        "line": 187,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -4451,7 +4662,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 192,
+        "line": 191,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4469,7 +4680,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 189,
+        "line": 188,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4487,7 +4698,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 321,
+        "line": 307,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4850,7 +5061,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 119,
+        "line": 121,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4868,7 +5079,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 126,
+        "line": 128,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -4886,7 +5097,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 121,
+        "line": 123,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5017,7 +5228,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 101,
+        "line": 103,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5057,7 +5268,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 131,
+        "line": 133,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5075,7 +5286,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 99,
+        "line": 101,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5162,7 +5373,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 49,
+        "line": 51,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5270,6 +5481,150 @@
       "structuredRows": []
     },
     {
+      "name": "CUSTOM_TABS_PRESENTATIONS",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 100,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "CustomNavigatorNode",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 212,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["ManifestValue", "RouteDefinition"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "config",
+          "kind": "property",
+          "type": "Readonly<Record<string, ManifestValue>> | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "initialRouteName",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "navigatorId",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "routes",
+          "kind": "property",
+          "type": "RouteDefinition[]",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "type",
+          "kind": "property",
+          "type": "\"custom\"",
+          "required": true,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "CustomTabsConfig",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 142,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "CustomTabsPresentation",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 105,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "CustomTabsPresentationConfig",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 124,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "CustomTabsWebConfig",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 146,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
       "name": "DATABASE_PROVIDERS",
       "description": null,
       "isReadme": false,
@@ -5278,7 +5633,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 171,
+        "line": 170,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -5296,7 +5651,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 175,
+        "line": 174,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -5405,7 +5760,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"./endpoints\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -5440,7 +5795,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"./schemas\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -5456,7 +5811,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 173,
+        "line": 172,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5474,7 +5829,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 306,
+        "line": 292,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5507,7 +5862,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 176,
+        "line": 175,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -7723,7 +8078,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 167,
+        "line": 166,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -7741,7 +8096,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 301,
+        "line": 287,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -7774,7 +8129,173 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 169,
+        "line": 168,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "DRAWER_POSITIONS",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 84,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "DRAWER_TYPES",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 87,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "DrawerNavigatorNode",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 190,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["DrawerNavigatorOptions", "RouteDefinition"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "initialRouteName",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "options",
+          "kind": "property",
+          "type": "DrawerNavigatorOptions | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "routes",
+          "kind": "property",
+          "type": "RouteDefinition[]",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "type",
+          "kind": "property",
+          "type": "\"drawer\"",
+          "required": true,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "DrawerNavigatorOptions",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 90,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "drawerPosition",
+          "kind": "property",
+          "type": "\"left\" | \"right\" | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "drawerType",
+          "kind": "property",
+          "type": "\"front\" | \"back\" | \"slide\" | \"permanent\" | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "headerShown",
+          "kind": "property",
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "swipeEnabled",
+          "kind": "property",
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "DrawerPosition",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 85,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "DrawerType",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 88,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -7898,7 +8419,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"./endpoints\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -7954,7 +8475,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"./schemas\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -8007,7 +8528,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"./endpoints\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -8056,7 +8577,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"./schemas\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -8072,7 +8593,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 74,
+        "line": 76,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8129,6 +8650,42 @@
       "structuredRows": []
     },
     {
+      "name": "FIXED_CUSTOM_TABS_PRESENTATIONS",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 97,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "FixedCustomTabsPresentation",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 98,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
       "name": "FORBIDDEN_INLINE_SECRET_FIELDS",
       "description": null,
       "isReadme": false,
@@ -8155,7 +8712,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 112,
+        "line": 114,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8173,7 +8730,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 110,
+        "line": 112,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8220,46 +8777,17 @@
       "description": null,
       "isReadme": false,
       "examples": [],
-      "kind": "type",
+      "kind": "unknown",
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 226,
+        "line": 242,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
       "relatedSymbols": [],
       "signatures": [],
-      "members": [
-        {
-          "name": "color",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "name",
-          "kind": "property",
-          "type": "string",
-          "required": true,
-          "description": null
-        },
-        {
-          "name": "provider",
-          "kind": "property",
-          "type": "string | undefined",
-          "required": false,
-          "description": null
-        },
-        {
-          "name": "size",
-          "kind": "property",
-          "type": "string | number | undefined",
-          "required": false,
-          "description": null
-        }
-      ],
+      "members": [],
       "structuredRows": []
     },
     {
@@ -8329,7 +8857,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 360,
+        "line": 346,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8484,7 +9012,7 @@
         {
           "name": "endpoints",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataEndpointConfig>>",
+          "type": "Readonly<Record<string, import(\"./endpoints\").DataEndpointConfig>>",
           "required": true,
           "description": null
         },
@@ -8526,7 +9054,7 @@
         {
           "name": "schemas",
           "kind": "property",
-          "type": "Readonly<Record<string, import(\"./src/index\").DataSchema>> | undefined",
+          "type": "Readonly<Record<string, import(\"./schemas\").DataSchema>> | undefined",
           "required": false,
           "description": null
         }
@@ -8574,7 +9102,7 @@
       "modulePath": "src/appManifest.ts",
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 50,
+        "line": 51,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8630,6 +9158,129 @@
       "structuredRows": []
     },
     {
+      "name": "JAVASCRIPT_STACK_PRESENTATIONS",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 40,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "JAVASCRIPT_TABS_PRESENTATIONS",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 107,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "JavaScriptStackPresentation",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 41,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "JavaScriptStackScreenOptions",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 64,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "JavaScriptTabsConfig",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 160,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "implementation",
+          "kind": "property",
+          "type": "\"javascript\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "presentation",
+          "kind": "property",
+          "type": "\"bottom\" | \"top\" | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "JavaScriptTabsPresentation",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 108,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
       "name": "KnownAuthOAuthProviderId",
       "description": null,
       "isReadme": false,
@@ -8674,7 +9325,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 214,
+        "line": 213,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8692,7 +9343,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 198,
+        "line": 197,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8728,7 +9379,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 134,
+        "line": 136,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8746,7 +9397,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 172,
+        "line": 171,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8764,7 +9415,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 168,
+        "line": 167,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8800,7 +9451,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 182,
+        "line": 181,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8818,7 +9469,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 91,
+        "line": 93,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9261,6 +9912,136 @@
       "structuredRows": []
     },
     {
+      "name": "NamedIconSpec",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/types.ts",
+      "sourceLocation": {
+        "filePath": "src/types.ts",
+        "line": 230,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "color",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "name",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "provider",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "size",
+          "kind": "property",
+          "type": "string | number | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "source",
+          "kind": "property",
+          "type": "undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "NATIVE_TABS_MINIMIZE_BEHAVIORS",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 110,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "NativeTabsConfig",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 152,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["NavigatorScreenReference"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "bottomAccessory",
+          "kind": "property",
+          "type": "NavigatorScreenReference | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "implementation",
+          "kind": "property",
+          "type": "\"native\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "minimizeBehavior",
+          "kind": "property",
+          "type": "\"automatic\" | \"never\" | \"onScrollDown\" | \"onScrollUp\" | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "NativeTabsMinimizeBehavior",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 116,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
       "name": "NavigateAction",
       "description": null,
       "isReadme": false,
@@ -9269,7 +10050,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 34,
+        "line": 36,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9294,15 +10075,15 @@
       "structuredRows": []
     },
     {
-      "name": "NAVIGATOR_TYPES",
+      "name": "NAVIGATOR_PRESETS",
       "description": null,
       "isReadme": false,
       "examples": [],
       "kind": "value",
-      "modulePath": "src/types.ts",
+      "modulePath": "src/navigator.ts",
       "sourceLocation": {
-        "filePath": "src/types.ts",
-        "line": 137,
+        "filePath": "src/navigator.ts",
+        "line": 6,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -9312,46 +10093,218 @@
       "structuredRows": []
     },
     {
-      "name": "NavigatorSpec",
+      "name": "NAVIGATOR_TYPES",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 3,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "NavigatorDefaults",
       "description": null,
       "isReadme": false,
       "examples": [],
       "kind": "type",
-      "modulePath": "src/types.ts",
+      "modulePath": "src/navigator.ts",
       "sourceLocation": {
-        "filePath": "src/types.ts",
-        "line": 260,
+        "filePath": "src/navigator.ts",
+        "line": 245,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
-      "relatedSymbols": ["RouteDefinition"],
+      "relatedSymbols": ["StackImplementationConfig", "TabsImplementationConfig"],
       "signatures": [],
       "members": [
         {
-          "name": "initialRouteName",
+          "name": "stack",
           "kind": "property",
-          "type": "string | undefined",
+          "type": "StackImplementationConfig | undefined",
           "required": false,
           "description": null
         },
         {
-          "name": "options",
+          "name": "tabs",
           "kind": "property",
-          "type": "Record<string, unknown> | undefined",
+          "type": "TabsImplementationConfig | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "NavigatorFlows",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 240,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "authentication",
+          "kind": "property",
+          "type": "boolean | undefined",
           "required": false,
           "description": null
         },
         {
-          "name": "routes",
+          "name": "onboarding",
           "kind": "property",
-          "type": "RouteDefinition[]",
-          "required": true,
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "NavigatorNode",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 218,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "NavigatorPlatformConfig",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 250,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["StackImplementationConfig", "TabsImplementationConfig"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "stack",
+          "kind": "property",
+          "type": "StackImplementationConfig | undefined",
+          "required": false,
           "description": null
         },
         {
-          "name": "type",
+          "name": "tabs",
           "kind": "property",
-          "type": "\"stack\" | \"tabs\" | \"drawer\"",
+          "type": "TabsImplementationConfig | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "NavigatorPlatforms",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 255,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["NavigatorPlatformConfig"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "android",
+          "kind": "property",
+          "type": "NavigatorPlatformConfig | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "ios",
+          "kind": "property",
+          "type": "NavigatorPlatformConfig | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "web",
+          "kind": "property",
+          "type": "NavigatorPlatformConfig | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "NavigatorPreset",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 24,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "NavigatorScreenReference",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 148,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "screenId",
+          "kind": "property",
+          "type": "string",
           "required": true,
           "description": null
         }
@@ -9364,10 +10317,10 @@
       "isReadme": false,
       "examples": [],
       "kind": "unknown",
-      "modulePath": "src/types.ts",
+      "modulePath": "src/navigator.ts",
       "sourceLocation": {
-        "filePath": "src/types.ts",
-        "line": 138,
+        "filePath": "src/navigator.ts",
+        "line": 4,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9385,7 +10338,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 355,
+        "line": 341,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9587,7 +10540,7 @@
       "modulePath": "src/appManifest.ts",
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 43,
+        "line": 44,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9710,6 +10663,60 @@
       "structuredRows": []
     },
     {
+      "name": "RepositoryManifest",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/repository.ts",
+      "sourceLocation": {
+        "filePath": "src/repository.ts",
+        "line": 1,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "defaultBranch",
+          "kind": "property",
+          "type": "\"main\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "name",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "owner",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "provider",
+          "kind": "property",
+          "type": "\"github\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "url",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
       "name": "resolveAuthFlow",
       "description": null,
       "isReadme": false,
@@ -9742,19 +10749,59 @@
       "structuredRows": []
     },
     {
+      "name": "ResponsiveTabsPresentation",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 118,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "compact",
+          "kind": "property",
+          "type": "\"bottom\" | \"top\" | \"rail\" | \"sidebar\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "expanded",
+          "kind": "property",
+          "type": "\"bottom\" | \"top\" | \"rail\" | \"sidebar\"",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "medium",
+          "kind": "property",
+          "type": "\"bottom\" | \"top\" | \"rail\" | \"sidebar\" | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
       "name": "RouteDefinition",
       "description": null,
       "isReadme": false,
       "examples": [],
       "kind": "type",
-      "modulePath": "src/types.ts",
+      "modulePath": "src/navigator.ts",
       "sourceLocation": {
-        "filePath": "src/types.ts",
-        "line": 267,
+        "filePath": "src/navigator.ts",
+        "line": 226,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
-      "relatedSymbols": ["IconSpec", "NavigatorSpec"],
+      "relatedSymbols": ["IconSpec", "NavigatorNode", "StackScreenOptions"],
       "signatures": [],
       "members": [
         {
@@ -9788,7 +10835,7 @@
         {
           "name": "navigator",
           "kind": "property",
-          "type": "NavigatorSpec | undefined",
+          "type": "NavigatorNode | undefined",
           "required": false,
           "description": null
         },
@@ -9810,6 +10857,13 @@
           "name": "showInPrimaryNavigation",
           "kind": "property",
           "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "stackOptions",
+          "kind": "property",
+          "type": "StackScreenOptions | undefined",
           "required": false,
           "description": null
         }
@@ -10073,7 +11127,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 250,
+        "line": 261,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10083,7 +11137,7 @@
         {
           "name": "dataLoaders",
           "kind": "property",
-          "type": "readonly import(\"./src/bindings\").OperationScreenDataLoaderDefinition[] | undefined",
+          "type": "readonly import(\"./bindings\").OperationScreenDataLoaderDefinition[] | undefined",
           "required": false,
           "description": null
         },
@@ -10141,7 +11195,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 66,
+        "line": 68,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10763,7 +11817,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 59,
+        "line": 61,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10922,6 +11976,46 @@
       "structuredRows": []
     },
     {
+      "name": "SlotNavigatorNode",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 182,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["RouteDefinition"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "initialRouteName",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "routes",
+          "kind": "property",
+          "type": "RouteDefinition[]",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "type",
+          "kind": "property",
+          "type": "\"slot\"",
+          "required": true,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
       "name": "SplashScreenAssetSpec",
       "description": null,
       "isReadme": false,
@@ -10930,7 +12024,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 287,
+        "line": 273,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10970,7 +12064,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 293,
+        "line": 279,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11017,7 +12111,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 285,
+        "line": 271,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11035,7 +12129,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 297,
+        "line": 283,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11078,6 +12172,240 @@
           "description": null
         }
       ],
+      "structuredRows": []
+    },
+    {
+      "name": "SplitViewNavigatorNode",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 201,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["NavigatorScreenReference", "RouteDefinition"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "columns",
+          "kind": "property",
+          "type": "{ primary: NavigatorScreenReference; supplementary?: NavigatorScreenReference; }",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "initialRouteName",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "inspector",
+          "kind": "property",
+          "type": "NavigatorScreenReference | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "routes",
+          "kind": "property",
+          "type": "RouteDefinition[]",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "topColumnForCollapsing",
+          "kind": "property",
+          "type": "\"primary\" | \"supplementary\" | \"secondary\" | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "type",
+          "kind": "property",
+          "type": "\"split-view\"",
+          "required": true,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "STACK_IMPLEMENTATIONS",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 26,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "STACK_PRESENTATIONS",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 29,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "StackHeaderOptions",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 43,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "headerBackVisible",
+          "kind": "property",
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "headerShown",
+          "kind": "property",
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "headerTransparent",
+          "kind": "property",
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "title",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "StackImplementation",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 27,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "StackImplementationConfig",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 68,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "StackNavigatorNode",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 186,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "StackPresentation",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 38,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "StackScreenOptions",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 50,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
       "structuredRows": []
     },
     {
@@ -11136,7 +12464,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 185,
+        "line": 184,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -11154,7 +12482,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 181,
+        "line": 180,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -11349,7 +12677,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 186,
+        "line": 185,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11385,7 +12713,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 183,
+        "line": 182,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11454,7 +12782,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 316,
+        "line": 302,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11549,7 +12877,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 178,
+        "line": 177,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -12005,7 +13333,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 179,
+        "line": 178,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -12332,7 +13660,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 311,
+        "line": 297,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -12375,7 +13703,7 @@
         {
           "name": "body",
           "kind": "property",
-          "type": "Uint8Array",
+          "type": "Uint8Array<ArrayBufferLike>",
           "required": true,
           "description": null
         },
@@ -12451,6 +13779,114 @@
       "structuredRows": []
     },
     {
+      "name": "SvgIconSpec",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/types.ts",
+      "sourceLocation": {
+        "filePath": "src/types.ts",
+        "line": 236,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["MediaAssetReference"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "color",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "name",
+          "kind": "property",
+          "type": "undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "provider",
+          "kind": "property",
+          "type": "undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "size",
+          "kind": "property",
+          "type": "string | number | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "source",
+          "kind": "property",
+          "type": "MediaAssetReference",
+          "required": true,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "TabsImplementationConfig",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 174,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "TabsNavigatorConfig",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 195,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "TabsNavigatorNode",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "unknown",
+      "modulePath": "src/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/navigator.ts",
+        "line": 199,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
       "name": "ThemeConfig",
       "description": null,
       "isReadme": false,
@@ -12459,7 +13895,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 20,
+        "line": 22,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -12567,7 +14003,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 15,
+        "line": 17,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -12577,7 +14013,7 @@
         {
           "name": "harmony",
           "kind": "property",
-          "type": "\"monochromatic\" | \"analogous\" | \"complementary\" | \"triadic\" | \"tetradic\" | \"splitComplementary\"",
+          "type": "\"monochromatic\" | \"analogous\" | \"complementary\" | \"splitComplementary\" | \"triadic\" | \"tetradic\" | \"square\"",
           "required": true,
           "description": null
         },
@@ -12785,7 +14221,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 54,
+        "line": 56,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13734,7 +15170,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 240,
+        "line": 251,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13802,7 +15238,7 @@
       "modulePath": "src/types.ts",
       "sourceLocation": {
         "filePath": "src/types.ts",
-        "line": 233,
+        "line": 244,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13995,7 +15431,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 43,
+        "line": 44,
         "column": 1
       }
     },
@@ -14004,7 +15440,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 50,
+        "line": 51,
         "column": 1
       }
     },
@@ -14013,7 +15449,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 72,
+        "line": 74,
         "column": 1
       }
     },
@@ -14022,7 +15458,16 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 78,
+        "line": 80,
+        "column": 1
+      }
+    },
+    {
+      "name": "isRepositoryManifest",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/appManifest.ts",
+        "line": 84,
         "column": 1
       }
     },
@@ -14031,7 +15476,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest.ts",
-        "line": 82,
+        "line": 98,
         "column": 1
       }
     },
@@ -14513,11 +15958,20 @@
       }
     },
     {
+      "name": "isIconSpec",
+      "description": "Validate a serializable icon as either a named font glyph or an SVG media reference.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/icon.ts",
+        "line": 5,
+        "column": 1
+      }
+    },
+    {
       "name": "isInfraManifest",
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 37,
+        "line": 38,
         "column": 1
       }
     },
@@ -14526,7 +15980,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 55,
+        "line": 56,
         "column": 1
       }
     },
@@ -14535,7 +15989,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 61,
+        "line": 62,
         "column": 1
       }
     },
@@ -14544,7 +15998,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 70,
+        "line": 71,
         "column": 1
       }
     },
@@ -14553,7 +16007,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 79,
+        "line": 80,
         "column": 1
       }
     },
@@ -14562,7 +16016,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 88,
+        "line": 89,
         "column": 1
       }
     },
@@ -14571,7 +16025,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 92,
+        "line": 93,
         "column": 1
       }
     },
@@ -14580,7 +16034,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 107,
+        "line": 108,
         "column": 1
       }
     },
@@ -14589,7 +16043,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 117,
+        "line": 118,
         "column": 1
       }
     },
@@ -14598,7 +16052,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 130,
+        "line": 131,
         "column": 1
       }
     },
@@ -14607,7 +16061,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 140,
+        "line": 141,
         "column": 1
       }
     },
@@ -14616,7 +16070,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 150,
+        "line": 151,
         "column": 1
       }
     },
@@ -14625,7 +16079,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 160,
+        "line": 161,
         "column": 1
       }
     },
@@ -14634,16 +16088,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/infra.ts",
-        "line": 174,
-        "column": 1
-      }
-    },
-    {
-      "name": "isIconSpec",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/infra.ts",
-        "line": 191,
+        "line": 175,
         "column": 1
       }
     },
@@ -14738,11 +16183,281 @@
       }
     },
     {
+      "name": "isAppNavigatorManifest",
+      "description": "Validate the complete serialized `AppManifest.navigator` slice.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 17,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNavigatorNode",
+      "description": "Validate one nested navigator node independently from app-level authoring metadata.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 30,
+        "column": 1
+      }
+    },
+    {
+      "name": "isRouteDefinition",
+      "description": "Validate one route and preserve its portable metadata and nested navigator.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 64,
+        "column": 1
+      }
+    },
+    {
+      "name": "isSplitViewNavigatorNode",
+      "description": "Validate Split View screen references without duplicating the routed secondary tree.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 80,
+        "column": 1
+      }
+    },
+    {
+      "name": "isCustomNavigatorNode",
+      "description": "Validate a registered custom navigator with JSON-safe configuration only.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 98,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNavigatorJsonRecord",
+      "description": "Validate an acyclic, finite JSON object used by a custom navigator adapter.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 108,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNavigatorJsonValue",
+      "description": "Recursively validate the portable manifest value domain and reject cycles.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 113,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNavigatorFlows",
+      "description": "Validate optional app-level navigator flow intent.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 138,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNavigatorDefaults",
+      "description": "Validate package-owned navigator defaults without requiring a navigator node type.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 147,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNavigatorPlatforms",
+      "description": "Validate per-platform navigator implementation overrides.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 159,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNavigatorPlatformConfig",
+      "description": "Validate one platform-specific navigator override slice.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 170,
+        "column": 1
+      }
+    },
+    {
+      "name": "isStackImplementationConfig",
+      "description": "Validate stable native, JavaScript, or alpha Experimental Stack desired state.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 23,
+        "column": 1
+      }
+    },
+    {
+      "name": "isStackScreenOptions",
+      "description": "Validate the serializable native-stack screen option subset.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 37,
+        "column": 1
+      }
+    },
+    {
+      "name": "isDrawerNavigatorOptions",
+      "description": "Validate the finite serializable Drawer option subset.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 66,
+        "column": 1
+      }
+    },
+    {
+      "name": "isTabsImplementationConfig",
+      "description": "Validate tabs implementation desired state, with omitted implementation meaning adaptive.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 81,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNavigatorScreenReference",
+      "description": "Validate a reference into the app-owned screen registry.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 95,
+        "column": 1
+      }
+    },
+    {
+      "name": "hasOnlyKeys",
+      "description": "Check that a finite configuration object contains no unsupported keys.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 100,
+        "column": 1
+      }
+    },
+    {
+      "name": "isJavaScriptStackScreenOptions",
+      "description": "Validate JavaScript Stack options without accepting native-only presentations.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 109,
+        "column": 1
+      }
+    },
+    {
+      "name": "isStackHeaderOptions",
+      "description": "Validate the portable header subset supported by Experimental Stack.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 127,
+        "column": 1
+      }
+    },
+    {
+      "name": "isStackHeaderOptionsShape",
+      "description": "Validate shared stack header field values after branch-specific key filtering.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 136,
+        "column": 1
+      }
+    },
+    {
+      "name": "isSheetAllowedDetents",
+      "description": "Validate sorted, finite native sheet detents or the fit-to-content sentinel.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 146,
+        "column": 1
+      }
+    },
+    {
+      "name": "isAdaptiveTabsConfig",
+      "description": "Validate an adaptive tabs branch and reject implementation-specific conflicts.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 160,
+        "column": 1
+      }
+    },
+    {
+      "name": "isFullNativeTabsConfig",
+      "description": "Validate the top-level native tabs implementation.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 176,
+        "column": 1
+      }
+    },
+    {
+      "name": "isJavaScriptTabsConfig",
+      "description": "Validate the top-level JavaScript tabs implementation.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 190,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNativeTabsConfig",
+      "description": "Validate the native branch used by adaptive tabs.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 208,
+        "column": 1
+      }
+    },
+    {
+      "name": "isNativeTabsFields",
+      "description": "Validate fields supported by the native tabs branch.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 218,
+        "column": 1
+      }
+    },
+    {
+      "name": "isCustomTabsWebConfig",
+      "description": "Validate the implementation-free custom-tabs Web branch inside adaptive tabs.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 228,
+        "column": 1
+      }
+    },
+    {
+      "name": "isCustomTabsPresentationConfig",
+      "description": "Validate custom-tab presentation and its conditional serializable configuration.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 237,
+        "column": 1
+      }
+    },
+    {
+      "name": "isResponsiveTabsPresentation",
+      "description": "Validate semantic compact/medium/expanded custom-tab presentation mapping.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 262,
+        "column": 1
+      }
+    },
+    {
+      "name": "hasNoDefinedKeys",
+      "description": "Check that mutually exclusive branch fields are absent.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 276,
+        "column": 1
+      }
+    },
+    {
       "name": "isManifestMetadata",
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 18,
+        "line": 13,
         "column": 1
       }
     },
@@ -14751,16 +16466,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 32,
-        "column": 1
-      }
-    },
-    {
-      "name": "isNavigatorSpec",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/screens.ts",
-        "line": 42,
+        "line": 27,
         "column": 1
       }
     },
@@ -14769,7 +16475,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 54,
+        "line": 37,
         "column": 1
       }
     },
@@ -14778,7 +16484,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 64,
+        "line": 47,
         "column": 1
       }
     },
@@ -14787,7 +16493,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 72,
+        "line": 55,
         "column": 1
       }
     },
@@ -14796,7 +16502,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 81,
+        "line": 64,
         "column": 1
       }
     },
@@ -14805,7 +16511,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 95,
+        "line": 78,
         "column": 1
       }
     },
@@ -14814,25 +16520,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 105,
-        "column": 1
-      }
-    },
-    {
-      "name": "isRouteDefinition",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/screens.ts",
-        "line": 120,
-        "column": 1
-      }
-    },
-    {
-      "name": "isIconSpec",
-      "description": null,
-      "sourceLocation": {
-        "filePath": "src/appManifest/screens.ts",
-        "line": 134,
+        "line": 88,
         "column": 1
       }
     },
@@ -14841,7 +16529,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 146,
+        "line": 103,
         "column": 1
       }
     },
@@ -14850,7 +16538,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 158,
+        "line": 115,
         "column": 1
       }
     },
@@ -14859,7 +16547,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/appManifest/screens.ts",
-        "line": 166,
+        "line": 123,
         "column": 1
       }
     },
@@ -15164,6 +16852,16 @@
       },
       {
         "fromPath": "src/index.ts",
+        "toPath": "src/navigator.ts",
+        "sourcePath": "src/index.ts"
+      },
+      {
+        "fromPath": "src/index.ts",
+        "toPath": "src/repository.ts",
+        "sourcePath": "src/index.ts"
+      },
+      {
+        "fromPath": "src/index.ts",
         "toPath": "src/requirements.ts",
         "sourcePath": "src/index.ts"
       },
@@ -15208,6 +16906,11 @@
         "sourcePath": "src/index.ts"
       },
       {
+        "fromPath": "src/navigator.ts",
+        "toPath": "src/types.ts",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
         "fromPath": "src/runtimeCallbacks.ts",
         "toPath": "src/types.ts",
         "sourcePath": "src/runtimeCallbacks.ts"
@@ -15240,6 +16943,16 @@
       {
         "fromPath": "src/types.ts",
         "toPath": "src/media.ts",
+        "sourcePath": "src/types.ts"
+      },
+      {
+        "fromPath": "src/types.ts",
+        "toPath": "src/navigator.ts",
+        "sourcePath": "src/types.ts"
+      },
+      {
+        "fromPath": "src/types.ts",
+        "toPath": "src/repository.ts",
         "sourcePath": "src/types.ts"
       },
       {
@@ -15308,6 +17021,16 @@
         "sourcePath": "src/appManifest/deploy.ts"
       },
       {
+        "fromPath": "src/appManifest/icon.ts",
+        "toPath": "src/media.ts",
+        "sourcePath": "src/appManifest/icon.ts"
+      },
+      {
+        "fromPath": "src/appManifest/icon.ts",
+        "toPath": "src/appManifest/shared.ts",
+        "sourcePath": "src/appManifest/icon.ts"
+      },
+      {
         "fromPath": "src/appManifest/infra.ts",
         "toPath": "src/auth.ts",
         "sourcePath": "src/appManifest/infra.ts"
@@ -15320,6 +17043,11 @@
       {
         "fromPath": "src/appManifest/infra.ts",
         "toPath": "src/appManifest/apis.ts",
+        "sourcePath": "src/appManifest/infra.ts"
+      },
+      {
+        "fromPath": "src/appManifest/infra.ts",
+        "toPath": "src/appManifest/icon.ts",
         "sourcePath": "src/appManifest/infra.ts"
       },
       {
@@ -15338,6 +17066,36 @@
         "sourcePath": "src/appManifest/media.ts"
       },
       {
+        "fromPath": "src/appManifest/navigator.ts",
+        "toPath": "src/navigator.ts",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromPath": "src/appManifest/navigator.ts",
+        "toPath": "src/appManifest/icon.ts",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromPath": "src/appManifest/navigator.ts",
+        "toPath": "src/appManifest/navigatorOptions.ts",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromPath": "src/appManifest/navigator.ts",
+        "toPath": "src/appManifest/shared.ts",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromPath": "src/appManifest/navigatorOptions.ts",
+        "toPath": "src/navigator.ts",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromPath": "src/appManifest/navigatorOptions.ts",
+        "toPath": "src/appManifest/shared.ts",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
         "fromPath": "src/appManifest/screens.ts",
         "toPath": "src/types.ts",
         "sourcePath": "src/appManifest/screens.ts"
@@ -15350,6 +17108,11 @@
       {
         "fromPath": "src/appManifest/screens.ts",
         "toPath": "src/appManifest/shared.ts",
+        "sourcePath": "src/appManifest/screens.ts"
+      },
+      {
+        "fromPath": "src/appManifest/screens.ts",
+        "toPath": "src/appManifest/navigator.ts",
         "sourcePath": "src/appManifest/screens.ts"
       },
       {
@@ -15570,8 +17333,8 @@
       },
       {
         "fromSymbol": "isAppManifest",
-        "toSymbol": "isNavigatorSpec",
-        "callExpression": "isNavigatorSpec",
+        "toSymbol": "isAppNavigatorManifest",
+        "callExpression": "isAppNavigatorManifest",
         "sourcePath": "src/appManifest.ts"
       },
       {
@@ -15594,8 +17357,20 @@
       },
       {
         "fromSymbol": "isAppManifest",
+        "toSymbol": "isRepositoryManifest",
+        "callExpression": "isRepositoryManifest",
+        "sourcePath": "src/appManifest.ts"
+      },
+      {
+        "fromSymbol": "isAppManifest",
         "toSymbol": "isAppSettings",
         "callExpression": "isAppSettings",
+        "sourcePath": "src/appManifest.ts"
+      },
+      {
+        "fromSymbol": "isRepositoryManifest",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
         "sourcePath": "src/appManifest.ts"
       },
       {
@@ -16463,6 +18238,24 @@
         "sourcePath": "src/appManifest/deploy.ts"
       },
       {
+        "fromSymbol": "isIconSpec",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/icon.ts"
+      },
+      {
+        "fromSymbol": "isIconSpec",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/icon.ts"
+      },
+      {
+        "fromSymbol": "isIconSpec",
+        "toSymbol": "isMediaAssetReference",
+        "callExpression": "isMediaAssetReference",
+        "sourcePath": "src/appManifest/icon.ts"
+      },
+      {
         "fromSymbol": "isInfraManifest",
         "toSymbol": "isRecord",
         "callExpression": "isRecord",
@@ -16691,18 +18484,6 @@
         "sourcePath": "src/appManifest/infra.ts"
       },
       {
-        "fromSymbol": "isIconSpec",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/infra.ts"
-      },
-      {
-        "fromSymbol": "isIconSpec",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/infra.ts"
-      },
-      {
         "fromSymbol": "isMediaManifest",
         "toSymbol": "isRecord",
         "callExpression": "isRecord",
@@ -16829,6 +18610,498 @@
         "sourcePath": "src/appManifest/media.ts"
       },
       {
+        "fromSymbol": "isAppNavigatorManifest",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isAppNavigatorManifest",
+        "toSymbol": "isNavigatorNode",
+        "callExpression": "isNavigatorNode",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isAppNavigatorManifest",
+        "toSymbol": "isNavigatorFlows",
+        "callExpression": "isNavigatorFlows",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isAppNavigatorManifest",
+        "toSymbol": "isNavigatorDefaults",
+        "callExpression": "isNavigatorDefaults",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isAppNavigatorManifest",
+        "toSymbol": "isNavigatorPlatforms",
+        "callExpression": "isNavigatorPlatforms",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorNode",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorNode",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorNode",
+        "toSymbol": "isStackImplementationConfig",
+        "callExpression": "isStackImplementationConfig",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorNode",
+        "toSymbol": "isTabsImplementationConfig",
+        "callExpression": "isTabsImplementationConfig",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorNode",
+        "toSymbol": "isDrawerNavigatorOptions",
+        "callExpression": "isDrawerNavigatorOptions",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorNode",
+        "toSymbol": "isSplitViewNavigatorNode",
+        "callExpression": "isSplitViewNavigatorNode",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorNode",
+        "toSymbol": "isCustomNavigatorNode",
+        "callExpression": "isCustomNavigatorNode",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isRouteDefinition",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isRouteDefinition",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isRouteDefinition",
+        "toSymbol": "isIconSpec",
+        "callExpression": "isIconSpec",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isRouteDefinition",
+        "toSymbol": "isOptionalBoolean",
+        "callExpression": "isOptionalBoolean",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isRouteDefinition",
+        "toSymbol": "isStringArray",
+        "callExpression": "isStringArray",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isRouteDefinition",
+        "toSymbol": "isStackScreenOptions",
+        "callExpression": "isStackScreenOptions",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isRouteDefinition",
+        "toSymbol": "isNavigatorNode",
+        "callExpression": "isNavigatorNode",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isSplitViewNavigatorNode",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isSplitViewNavigatorNode",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isSplitViewNavigatorNode",
+        "toSymbol": "isNavigatorScreenReference",
+        "callExpression": "isNavigatorScreenReference",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isCustomNavigatorNode",
+        "toSymbol": "isNavigatorJsonRecord",
+        "callExpression": "isNavigatorJsonRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorJsonRecord",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorJsonRecord",
+        "toSymbol": "isNavigatorJsonValue",
+        "callExpression": "isNavigatorJsonValue",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "src/appManifest/navigator.ts",
+        "toSymbol": "isNavigatorJsonValue",
+        "callExpression": "isNavigatorJsonValue",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorFlows",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorFlows",
+        "toSymbol": "isOptionalBoolean",
+        "callExpression": "isOptionalBoolean",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorDefaults",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorDefaults",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorDefaults",
+        "toSymbol": "isTabsImplementationConfig",
+        "callExpression": "isTabsImplementationConfig",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorDefaults",
+        "toSymbol": "isStackImplementationConfig",
+        "callExpression": "isStackImplementationConfig",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorPlatforms",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorPlatforms",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorPlatforms",
+        "toSymbol": "isNavigatorPlatformConfig",
+        "callExpression": "isNavigatorPlatformConfig",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorPlatformConfig",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorPlatformConfig",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorPlatformConfig",
+        "toSymbol": "isTabsImplementationConfig",
+        "callExpression": "isTabsImplementationConfig",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorPlatformConfig",
+        "toSymbol": "isStackImplementationConfig",
+        "callExpression": "isStackImplementationConfig",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isStackImplementationConfig",
+        "toSymbol": "isStackScreenOptions",
+        "callExpression": "isStackScreenOptions",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackImplementationConfig",
+        "toSymbol": "isJavaScriptStackScreenOptions",
+        "callExpression": "isJavaScriptStackScreenOptions",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackImplementationConfig",
+        "toSymbol": "isStackHeaderOptions",
+        "callExpression": "isStackHeaderOptions",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackScreenOptions",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackScreenOptions",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackScreenOptions",
+        "toSymbol": "isStackHeaderOptionsShape",
+        "callExpression": "isStackHeaderOptionsShape",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackScreenOptions",
+        "toSymbol": "isSheetAllowedDetents",
+        "callExpression": "isSheetAllowedDetents",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackScreenOptions",
+        "toSymbol": "isOptionalBoolean",
+        "callExpression": "isOptionalBoolean",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isDrawerNavigatorOptions",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isDrawerNavigatorOptions",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isDrawerNavigatorOptions",
+        "toSymbol": "isOptionalBoolean",
+        "callExpression": "isOptionalBoolean",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isTabsImplementationConfig",
+        "toSymbol": "isAdaptiveTabsConfig",
+        "callExpression": "isAdaptiveTabsConfig",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isTabsImplementationConfig",
+        "toSymbol": "isFullNativeTabsConfig",
+        "callExpression": "isFullNativeTabsConfig",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isTabsImplementationConfig",
+        "toSymbol": "isJavaScriptTabsConfig",
+        "callExpression": "isJavaScriptTabsConfig",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isTabsImplementationConfig",
+        "toSymbol": "hasNoDefinedKeys",
+        "callExpression": "hasNoDefinedKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isTabsImplementationConfig",
+        "toSymbol": "isCustomTabsPresentationConfig",
+        "callExpression": "isCustomTabsPresentationConfig",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorScreenReference",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorScreenReference",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isJavaScriptStackScreenOptions",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isJavaScriptStackScreenOptions",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isJavaScriptStackScreenOptions",
+        "toSymbol": "isStackHeaderOptionsShape",
+        "callExpression": "isStackHeaderOptionsShape",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackHeaderOptions",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackHeaderOptions",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackHeaderOptions",
+        "toSymbol": "isStackHeaderOptionsShape",
+        "callExpression": "isStackHeaderOptionsShape",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackHeaderOptionsShape",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackHeaderOptionsShape",
+        "toSymbol": "isOptionalBoolean",
+        "callExpression": "isOptionalBoolean",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isAdaptiveTabsConfig",
+        "toSymbol": "hasNoDefinedKeys",
+        "callExpression": "hasNoDefinedKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isAdaptiveTabsConfig",
+        "toSymbol": "isNativeTabsConfig",
+        "callExpression": "isNativeTabsConfig",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isAdaptiveTabsConfig",
+        "toSymbol": "isCustomTabsWebConfig",
+        "callExpression": "isCustomTabsWebConfig",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isFullNativeTabsConfig",
+        "toSymbol": "hasNoDefinedKeys",
+        "callExpression": "hasNoDefinedKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isFullNativeTabsConfig",
+        "toSymbol": "isNativeTabsFields",
+        "callExpression": "isNativeTabsFields",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isJavaScriptTabsConfig",
+        "toSymbol": "hasNoDefinedKeys",
+        "callExpression": "hasNoDefinedKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isNativeTabsConfig",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isNativeTabsConfig",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isNativeTabsConfig",
+        "toSymbol": "isNativeTabsFields",
+        "callExpression": "isNativeTabsFields",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isNativeTabsFields",
+        "toSymbol": "isNavigatorScreenReference",
+        "callExpression": "isNavigatorScreenReference",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isCustomTabsWebConfig",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isCustomTabsWebConfig",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isCustomTabsWebConfig",
+        "toSymbol": "isCustomTabsPresentationConfig",
+        "callExpression": "isCustomTabsPresentationConfig",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isCustomTabsPresentationConfig",
+        "toSymbol": "isResponsiveTabsPresentation",
+        "callExpression": "isResponsiveTabsPresentation",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isCustomTabsPresentationConfig",
+        "toSymbol": "isOptionalString",
+        "callExpression": "isOptionalString",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isResponsiveTabsPresentation",
+        "toSymbol": "isRecord",
+        "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isResponsiveTabsPresentation",
+        "toSymbol": "hasOnlyKeys",
+        "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
         "fromSymbol": "isManifestMetadata",
         "toSymbol": "isRecord",
         "callExpression": "isRecord",
@@ -16850,18 +19123,6 @@
         "fromSymbol": "isThemeConfig",
         "toSymbol": "isThemeModeConfig",
         "callExpression": "isThemeModeConfig",
-        "sourcePath": "src/appManifest/screens.ts"
-      },
-      {
-        "fromSymbol": "isNavigatorSpec",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/screens.ts"
-      },
-      {
-        "fromSymbol": "isNavigatorSpec",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
         "sourcePath": "src/appManifest/screens.ts"
       },
       {
@@ -16958,54 +19219,6 @@
         "fromSymbol": "isScreenSpec",
         "toSymbol": "isUiNode",
         "callExpression": "isUiNode",
-        "sourcePath": "src/appManifest/screens.ts"
-      },
-      {
-        "fromSymbol": "isRouteDefinition",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/screens.ts"
-      },
-      {
-        "fromSymbol": "isRouteDefinition",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
-        "sourcePath": "src/appManifest/screens.ts"
-      },
-      {
-        "fromSymbol": "isRouteDefinition",
-        "toSymbol": "isIconSpec",
-        "callExpression": "isIconSpec",
-        "sourcePath": "src/appManifest/screens.ts"
-      },
-      {
-        "fromSymbol": "isRouteDefinition",
-        "toSymbol": "isOptionalBoolean",
-        "callExpression": "isOptionalBoolean",
-        "sourcePath": "src/appManifest/screens.ts"
-      },
-      {
-        "fromSymbol": "isRouteDefinition",
-        "toSymbol": "isStringArray",
-        "callExpression": "isStringArray",
-        "sourcePath": "src/appManifest/screens.ts"
-      },
-      {
-        "fromSymbol": "isRouteDefinition",
-        "toSymbol": "isNavigatorSpec",
-        "callExpression": "isNavigatorSpec",
-        "sourcePath": "src/appManifest/screens.ts"
-      },
-      {
-        "fromSymbol": "isIconSpec",
-        "toSymbol": "isRecord",
-        "callExpression": "isRecord",
-        "sourcePath": "src/appManifest/screens.ts"
-      },
-      {
-        "fromSymbol": "isIconSpec",
-        "toSymbol": "isOptionalString",
-        "callExpression": "isOptionalString",
         "sourcePath": "src/appManifest/screens.ts"
       },
       {
@@ -17923,6 +20136,101 @@
         "sourcePath": "src/media.ts"
       },
       {
+        "fromSymbol": "NativeTabsConfig",
+        "toType": "NavigatorScreenReference",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "AdaptiveTabsConfig",
+        "toType": "CustomTabsPresentationConfig",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "AdaptiveTabsConfig",
+        "toType": "NativeTabsConfig",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "SlotNavigatorNode",
+        "toType": "RouteDefinition",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "DrawerNavigatorNode",
+        "toType": "DrawerNavigatorOptions",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "DrawerNavigatorNode",
+        "toType": "RouteDefinition",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "SplitViewNavigatorNode",
+        "toType": "NavigatorScreenReference",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "SplitViewNavigatorNode",
+        "toType": "RouteDefinition",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "CustomNavigatorNode",
+        "toType": "ManifestValue",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "CustomNavigatorNode",
+        "toType": "Readonly",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "CustomNavigatorNode",
+        "toType": "RouteDefinition",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "RouteDefinition",
+        "toType": "IconSpec",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "RouteDefinition",
+        "toType": "NavigatorNode",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "RouteDefinition",
+        "toType": "StackScreenOptions",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "NavigatorDefaults",
+        "toType": "StackImplementationConfig",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "NavigatorDefaults",
+        "toType": "TabsImplementationConfig",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "NavigatorPlatformConfig",
+        "toType": "StackImplementationConfig",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "NavigatorPlatformConfig",
+        "toType": "TabsImplementationConfig",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromSymbol": "NavigatorPlatforms",
+        "toType": "NavigatorPlatformConfig",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
         "fromSymbol": "ScreenRequirements",
         "toType": "ScreenCapabilityRequirement",
         "sourcePath": "src/requirements.ts"
@@ -18116,6 +20424,11 @@
         "fromSymbol": "StateAdapter",
         "toType": "TValue",
         "sourcePath": "src/state.ts"
+      },
+      {
+        "fromSymbol": "StorageUploadInput",
+        "toType": "ArrayBufferLike",
+        "sourcePath": "src/storage.ts"
       },
       {
         "fromSymbol": "StorageUploadInput",
@@ -18348,6 +20661,11 @@
         "sourcePath": "src/types.ts"
       },
       {
+        "fromSymbol": "SvgIconSpec",
+        "toType": "MediaAssetReference",
+        "sourcePath": "src/types.ts"
+      },
+      {
         "fromSymbol": "UiNodeRepeatSpec",
         "toType": "BindingValueSource",
         "sourcePath": "src/types.ts"
@@ -18375,21 +20693,6 @@
       {
         "fromSymbol": "ScreenSpec",
         "toType": "UiNode",
-        "sourcePath": "src/types.ts"
-      },
-      {
-        "fromSymbol": "NavigatorSpec",
-        "toType": "RouteDefinition",
-        "sourcePath": "src/types.ts"
-      },
-      {
-        "fromSymbol": "RouteDefinition",
-        "toType": "IconSpec",
-        "sourcePath": "src/types.ts"
-      },
-      {
-        "fromSymbol": "RouteDefinition",
-        "toType": "NavigatorSpec",
         "sourcePath": "src/types.ts"
       },
       {
@@ -18534,6 +20837,11 @@
       },
       {
         "fromSymbol": "AppManifest",
+        "toType": "AppNavigatorManifest",
+        "sourcePath": "src/types.ts"
+      },
+      {
+        "fromSymbol": "AppManifest",
         "toType": "AppSettings",
         "sourcePath": "src/types.ts"
       },
@@ -18559,12 +20867,12 @@
       },
       {
         "fromSymbol": "AppManifest",
-        "toType": "NavigatorSpec",
+        "toType": "Readonly",
         "sourcePath": "src/types.ts"
       },
       {
         "fromSymbol": "AppManifest",
-        "toType": "Readonly",
+        "toType": "RepositoryManifest",
         "sourcePath": "src/types.ts"
       },
       {

--- a/src/appManifest/navigator.ts
+++ b/src/appManifest/navigator.ts
@@ -1,0 +1,179 @@
+import { NAVIGATOR_PRESETS, NAVIGATOR_TYPES } from '../navigator';
+import { isIconSpec } from './icon';
+import {
+  hasOnlyKeys,
+  isDrawerNavigatorOptions,
+  isNavigatorScreenReference,
+  isStackImplementationConfig,
+  isStackScreenOptions,
+  isTabsImplementationConfig,
+} from './navigatorOptions';
+import { isOptionalBoolean, isOptionalString, isRecord, isStringArray } from './shared';
+
+const NAVIGATOR_PRESET_SET = new Set<string>(NAVIGATOR_PRESETS);
+const NAVIGATOR_TYPE_SET = new Set<string>(NAVIGATOR_TYPES);
+
+/*** Validate the complete serialized `AppManifest.navigator` slice. */
+export function isAppNavigatorManifest(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    isNavigatorNode(value) &&
+    (value.preset === undefined ||
+      (typeof value.preset === 'string' && NAVIGATOR_PRESET_SET.has(value.preset))) &&
+    (value.flows === undefined || isNavigatorFlows(value.flows)) &&
+    (value.defaults === undefined || isNavigatorDefaults(value.defaults)) &&
+    (value.platforms === undefined || isNavigatorPlatforms(value.platforms))
+  );
+}
+
+/*** Validate one nested navigator node independently from app-level authoring metadata. */
+function isNavigatorNode(value: unknown): boolean {
+  if (
+    !isRecord(value) ||
+    typeof value.type !== 'string' ||
+    !NAVIGATOR_TYPE_SET.has(value.type) ||
+    !isOptionalString(value.initialRouteName) ||
+    !Array.isArray(value.routes) ||
+    !value.routes.every(isRouteDefinition)
+  ) {
+    return false;
+  }
+
+  switch (value.type) {
+    case 'slot':
+      return value.options === undefined && value.implementation === undefined;
+    case 'stack':
+      return isStackImplementationConfig(value);
+    case 'tabs':
+      return isTabsImplementationConfig(value);
+    case 'drawer':
+      return (
+        value.implementation === undefined &&
+        (value.options === undefined || isDrawerNavigatorOptions(value.options))
+      );
+    case 'split-view':
+      return isSplitViewNavigatorNode(value);
+    case 'custom':
+      return isCustomNavigatorNode(value);
+    default:
+      return false;
+  }
+}
+
+/*** Validate one route and preserve its portable metadata and nested navigator. */
+function isRouteDefinition(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.name === 'string' &&
+    isOptionalString(value.path) &&
+    isOptionalString(value.label) &&
+    (value.icon === undefined || isIconSpec(value.icon)) &&
+    isOptionalBoolean(value.showInPrimaryNavigation) &&
+    (value.guards === undefined || isStringArray(value.guards)) &&
+    isOptionalString(value.screenId) &&
+    (value.stackOptions === undefined || isStackScreenOptions(value.stackOptions)) &&
+    (value.navigator === undefined || isNavigatorNode(value.navigator))
+  );
+}
+
+/*** Validate Split View screen references without duplicating the routed secondary tree. */
+function isSplitViewNavigatorNode(value: Record<string, unknown>): boolean {
+  return (
+    value.implementation === undefined &&
+    value.options === undefined &&
+    isRecord(value.columns) &&
+    hasOnlyKeys(value.columns, ['primary', 'supplementary']) &&
+    isNavigatorScreenReference(value.columns.primary) &&
+    (value.columns.supplementary === undefined ||
+      isNavigatorScreenReference(value.columns.supplementary)) &&
+    (value.inspector === undefined || isNavigatorScreenReference(value.inspector)) &&
+    (value.topColumnForCollapsing === undefined ||
+      value.topColumnForCollapsing === 'primary' ||
+      value.topColumnForCollapsing === 'supplementary' ||
+      value.topColumnForCollapsing === 'secondary')
+  );
+}
+
+/*** Validate a registered custom navigator with JSON-safe configuration only. */
+function isCustomNavigatorNode(value: Record<string, unknown>): boolean {
+  return (
+    value.implementation === undefined &&
+    value.options === undefined &&
+    typeof value.navigatorId === 'string' &&
+    (value.config === undefined || isNavigatorJsonRecord(value.config))
+  );
+}
+
+/*** Validate an acyclic, finite JSON object used by a custom navigator adapter. */
+function isNavigatorJsonRecord(value: unknown): boolean {
+  return isRecord(value) && isNavigatorJsonValue(value, new Set<object>());
+}
+
+/*** Recursively validate the portable manifest value domain and reject cycles. */
+function isNavigatorJsonValue(value: unknown, ancestors: Set<object>): boolean {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value !== 'object' || ancestors.has(value)) return false;
+
+  if (Array.isArray(value)) {
+    if (
+      Object.keys(value).length !== value.length ||
+      Object.getOwnPropertySymbols(value).length > 0
+    ) {
+      return false;
+    }
+  } else {
+    const prototype = Object.getPrototypeOf(value) as object | null;
+    if (prototype !== Object.prototype && prototype !== null) return false;
+    if (Reflect.ownKeys(value).some((key) => typeof key !== 'string')) return false;
+  }
+
+  ancestors.add(value);
+  const isValid = Object.values(value).every((entry) => isNavigatorJsonValue(entry, ancestors));
+  ancestors.delete(value);
+  return isValid;
+}
+
+/*** Validate optional app-level navigator flow intent. */
+function isNavigatorFlows(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    isOptionalBoolean(value.onboarding) &&
+    isOptionalBoolean(value.authentication)
+  );
+}
+
+/*** Validate package-owned navigator defaults without requiring a navigator node type. */
+function isNavigatorDefaults(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['tabs', 'stack']) &&
+    (value.tabs === undefined ||
+      (isRecord(value.tabs) && isTabsImplementationConfig(value.tabs))) &&
+    (value.stack === undefined ||
+      (isRecord(value.stack) && isStackImplementationConfig(value.stack)))
+  );
+}
+
+/*** Validate per-platform navigator implementation overrides. */
+function isNavigatorPlatforms(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['android', 'ios', 'web']) &&
+    (value.android === undefined || isNavigatorPlatformConfig(value.android)) &&
+    (value.ios === undefined || isNavigatorPlatformConfig(value.ios)) &&
+    (value.web === undefined || isNavigatorPlatformConfig(value.web))
+  );
+}
+
+/*** Validate one platform-specific navigator override slice. */
+function isNavigatorPlatformConfig(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['tabs', 'stack']) &&
+    (value.tabs === undefined ||
+      (isRecord(value.tabs) && isTabsImplementationConfig(value.tabs))) &&
+    (value.stack === undefined ||
+      (isRecord(value.stack) && isStackImplementationConfig(value.stack)))
+  );
+}

--- a/src/appManifest/navigatorOptions.ts
+++ b/src/appManifest/navigatorOptions.ts
@@ -1,0 +1,292 @@
+import {
+  CUSTOM_TABS_PRESENTATIONS,
+  DRAWER_POSITIONS,
+  DRAWER_TYPES,
+  FIXED_CUSTOM_TABS_PRESENTATIONS,
+  JAVASCRIPT_STACK_PRESENTATIONS,
+  JAVASCRIPT_TABS_PRESENTATIONS,
+  NATIVE_TABS_MINIMIZE_BEHAVIORS,
+  STACK_PRESENTATIONS,
+} from '../navigator';
+import { isOptionalBoolean, isOptionalString, isRecord } from './shared';
+
+const CUSTOM_TABS_PRESENTATION_SET = new Set<string>(CUSTOM_TABS_PRESENTATIONS);
+const DRAWER_POSITION_SET = new Set<string>(DRAWER_POSITIONS);
+const DRAWER_TYPE_SET = new Set<string>(DRAWER_TYPES);
+const FIXED_CUSTOM_TABS_PRESENTATION_SET = new Set<string>(FIXED_CUSTOM_TABS_PRESENTATIONS);
+const JAVASCRIPT_STACK_PRESENTATION_SET = new Set<string>(JAVASCRIPT_STACK_PRESENTATIONS);
+const JAVASCRIPT_TABS_PRESENTATION_SET = new Set<string>(JAVASCRIPT_TABS_PRESENTATIONS);
+const NATIVE_TABS_MINIMIZE_BEHAVIOR_SET = new Set<string>(NATIVE_TABS_MINIMIZE_BEHAVIORS);
+const STACK_PRESENTATION_SET = new Set<string>(STACK_PRESENTATIONS);
+
+/*** Validate stable native, JavaScript, or alpha Experimental Stack desired state. */
+export function isStackImplementationConfig(value: Record<string, unknown>): boolean {
+  if (
+    !hasNoDefinedKeys(value, [
+      'native',
+      'web',
+      'presentation',
+      'responsive',
+      'customPresentationId',
+      'minimizeBehavior',
+      'bottomAccessory',
+    ])
+  ) {
+    return false;
+  }
+  if (value.implementation === undefined || value.implementation === 'native') {
+    return value.options === undefined || isStackScreenOptions(value.options);
+  }
+  if (value.implementation === 'javascript') {
+    return value.options === undefined || isJavaScriptStackScreenOptions(value.options);
+  }
+  return (
+    value.implementation === 'experimental' &&
+    (value.options === undefined || isStackHeaderOptions(value.options))
+  );
+}
+
+/*** Validate the serializable native-stack screen option subset. */
+export function isStackScreenOptions(value: unknown): boolean {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      'title',
+      'headerShown',
+      'headerTransparent',
+      'headerBackVisible',
+      'presentation',
+      'sheetAllowedDetents',
+      'sheetGrabberVisible',
+    ]) ||
+    !isStackHeaderOptionsShape(value) ||
+    (value.presentation !== undefined &&
+      (typeof value.presentation !== 'string' || !STACK_PRESENTATION_SET.has(value.presentation)))
+  ) {
+    return false;
+  }
+
+  if (value.presentation !== 'formSheet') {
+    return value.sheetAllowedDetents === undefined && value.sheetGrabberVisible === undefined;
+  }
+  return (
+    (value.sheetAllowedDetents === undefined || isSheetAllowedDetents(value.sheetAllowedDetents)) &&
+    isOptionalBoolean(value.sheetGrabberVisible)
+  );
+}
+
+/*** Validate the finite serializable Drawer option subset. */
+export function isDrawerNavigatorOptions(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['drawerPosition', 'drawerType', 'swipeEnabled', 'headerShown']) &&
+    (value.drawerPosition === undefined ||
+      (typeof value.drawerPosition === 'string' &&
+        DRAWER_POSITION_SET.has(value.drawerPosition))) &&
+    (value.drawerType === undefined ||
+      (typeof value.drawerType === 'string' && DRAWER_TYPE_SET.has(value.drawerType))) &&
+    isOptionalBoolean(value.swipeEnabled) &&
+    isOptionalBoolean(value.headerShown)
+  );
+}
+
+/*** Validate tabs implementation desired state, with omitted implementation meaning adaptive. */
+export function isTabsImplementationConfig(value: Record<string, unknown>): boolean {
+  if (value.implementation === undefined || value.implementation === 'adaptive') {
+    return isAdaptiveTabsConfig(value);
+  }
+  if (value.implementation === 'native') return isFullNativeTabsConfig(value);
+  if (value.implementation === 'javascript') return isJavaScriptTabsConfig(value);
+  return (
+    value.implementation === 'custom' &&
+    hasNoDefinedKeys(value, ['options', 'native', 'web', 'minimizeBehavior', 'bottomAccessory']) &&
+    isCustomTabsPresentationConfig(value)
+  );
+}
+
+/*** Validate a reference into the app-owned screen registry. */
+export function isNavigatorScreenReference(value: unknown): boolean {
+  return isRecord(value) && hasOnlyKeys(value, ['screenId']) && typeof value.screenId === 'string';
+}
+
+/*** Check that a finite configuration object contains no unsupported keys. */
+export function hasOnlyKeys(
+  value: Record<string, unknown>,
+  allowedKeys: readonly string[],
+): boolean {
+  const allowed = new Set(allowedKeys);
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+/*** Validate JavaScript Stack options without accepting native-only presentations. */
+function isJavaScriptStackScreenOptions(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, [
+      'title',
+      'headerShown',
+      'headerTransparent',
+      'headerBackVisible',
+      'presentation',
+    ]) &&
+    isStackHeaderOptionsShape(value) &&
+    (value.presentation === undefined ||
+      (typeof value.presentation === 'string' &&
+        JAVASCRIPT_STACK_PRESENTATION_SET.has(value.presentation)))
+  );
+}
+
+/*** Validate the portable header subset supported by Experimental Stack. */
+function isStackHeaderOptions(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['title', 'headerShown', 'headerTransparent', 'headerBackVisible']) &&
+    isStackHeaderOptionsShape(value)
+  );
+}
+
+/*** Validate shared stack header field values after branch-specific key filtering. */
+function isStackHeaderOptionsShape(value: Record<string, unknown>): boolean {
+  return (
+    isOptionalString(value.title) &&
+    isOptionalBoolean(value.headerShown) &&
+    isOptionalBoolean(value.headerTransparent) &&
+    isOptionalBoolean(value.headerBackVisible)
+  );
+}
+
+/*** Validate sorted, finite native sheet detents or the fit-to-content sentinel. */
+function isSheetAllowedDetents(value: unknown): boolean {
+  if (value === 'fitToContents') return true;
+  if (!Array.isArray(value) || value.length === 0) return false;
+  return value.every(
+    (detent, index) =>
+      typeof detent === 'number' &&
+      Number.isFinite(detent) &&
+      detent > 0 &&
+      detent <= 1 &&
+      (index === 0 || detent > value[index - 1]),
+  );
+}
+
+/*** Validate an adaptive tabs branch and reject implementation-specific conflicts. */
+function isAdaptiveTabsConfig(value: Record<string, unknown>): boolean {
+  return (
+    hasNoDefinedKeys(value, [
+      'options',
+      'presentation',
+      'responsive',
+      'customPresentationId',
+      'minimizeBehavior',
+      'bottomAccessory',
+    ]) &&
+    (value.native === undefined || isNativeTabsConfig(value.native)) &&
+    (value.web === undefined || isCustomTabsWebConfig(value.web))
+  );
+}
+
+/*** Validate the top-level native tabs implementation. */
+function isFullNativeTabsConfig(value: Record<string, unknown>): boolean {
+  return (
+    hasNoDefinedKeys(value, [
+      'options',
+      'native',
+      'web',
+      'presentation',
+      'responsive',
+      'customPresentationId',
+    ]) && isNativeTabsFields(value)
+  );
+}
+
+/*** Validate the top-level JavaScript tabs implementation. */
+function isJavaScriptTabsConfig(value: Record<string, unknown>): boolean {
+  return (
+    hasNoDefinedKeys(value, [
+      'options',
+      'native',
+      'web',
+      'responsive',
+      'customPresentationId',
+      'minimizeBehavior',
+      'bottomAccessory',
+    ]) &&
+    (value.presentation === undefined ||
+      (typeof value.presentation === 'string' &&
+        JAVASCRIPT_TABS_PRESENTATION_SET.has(value.presentation)))
+  );
+}
+
+/*** Validate the native branch used by adaptive tabs. */
+function isNativeTabsConfig(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['implementation', 'minimizeBehavior', 'bottomAccessory']) &&
+    value.implementation === 'native' &&
+    isNativeTabsFields(value)
+  );
+}
+
+/*** Validate fields supported by the native tabs branch. */
+function isNativeTabsFields(value: Record<string, unknown>): boolean {
+  return (
+    (value.minimizeBehavior === undefined ||
+      (typeof value.minimizeBehavior === 'string' &&
+        NATIVE_TABS_MINIMIZE_BEHAVIOR_SET.has(value.minimizeBehavior))) &&
+    (value.bottomAccessory === undefined || isNavigatorScreenReference(value.bottomAccessory))
+  );
+}
+
+/*** Validate the implementation-free custom-tabs Web branch inside adaptive tabs. */
+function isCustomTabsWebConfig(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['presentation', 'responsive', 'customPresentationId']) &&
+    isCustomTabsPresentationConfig(value)
+  );
+}
+
+/*** Validate custom-tab presentation and its conditional serializable configuration. */
+function isCustomTabsPresentationConfig(value: Record<string, unknown>): boolean {
+  if (
+    typeof value.presentation !== 'string' ||
+    !CUSTOM_TABS_PRESENTATION_SET.has(value.presentation)
+  ) {
+    return false;
+  }
+  if (value.responsive !== undefined && !isResponsiveTabsPresentation(value.responsive)) {
+    return false;
+  }
+  if (!isOptionalString(value.customPresentationId)) return false;
+  if (FIXED_CUSTOM_TABS_PRESENTATION_SET.has(value.presentation)) {
+    return value.responsive === undefined && value.customPresentationId === undefined;
+  }
+  if (value.presentation === 'responsive') {
+    return value.responsive !== undefined && value.customPresentationId === undefined;
+  }
+  return (
+    value.responsive === undefined &&
+    typeof value.customPresentationId === 'string' &&
+    value.customPresentationId.length > 0
+  );
+}
+
+/*** Validate semantic compact/medium/expanded custom-tab presentation mapping. */
+function isResponsiveTabsPresentation(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['compact', 'medium', 'expanded']) &&
+    typeof value.compact === 'string' &&
+    FIXED_CUSTOM_TABS_PRESENTATION_SET.has(value.compact) &&
+    (value.medium === undefined ||
+      (typeof value.medium === 'string' && FIXED_CUSTOM_TABS_PRESENTATION_SET.has(value.medium))) &&
+    typeof value.expanded === 'string' &&
+    FIXED_CUSTOM_TABS_PRESENTATION_SET.has(value.expanded)
+  );
+}
+
+/*** Check that mutually exclusive branch fields are absent. */
+function hasNoDefinedKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const prohibited = new Set(keys);
+  return !Object.entries(value).some(([key, entry]) => prohibited.has(key) && entry !== undefined);
+}

--- a/src/appManifest/screens.ts
+++ b/src/appManifest/screens.ts
@@ -1,30 +1,13 @@
 import { COLOR_HARMONIES } from '@ankhorage/color-theory';
 
-import {
-  CUSTOM_TABS_PRESENTATIONS,
-  FIXED_CUSTOM_TABS_PRESENTATIONS,
-  JAVASCRIPT_TABS_PRESENTATIONS,
-  NAVIGATOR_PRESETS,
-  NAVIGATOR_TYPES,
-} from '../navigator';
 import { APP_CATEGORIES } from '../types';
 import { isBindingValueSource, isScreenDataLoaderDefinition } from './bindings';
-import { isIconSpec } from './icon';
-import {
-  isOptionalBoolean,
-  isOptionalNumber,
-  isOptionalString,
-  isRecord,
-  isStringArray,
-} from './shared';
+import { isOptionalNumber, isOptionalString, isRecord } from './shared';
+
+export { isAppNavigatorManifest } from './navigator';
 
 const APP_CATEGORY_SET = new Set<string>(APP_CATEGORIES);
 const COLOR_HARMONY_SET = new Set<string>(COLOR_HARMONIES);
-const CUSTOM_TABS_PRESENTATION_SET = new Set<string>(CUSTOM_TABS_PRESENTATIONS);
-const FIXED_CUSTOM_TABS_PRESENTATION_SET = new Set<string>(FIXED_CUSTOM_TABS_PRESENTATIONS);
-const JAVASCRIPT_TABS_PRESENTATION_SET = new Set<string>(JAVASCRIPT_TABS_PRESENTATIONS);
-const NAVIGATOR_PRESET_SET = new Set<string>(NAVIGATOR_PRESETS);
-const NAVIGATOR_TYPE_SET = new Set<string>(NAVIGATOR_TYPES);
 const SPLASH_SCREEN_RESIZE_MODE_SET = new Set<string>(['contain', 'cover', 'native']);
 
 export function isManifestMetadata(value: unknown): boolean {
@@ -48,19 +31,6 @@ export function isThemeConfig(value: unknown): boolean {
     typeof value.name === 'string' &&
     isThemeModeConfig(value.light) &&
     isThemeModeConfig(value.dark)
-  );
-}
-
-/*** Validate the complete serialized `AppManifest.navigator` slice. */
-export function isAppNavigatorManifest(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    isNavigatorNode(value) &&
-    (value.preset === undefined ||
-      (typeof value.preset === 'string' && NAVIGATOR_PRESET_SET.has(value.preset))) &&
-    (value.flows === undefined || isNavigatorFlows(value.flows)) &&
-    (value.defaults === undefined || isNavigatorDefaults(value.defaults)) &&
-    (value.platforms === undefined || isNavigatorPlatforms(value.platforms))
   );
 }
 
@@ -127,143 +97,6 @@ function isScreenSpec(value: unknown): boolean {
         value.dataLoaders.every(isScreenDataLoaderDefinition))) &&
     (value.requires === undefined || isScreenRequirements(value.requires)) &&
     isUiNode(value.root)
-  );
-}
-
-/*** Validate one nested navigator node independently from app-level authoring metadata. */
-function isNavigatorNode(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    typeof value.type === 'string' &&
-    NAVIGATOR_TYPE_SET.has(value.type) &&
-    isOptionalString(value.initialRouteName) &&
-    Array.isArray(value.routes) &&
-    value.routes.every(isRouteDefinition) &&
-    (value.options === undefined || isRecord(value.options)) &&
-    (value.type !== 'tabs' || isTabsImplementationConfig(value))
-  );
-}
-
-function isRouteDefinition(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    typeof value.name === 'string' &&
-    isOptionalString(value.path) &&
-    isOptionalString(value.label) &&
-    (value.icon === undefined || isIconSpec(value.icon)) &&
-    isOptionalBoolean(value.showInPrimaryNavigation) &&
-    (value.guards === undefined || isStringArray(value.guards)) &&
-    isOptionalString(value.screenId) &&
-    (value.navigator === undefined || isNavigatorNode(value.navigator))
-  );
-}
-
-/*** Validate tabs implementation desired state, with omitted implementation meaning adaptive. */
-function isTabsImplementationConfig(value: Record<string, unknown>): boolean {
-  if (value.implementation === undefined || value.implementation === 'adaptive') {
-    return (
-      (value.native === undefined || isNativeTabsConfig(value.native)) &&
-      (value.web === undefined || isCustomTabsWebConfig(value.web))
-    );
-  }
-
-  if (value.implementation === 'native') return true;
-
-  if (value.implementation === 'javascript') {
-    return (
-      value.presentation === undefined ||
-      (typeof value.presentation === 'string' &&
-        JAVASCRIPT_TABS_PRESENTATION_SET.has(value.presentation))
-    );
-  }
-
-  return value.implementation === 'custom' && isCustomTabsConfig(value);
-}
-
-/*** Validate the native branch used by adaptive tabs. */
-function isNativeTabsConfig(value: unknown): boolean {
-  return isRecord(value) && value.implementation === 'native';
-}
-
-/*** Validate a full custom-tabs implementation config. */
-function isCustomTabsConfig(value: Record<string, unknown>): boolean {
-  return value.implementation === 'custom' && isCustomTabsPresentationConfig(value);
-}
-
-/*** Validate the implementation-free custom-tabs Web branch inside adaptive tabs. */
-function isCustomTabsWebConfig(value: unknown): boolean {
-  return (
-    isRecord(value) && value.implementation === undefined && isCustomTabsPresentationConfig(value)
-  );
-}
-
-/*** Validate custom-tab presentation and its conditional serializable configuration. */
-function isCustomTabsPresentationConfig(value: Record<string, unknown>): boolean {
-  if (
-    typeof value.presentation !== 'string' ||
-    !CUSTOM_TABS_PRESENTATION_SET.has(value.presentation)
-  ) {
-    return false;
-  }
-
-  if (value.responsive !== undefined && !isResponsiveTabsPresentation(value.responsive)) {
-    return false;
-  }
-
-  if (!isOptionalString(value.customPresentationId)) return false;
-  if (value.presentation === 'responsive' && value.responsive === undefined) return false;
-
-  return (
-    value.presentation !== 'custom' ||
-    (typeof value.customPresentationId === 'string' && value.customPresentationId.length > 0)
-  );
-}
-
-/*** Validate semantic compact/medium/expanded custom-tab presentation mapping. */
-function isResponsiveTabsPresentation(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    typeof value.compact === 'string' &&
-    FIXED_CUSTOM_TABS_PRESENTATION_SET.has(value.compact) &&
-    (value.medium === undefined ||
-      (typeof value.medium === 'string' && FIXED_CUSTOM_TABS_PRESENTATION_SET.has(value.medium))) &&
-    typeof value.expanded === 'string' &&
-    FIXED_CUSTOM_TABS_PRESENTATION_SET.has(value.expanded)
-  );
-}
-
-/*** Validate optional app-level navigator flow intent. */
-function isNavigatorFlows(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    isOptionalBoolean(value.onboarding) &&
-    isOptionalBoolean(value.authentication)
-  );
-}
-
-/*** Validate package-owned navigator defaults without requiring a navigator node type. */
-function isNavigatorDefaults(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    (value.tabs === undefined || (isRecord(value.tabs) && isTabsImplementationConfig(value.tabs)))
-  );
-}
-
-/*** Validate per-platform navigator implementation overrides. */
-function isNavigatorPlatforms(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    (value.android === undefined || isNavigatorPlatformConfig(value.android)) &&
-    (value.ios === undefined || isNavigatorPlatformConfig(value.ios)) &&
-    (value.web === undefined || isNavigatorPlatformConfig(value.web))
-  );
-}
-
-/*** Validate one platform-specific navigator override slice. */
-function isNavigatorPlatformConfig(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    (value.tabs === undefined || (isRecord(value.tabs) && isTabsImplementationConfig(value.tabs)))
   );
 }
 

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -80,7 +80,7 @@ describe('contracts', () => {
   });
 
   it('exports stable platform constants', () => {
-    expect(NAVIGATOR_TYPES).toEqual(['stack', 'tabs', 'drawer']);
+    expect(NAVIGATOR_TYPES).toEqual(['slot', 'stack', 'tabs', 'drawer', 'split-view', 'custom']);
     expect(APP_CATEGORIES).toEqual([
       'books_reading',
       'business_productivity',

--- a/src/navigator-validation.test.ts
+++ b/src/navigator-validation.test.ts
@@ -1,0 +1,153 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'bun:test';
+
+import { isAppNavigatorManifest } from './appManifest/screens';
+import type {
+  CustomNavigatorNode,
+  CustomTabsConfig,
+  NavigatorNode,
+  StackImplementationConfig,
+} from './navigator';
+
+describe('app navigator manifest type discrimination', () => {
+  it('prevents incompatible options and non-serializable configuration at compile time', () => {
+    // @ts-expect-error Slot does not own an arbitrary options bag.
+    const slot: NavigatorNode = { type: 'slot', options: { arbitrary: true }, routes: [] };
+    // @ts-expect-error Experimental Stack has no presentation options.
+    const experimental: StackImplementationConfig = {
+      implementation: 'experimental',
+      options: { presentation: 'modal' },
+    };
+    // @ts-expect-error Fixed custom tabs do not accept a registered custom presentation id.
+    const tabs: CustomTabsConfig = {
+      implementation: 'custom',
+      presentation: 'sidebar',
+      customPresentationId: 'workspace-tabs',
+    };
+    // @ts-expect-error Custom navigator configuration must be serializable manifest values.
+    const custom: CustomNavigatorNode = {
+      type: 'custom',
+      navigatorId: 'workspace',
+      config: { callback: () => undefined },
+      routes: [],
+    };
+
+    expect([slot, experimental, tabs, custom]).toHaveLength(4);
+  });
+});
+
+describe('app navigator manifest stack validation', () => {
+  it('rejects the removed untyped options bag and unsupported stack branch fields', () => {
+    expect(isAppNavigatorManifest({ type: 'slot', options: { arbitrary: true }, routes: [] })).toBe(
+      false,
+    );
+    expect(
+      isAppNavigatorManifest({
+        type: 'stack',
+        implementation: 'experimental',
+        options: { presentation: 'modal' },
+        routes: [],
+      }),
+    ).toBe(false);
+    expect(
+      isAppNavigatorManifest({
+        type: 'stack',
+        implementation: 'javascript',
+        options: { presentation: 'formSheet' },
+        routes: [],
+      }),
+    ).toBe(false);
+    expect(
+      isAppNavigatorManifest({
+        type: 'stack',
+        implementation: 'native',
+        minimizeBehavior: 'never',
+        routes: [],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('app navigator manifest sheet validation', () => {
+  it('validates native form-sheet detents and their presentation discriminant', () => {
+    for (const sheetAllowedDetents of [[], [0.8, 0.4], [0.4, 0.4], [0], [1.1], [Number.NaN]]) {
+      expect(
+        isAppNavigatorManifest({
+          type: 'stack',
+          options: { presentation: 'formSheet', sheetAllowedDetents },
+          routes: [],
+        }),
+      ).toBe(false);
+    }
+    expect(
+      isAppNavigatorManifest({
+        type: 'stack',
+        options: { presentation: 'modal', sheetGrabberVisible: true },
+        routes: [],
+      }),
+    ).toBe(false);
+    expect(
+      isAppNavigatorManifest({
+        type: 'stack',
+        routes: [
+          {
+            name: 'compose',
+            stackOptions: {
+              presentation: 'formSheet',
+              sheetAllowedDetents: 'fitToContents',
+            },
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('app navigator manifest custom validation', () => {
+  it('rejects non-JSON and cyclic custom navigator configuration', () => {
+    const cyclicConfig: Record<string, unknown> = {};
+    cyclicConfig.self = cyclicConfig;
+
+    for (const invalidConfig of [
+      { callback: () => undefined },
+      { token: Symbol('token') },
+      { count: Number.NaN },
+      { count: Number.POSITIVE_INFINITY },
+      cyclicConfig,
+    ]) {
+      expect(
+        isAppNavigatorManifest({
+          type: 'custom',
+          navigatorId: 'workspace',
+          config: invalidConfig,
+          routes: [],
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it('rejects incomplete Split View bindings', () => {
+    expect(
+      isAppNavigatorManifest({
+        type: 'split-view',
+        columns: {},
+        routes: [],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('app navigator manifest package boundary', () => {
+  it('publishes the focused navigator contract subpath', async () => {
+    const packageJson = JSON.parse(await readFile(join(process.cwd(), 'package.json'), 'utf8')) as {
+      exports?: Record<string, { default?: string; types?: string }>;
+    };
+
+    expect(packageJson.exports?.['./navigator']).toEqual({
+      types: './dist/navigator.d.ts',
+      default: './dist/navigator.js',
+    });
+  });
+});

--- a/src/navigator.test.ts
+++ b/src/navigator.test.ts
@@ -1,12 +1,12 @@
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
-
 import { describe, expect, it } from 'bun:test';
 
 import { isAppNavigatorManifest } from './appManifest/screens';
 import {
   type AppNavigatorManifest,
   NAVIGATOR_PRESETS,
+  NAVIGATOR_TYPES,
+  type NavigatorNode,
+  type StackImplementationConfig,
   type TabsNavigatorConfig,
 } from './navigator';
 
@@ -28,8 +28,66 @@ function createAdaptiveTabs(): AppNavigatorManifest {
   };
 }
 
+const VALID_NAVIGATOR_NODES = [
+  { type: 'slot', routes: [] },
+  {
+    type: 'stack',
+    implementation: 'native',
+    options: {
+      presentation: 'formSheet',
+      sheetAllowedDetents: [0.4, 0.8],
+      sheetGrabberVisible: true,
+    },
+    routes: [],
+  },
+  {
+    type: 'stack',
+    implementation: 'javascript',
+    options: { presentation: 'transparentModal', headerShown: false },
+    routes: [],
+  },
+  {
+    type: 'stack',
+    implementation: 'experimental',
+    options: { title: 'Profile', headerTransparent: true },
+    routes: [],
+  },
+  {
+    type: 'tabs',
+    implementation: 'native',
+    minimizeBehavior: 'onScrollDown',
+    bottomAccessory: { screenId: 'now-playing' },
+    routes: [],
+  },
+  {
+    type: 'drawer',
+    options: { drawerPosition: 'right', drawerType: 'permanent', swipeEnabled: false },
+    routes: [],
+  },
+  {
+    type: 'split-view',
+    columns: {
+      primary: { screenId: 'sidebar' },
+      supplementary: { screenId: 'inspector-list' },
+    },
+    inspector: { screenId: 'inspector' },
+    topColumnForCollapsing: 'secondary',
+    routes: [{ name: 'detail', screenId: 'detail' }],
+  },
+  {
+    type: 'custom',
+    navigatorId: 'workspace',
+    config: { animation: 'spring', thresholds: [0.25, 0.75], enabled: true },
+    routes: [],
+  },
+] as const satisfies readonly NavigatorNode[];
+
 describe('app navigator manifest topology', () => {
   it('keeps canonical topology presets finite and authorable', () => {
+    expect(NAVIGATOR_TYPES).toEqual(['slot', 'stack', 'tabs', 'drawer', 'split-view', 'custom']);
+    expect(NAVIGATOR_PRESETS).toContain('slot');
+    expect(NAVIGATOR_PRESETS).toContain('split-view');
+    expect(NAVIGATOR_PRESETS).toContain('custom');
     expect(NAVIGATOR_PRESETS).toContain('root-stack-tabs-stack');
     expect(NAVIGATOR_PRESETS).toContain('root-stack-drawer-tabs-stack');
   });
@@ -66,6 +124,31 @@ describe('app navigator manifest topology', () => {
     const navigator: AppNavigatorManifest = { ...tabs, routes: [] };
 
     expect(isAppNavigatorManifest(navigator)).toBe(true);
+  });
+});
+
+describe('app navigator manifest node variants', () => {
+  it('accepts every typed navigator node variant', () => {
+    expect(VALID_NAVIGATOR_NODES.every(isAppNavigatorManifest)).toBe(true);
+  });
+
+  it('accepts stack defaults and per-platform implementation overrides', () => {
+    const experimental = {
+      implementation: 'experimental',
+      options: { headerShown: false },
+    } as const satisfies StackImplementationConfig;
+
+    expect(
+      isAppNavigatorManifest({
+        type: 'stack',
+        routes: [],
+        defaults: { stack: { implementation: 'native' } },
+        platforms: {
+          ios: { stack: experimental },
+          web: { stack: { implementation: 'javascript', options: { presentation: 'card' } } },
+        },
+      }),
+    ).toBe(true);
   });
 });
 
@@ -112,6 +195,50 @@ describe('app navigator manifest custom presentation', () => {
   });
 });
 
+describe('app navigator manifest tabs branch validation', () => {
+  it('rejects fields from incompatible tab branches', () => {
+    expect(
+      isAppNavigatorManifest({
+        type: 'tabs',
+        implementation: 'native',
+        presentation: 'bottom',
+        routes: [],
+      }),
+    ).toBe(false);
+
+    expect(
+      isAppNavigatorManifest({
+        type: 'tabs',
+        implementation: 'javascript',
+        presentation: 'bottom',
+        native: { implementation: 'native' },
+        routes: [],
+      }),
+    ).toBe(false);
+
+    expect(
+      isAppNavigatorManifest({
+        type: 'tabs',
+        implementation: 'custom',
+        presentation: 'sidebar',
+        customPresentationId: 'must-not-apply',
+        routes: [],
+      }),
+    ).toBe(false);
+
+    expect(
+      isAppNavigatorManifest({
+        type: 'tabs',
+        implementation: 'custom',
+        presentation: 'custom',
+        customPresentationId: 'workspace-tabs',
+        responsive: { compact: 'bottom', expanded: 'sidebar' },
+        routes: [],
+      }),
+    ).toBe(false);
+  });
+});
+
 describe('app navigator manifest composition', () => {
   it('keeps nested topology separate from app-level flow metadata', () => {
     expect(
@@ -131,14 +258,30 @@ describe('app navigator manifest composition', () => {
     ).toBe(true);
   });
 
-  it('publishes the focused navigator contract subpath', async () => {
-    const packageJson = JSON.parse(await readFile(join(process.cwd(), 'package.json'), 'utf8')) as {
-      exports?: Record<string, { default?: string; types?: string }>;
-    };
+  it('preserves authored route names, labels, paths, guards, and visibility without inference', () => {
+    const navigator = {
+      type: 'stack',
+      routes: [
+        {
+          name: '(app)',
+          label: 'Application',
+          guards: ['authenticated'],
+          showInPrimaryNavigation: false,
+          navigator: {
+            type: 'tabs',
+            routes: [{ name: 'learn', path: '/learn', label: 'Train', screenId: 'learn' }],
+          },
+        },
+      ],
+    } as const satisfies AppNavigatorManifest;
 
-    expect(packageJson.exports?.['./navigator']).toEqual({
-      types: './dist/navigator.d.ts',
-      default: './dist/navigator.js',
+    expect(isAppNavigatorManifest(navigator)).toBe(true);
+    expect(JSON.parse(JSON.stringify(navigator))).toEqual(navigator);
+    expect(navigator.routes[0].navigator.routes[0]).toEqual({
+      name: 'learn',
+      path: '/learn',
+      label: 'Train',
+      screenId: 'learn',
     });
   });
 });

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -1,9 +1,10 @@
-import type { IconSpec } from './types';
+import type { IconSpec, ManifestValue } from './types';
 
-export const NAVIGATOR_TYPES = ['stack', 'tabs', 'drawer'] as const;
+export const NAVIGATOR_TYPES = ['slot', 'stack', 'tabs', 'drawer', 'split-view', 'custom'] as const;
 export type NavigatorType = (typeof NAVIGATOR_TYPES)[number];
 
 export const NAVIGATOR_PRESETS = [
+  'slot',
   'stack',
   'tabs',
   'tabs-stack',
@@ -17,8 +18,81 @@ export const NAVIGATOR_PRESETS = [
   'root-stack-drawer-stack',
   'root-stack-drawer-tabs',
   'root-stack-drawer-tabs-stack',
+  'split-view',
+  'custom',
 ] as const;
 export type NavigatorPreset = (typeof NAVIGATOR_PRESETS)[number];
+
+export const STACK_IMPLEMENTATIONS = ['native', 'javascript', 'experimental'] as const;
+export type StackImplementation = (typeof STACK_IMPLEMENTATIONS)[number];
+
+export const STACK_PRESENTATIONS = [
+  'card',
+  'modal',
+  'transparentModal',
+  'containedModal',
+  'containedTransparentModal',
+  'fullScreenModal',
+  'formSheet',
+] as const;
+export type StackPresentation = (typeof STACK_PRESENTATIONS)[number];
+
+export const JAVASCRIPT_STACK_PRESENTATIONS = ['card', 'modal', 'transparentModal'] as const;
+export type JavaScriptStackPresentation = (typeof JAVASCRIPT_STACK_PRESENTATIONS)[number];
+
+export interface StackHeaderOptions {
+  title?: string;
+  headerShown?: boolean;
+  headerTransparent?: boolean;
+  headerBackVisible?: boolean;
+}
+
+export type StackScreenOptions = StackHeaderOptions &
+  (
+    | {
+        presentation?: Exclude<StackPresentation, 'formSheet'>;
+        sheetAllowedDetents?: never;
+        sheetGrabberVisible?: never;
+      }
+    | {
+        presentation: 'formSheet';
+        sheetAllowedDetents?: 'fitToContents' | number[];
+        sheetGrabberVisible?: boolean;
+      }
+  );
+
+export type JavaScriptStackScreenOptions = StackHeaderOptions & {
+  presentation?: JavaScriptStackPresentation;
+};
+
+export type StackImplementationConfig =
+  | {
+      /** Omission selects the stable native stack implementation. */
+      implementation?: 'native';
+      options?: StackScreenOptions;
+    }
+  | {
+      implementation: 'javascript';
+      options?: JavaScriptStackScreenOptions;
+    }
+  | {
+      /** Expo Router Experimental Stack is alpha, native-only, and available from SDK 56. */
+      implementation: 'experimental';
+      options?: StackHeaderOptions;
+    };
+
+export const DRAWER_POSITIONS = ['left', 'right'] as const;
+export type DrawerPosition = (typeof DRAWER_POSITIONS)[number];
+
+export const DRAWER_TYPES = ['front', 'back', 'slide', 'permanent'] as const;
+export type DrawerType = (typeof DRAWER_TYPES)[number];
+
+export interface DrawerNavigatorOptions {
+  drawerPosition?: DrawerPosition;
+  drawerType?: DrawerType;
+  swipeEnabled?: boolean;
+  headerShown?: boolean;
+}
 
 export const FIXED_CUSTOM_TABS_PRESENTATIONS = ['bottom', 'top', 'rail', 'sidebar'] as const;
 export type FixedCustomTabsPresentation = (typeof FIXED_CUSTOM_TABS_PRESENTATIONS)[number];
@@ -33,22 +107,54 @@ export type CustomTabsPresentation = (typeof CUSTOM_TABS_PRESENTATIONS)[number];
 export const JAVASCRIPT_TABS_PRESENTATIONS = ['bottom', 'top'] as const;
 export type JavaScriptTabsPresentation = (typeof JAVASCRIPT_TABS_PRESENTATIONS)[number];
 
+export const NATIVE_TABS_MINIMIZE_BEHAVIORS = [
+  'automatic',
+  'never',
+  'onScrollDown',
+  'onScrollUp',
+] as const;
+export type NativeTabsMinimizeBehavior = (typeof NATIVE_TABS_MINIMIZE_BEHAVIORS)[number];
+
 export interface ResponsiveTabsPresentation {
   compact: FixedCustomTabsPresentation;
   medium?: FixedCustomTabsPresentation;
   expanded: FixedCustomTabsPresentation;
 }
 
-export interface CustomTabsConfig {
+export type CustomTabsPresentationConfig =
+  | {
+      presentation: FixedCustomTabsPresentation;
+      responsive?: never;
+      customPresentationId?: never;
+    }
+  | {
+      presentation: 'responsive';
+      responsive: ResponsiveTabsPresentation;
+      customPresentationId?: never;
+    }
+  | {
+      presentation: 'custom';
+      responsive?: never;
+      /** Serializable registered presentation id. */
+      customPresentationId: string;
+    };
+
+export type CustomTabsConfig = {
   implementation: 'custom';
-  presentation: CustomTabsPresentation;
-  responsive?: ResponsiveTabsPresentation;
-  /** Serializable registered presentation id used when `presentation` is `custom`. */
-  customPresentationId?: string;
+} & CustomTabsPresentationConfig;
+
+export type CustomTabsWebConfig = CustomTabsPresentationConfig;
+
+export interface NavigatorScreenReference {
+  screenId: string;
 }
 
 export interface NativeTabsConfig {
   implementation: 'native';
+  /** Expo Router Native Tabs is alpha; minimizing is available on iOS 26+ from SDK 55. */
+  minimizeBehavior?: NativeTabsMinimizeBehavior;
+  /** Registered screen rendered through NativeTabs.BottomAccessory, available from SDK 55. */
+  bottomAccessory?: NavigatorScreenReference;
 }
 
 export interface JavaScriptTabsConfig {
@@ -62,7 +168,7 @@ export interface AdaptiveTabsConfig {
   /** Android/iOS branch. Expo Router may expose this implementation as unstable. */
   native?: NativeTabsConfig;
   /** Web branch rendered through headless custom tabs. */
-  web?: Omit<CustomTabsConfig, 'implementation'>;
+  web?: CustomTabsWebConfig;
 }
 
 export type TabsImplementationConfig =
@@ -71,16 +177,19 @@ export type TabsImplementationConfig =
 interface NavigatorNodeBase {
   initialRouteName?: string;
   routes: RouteDefinition[];
-  /** Typed upstream options can be layered by the owning Navigator package. */
-  options?: Record<string, unknown>;
 }
 
-export interface StackNavigatorNode extends NavigatorNodeBase {
-  type: 'stack';
+export interface SlotNavigatorNode extends NavigatorNodeBase {
+  type: 'slot';
 }
+
+export type StackNavigatorNode = NavigatorNodeBase & {
+  type: 'stack';
+} & StackImplementationConfig;
 
 export interface DrawerNavigatorNode extends NavigatorNodeBase {
   type: 'drawer';
+  options?: DrawerNavigatorOptions;
 }
 
 export type TabsNavigatorConfig = {
@@ -89,7 +198,30 @@ export type TabsNavigatorConfig = {
 
 export type TabsNavigatorNode = NavigatorNodeBase & TabsNavigatorConfig;
 
-export type NavigatorNode = DrawerNavigatorNode | StackNavigatorNode | TabsNavigatorNode;
+export interface SplitViewNavigatorNode extends NavigatorNodeBase {
+  type: 'split-view';
+  columns: {
+    primary: NavigatorScreenReference;
+    supplementary?: NavigatorScreenReference;
+  };
+  inspector?: NavigatorScreenReference;
+  /** Split View is alpha and iOS-only; other platforms fall back to Slot. */
+  topColumnForCollapsing?: 'primary' | 'supplementary' | 'secondary';
+}
+
+export interface CustomNavigatorNode extends NavigatorNodeBase {
+  type: 'custom';
+  navigatorId: string;
+  config?: Readonly<Record<string, ManifestValue>>;
+}
+
+export type NavigatorNode =
+  | CustomNavigatorNode
+  | DrawerNavigatorNode
+  | SlotNavigatorNode
+  | SplitViewNavigatorNode
+  | StackNavigatorNode
+  | TabsNavigatorNode;
 
 export interface RouteDefinition {
   name: string;
@@ -100,6 +232,8 @@ export interface RouteDefinition {
   showInPrimaryNavigation?: boolean;
   guards?: string[];
   screenId?: string;
+  /** Presentation applied by the resolved parent stack implementation. */
+  stackOptions?: StackScreenOptions;
   navigator?: NavigatorNode;
 }
 
@@ -110,10 +244,12 @@ export interface NavigatorFlows {
 
 export interface NavigatorDefaults {
   tabs?: TabsImplementationConfig;
+  stack?: StackImplementationConfig;
 }
 
 export interface NavigatorPlatformConfig {
   tabs?: TabsImplementationConfig;
+  stack?: StackImplementationConfig;
 }
 
 export interface NavigatorPlatforms {


### PR DESCRIPTION
## Summary

- extend `AppNavigatorManifest` with serializable Slot, typed Stack, Drawer, Tabs, Split View, and registered Custom navigator variants
- replace the arbitrary navigator `options` bag with finite implementation-specific options and strict presentation discriminants
- validate unknown input for every variant, including sorted sheet detents, incompatible branches, screen references, and acyclic finite JSON custom configuration
- preserve route name, path, label, icon, guards, visibility, screen id, and nested topology without inferring public URL segments
- regenerate Paradox public API documentation and add a major Changeset

## Ownership and integration gates

Contracts owns only the portable types and structural parser. This change imports no Expo or React runtime, embeds no UI tree, and keeps `AppManifest.navigator` as the directly consumable manifest slice.

The consumer audit found no authored values using the removed arbitrary `options` bag. Studio currently preserves that property generically, so the major release prevents its existing `^10` range from updating automatically; `ankhorage/navigator#35` owns runtime resolution and `ankhorage/studio#415` owns the Studio migration after this release.

## Upstream support matrix frozen in this contract

| Contract branch | Upstream status represented structurally |
|---|---|
| Slot | standard Expo Router layout and non-iOS Split View fallback |
| Native Stack | stable Stack presentations, including typed form-sheet detents |
| JavaScript Stack | React Navigation-compatible card, modal, and transparent modal subset |
| Experimental Stack | Expo alpha from SDK 56 on Android/iOS; only title and the three supported header booleans |
| Native Tabs | Expo alpha from SDK 54; `minimizeBehavior` from SDK 55 on iOS 26+; bottom accessory from SDK 55 |
| Split View | Expo alpha, iOS-only, Slot fallback elsewhere; nesting/readiness remains Navigator-owned |
| Custom | registered navigator id plus JSON-safe configuration; no component or callback values |

SDK/platform readiness, registry existence, Split View nesting, platform overrides, and mixed-stack restrictions remain semantic checks for the standalone Navigator package.

## Verification

- `bun run build`
- `bunx @ankhorage/ankh doctor validate .`
- `bun run lint`
- `bun run format:check`
- `bun run knip:check`
- `bun run test` (129 passing)
- `bun run typecheck`
- `bun run changeset:status` (major)
- `bun run docs`
- `npm pack --dry-run --json --cache /tmp/ankhorage-contracts-npm-cache`
- Bun import acceptance for root and `./navigator` build outputs

Closes #176
Parent: ankhorage/navigator#34
