### PR TITLE
chore(release): version contracts package

### DIFF
--- a/.changeset/align-navigator-lifecycle.md
+++ b/.changeset/align-navigator-lifecycle.md
@@ -1,8 +1,0 @@
----
-'@ankhorage/contracts': major
----
-
-Align the portable Navigator contract with the standalone catalog lifecycle: remove flow-specific
-manifest and runtime fields, name the headless Tabs implementation explicitly, normalize structural
-preset IDs, and add catalog, capability, dependency, planning, generation, and verification result
-types.

--- a/.changeset/renovate-194.md
+++ b/.changeset/renovate-194.md
@@ -1,4 +1,0 @@
----
----
-
-Update Ankhorage dependencies: `@ankhorage/devtools`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ankhorage/contracts
 
+## 12.0.0
+
+### Major Changes
+
+- 89dfb46: Align the portable Navigator contract with the standalone catalog lifecycle: remove flow-specific
+  manifest and runtime fields, name the headless Tabs implementation explicitly, normalize structural
+  preset IDs, and add catalog, capability, dependency, planning, generation, and verification result
+  types.
+
 ## 11.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ankhorage/contracts",
-  "version": "11.1.0",
+  "version": "12.0.0",
   "main": "./dist/index.js",
   "ankh": {
     "category": "contracts",


### PR DESCRIPTION
## Summary

Apply the merged Contracts changesets through the repository's standard versioning command. This produces `@ankhorage/contracts@12.0.0`, records the standalone Navigator lifecycle contract in the changelog, and consumes the applied changesets.

This PR is required because [Release run #171](https://github.com/ankhorage/contracts/actions/runs/34136225455) correctly created the version commit after #196, but protected `main` rejected the direct push: changes must pass through a pull request with the required `validate` check.

Related:

- #195
- #196
- ankhorage/navigator#79

Skills loaded: `ankhorage-project-structure`, its required `ankhorage-coding-rules`, and `hexagonal-architecture`. No skill content is changed.

Recommended Codex review: `gpt-5.6-sol`, reasoning `high`.

## Validation

- `bun install --frozen-lockfile`
- `bun run build`
- `bun test src` — 133 passed
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run knip:check`
- `bunx @ankhorage/ankh doctor validate .` — 0 errors, 0 warnings
- `bun pm pack --quiet --filename ../contracts-12.0.0-review.tgz`
- `git diff --check`

## Release

After merge, the normal Release workflow will find no remaining changesets to version and will publish the already-versioned `@ankhorage/contracts@12.0.0` package. Navigator #79 must wait for that registry artifact.