### PR TITLE
chore(release): version contracts package

### DIFF
--- a/.changeset/navigator-runtime-contracts.md
+++ b/.changeset/navigator-runtime-contracts.md
@@ -1,5 +1,0 @@
----
-'@ankhorage/contracts': minor
----
-
-Expose the portable Navigator planning, generation, and custom-registration contracts through the navigator subpath. Group related declarations by topic so Navigator and Studio can consume canonical shared types without depending on another capability's type exports.

--- a/.changeset/renovate-165.md
+++ b/.changeset/renovate-165.md
@@ -1,4 +1,0 @@
----
----
-
-Update Ankhorage dependencies: `@ankhorage/devtools`.

--- a/.changeset/renovate-185.md
+++ b/.changeset/renovate-185.md
@@ -1,4 +1,0 @@
----
----
-
-Update Ankhorage dependencies: `@ankhorage/devtools`.

--- a/.changeset/renovate-188.md
+++ b/.changeset/renovate-188.md
@@ -1,4 +1,0 @@
----
----
-
-Update Ankhorage dependencies: `@ankhorage/devtools`.

--- a/.changeset/renovate-191.md
+++ b/.changeset/renovate-191.md
@@ -1,4 +1,0 @@
----
----
-
-Update Ankhorage dependencies: `@ankhorage/devtools`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,13 @@ jobs:
       - name: Check changesets
         if: github.event_name == 'pull_request'
         run: |
-          if node -e "const p=require('./package.json'); process.exit(p.scripts?.['changeset:status'] ? 0 : 1)"; then
+          base_version="$(git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")"
+          current_version="$(node -p "require('./package.json').version")"
+          consumed_changesets="$(git diff --name-status origin/main...HEAD -- .changeset | awk '$1 == "D" { count++ } END { print count + 0 }')"
+
+          if [ "$base_version" != "$current_version" ] && [ "$consumed_changesets" -gt 0 ]; then
+            echo "Version PR consumes $consumed_changesets changeset(s): $base_version -> $current_version"
+          elif node -e "const p=require('./package.json'); process.exit(p.scripts?.['changeset:status'] ? 0 : 1)"; then
             bun run changeset:status
           else
             echo "No changeset:status script found; skipping."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ankhorage/contracts
 
+## 11.1.0
+
+### Minor Changes
+
+- 8a62b08: Expose the portable Navigator planning, generation, and custom-registration contracts through the navigator subpath. Group related declarations by topic so Navigator and Studio can consume canonical shared types without depending on another capability's type exports.
+
 ## 11.0.0
 
 ### Major Changes

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # CONTRACTS
 
-![license: MIT](././paradox/badges/license.svg) ![npm: v11.0.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
+![license: MIT](././paradox/badges/license.svg) ![npm: v11.1.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
 
 Serializable app, action, theme, auth, and secret-store contracts for Ankhorage.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ankhorage/contracts",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "main": "./dist/index.js",
   "ankh": {
     "category": "contracts",

--- a/paradox/badges/npm.svg
+++ b/paradox/badges/npm.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="97" height="20" role="img" aria-label="npm: v11.0.0">
-<title>npm: v11.0.0</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="97" height="20" role="img" aria-label="npm: v11.1.0">
+<title>npm: v11.1.0</title>
 <rect width="38" height="20" fill="#374151"/>
 <rect x="38" width="59" height="20" fill="#cb3837"/>
 <text x="19" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">npm</text>
-<text x="67.5" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v11.0.0</text>
+<text x="67.5" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v11.1.0</text>
 </svg>

--- a/paradox/paradox.json
+++ b/paradox/paradox.json
@@ -14,7 +14,7 @@
     {
       "id": "npm",
       "label": "npm",
-      "value": "v11.0.0",
+      "value": "v11.1.0",
       "color": "cb3837"
     },
     {


### PR DESCRIPTION
## Summary

Apply the existing Contracts changesets through the repository's standard versioning command. This produces `@ankhorage/contracts@11.1.0`, records the Navigator contract additions in the changelog, and consumes the applied changeset files.

This PR is required because the automatic release run after ankhorage/contracts#190 was blocked by protected `main`: direct pushes are rejected and changes must pass through a pull request with the required `validate` check.

The CI changeset step now recognizes a version PR only when the package version differs from `origin/main` and the PR deletes already-applied changesets. Ordinary code PRs continue to run `changeset:status`. This resolves the circular rejection of repository-generated version PRs without changing branch protection or weakening normal changeset enforcement.

Related:
- https://github.com/ankhorage/contracts/pull/190
- https://github.com/ankhorage/navigator/pull/82
- https://github.com/ankhorage/studio/pull/443
- https://github.com/ankhorage/navigator/issues/65

Skills loaded: `ankhorage-project-structure` and its required `ankhorage-coding-rules` skill. No skill content is changed.
Recommended Codex review: GPT-5.6 Sol, high reasoning.

## Validation

- `bun install --frozen-lockfile`
- `bun run version-packages`
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run knip:check`
- `bun run test`: 131 passed
- `bun run docs`
- `bun run format`
- `bun run format:check`
- `bun pm pack --quiet --filename ../contracts-11.1.0-review.tgz`
- `git diff --check`
- Local version-PR CI condition: `11.0.0 -> 11.1.0`, five applied changesets consumed

## Review

Ready for human review. Do not merge or publish automatically from this task.
