### PR TITLE
fix(navigator): export standalone manifest parser

### DIFF
--- a/.changeset/export-navigator-parser.md
+++ b/.changeset/export-navigator-parser.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': patch
+---
+
+Export the standalone AppNavigatorManifest structural type guard from the navigator contract.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # CONTRACTS
 
-![license: MIT](././paradox/badges/license.svg) ![npm: v11.1.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
+![license: MIT](././paradox/badges/license.svg) ![npm: v12.0.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
 
 Serializable app, action, theme, auth, and secret-store contracts for Ankhorage.
 

--- a/paradox/badges/npm.svg
+++ b/paradox/badges/npm.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="97" height="20" role="img" aria-label="npm: v11.1.0">
-<title>npm: v11.1.0</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="97" height="20" role="img" aria-label="npm: v12.0.0">
+<title>npm: v12.0.0</title>
 <rect width="38" height="20" fill="#374151"/>
 <rect x="38" width="59" height="20" fill="#cb3837"/>
 <text x="19" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">npm</text>
-<text x="67.5" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v11.1.0</text>
+<text x="67.5" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v12.0.0</text>
 </svg>

--- a/paradox/diagrams/export-graph.mmd
+++ b/paradox/diagrams/export-graph.mmd
@@ -735,6 +735,8 @@ graph LR
   module_src_appManifest_deploy_ts --> export_isAppDeployManifest
   export_isAppManifest["isAppManifest"]
   module_src_appManifest_ts --> export_isAppManifest
+  export_isAppNavigatorManifest["isAppNavigatorManifest"]
+  module_src_appManifest_navigator_ts --> export_isAppNavigatorManifest
   export_isMediaAssetReference["isMediaAssetReference"]
   module_src_media_ts --> export_isMediaAssetReference
   export_JAVASCRIPT_STACK_PRESENTATIONS["JAVASCRIPT_STACK_PRESENTATIONS"]

--- a/paradox/exports.json
+++ b/paradox/exports.json
@@ -134,7 +134,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 165,
+      "line": 167,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -1146,7 +1146,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 262,
+      "line": 264,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -4238,7 +4238,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 212,
+      "line": 214,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6904,7 +6904,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 84,
+      "line": 86,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -6922,7 +6922,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 87,
+      "line": 89,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -6940,7 +6940,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 190,
+      "line": 192,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -6987,7 +6987,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 90,
+      "line": 92,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7034,7 +7034,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 85,
+      "line": 87,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7052,7 +7052,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 88,
+      "line": 90,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7433,7 +7433,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 97,
+      "line": 99,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -7451,7 +7451,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 98,
+      "line": 100,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7556,7 +7556,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 100,
+      "line": 102,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -7574,7 +7574,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 142,
+      "line": 144,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7592,7 +7592,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 105,
+      "line": 107,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7610,7 +7610,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 124,
+      "line": 126,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7628,7 +7628,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 146,
+      "line": 148,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -7991,6 +7991,38 @@
     "structuredRows": []
   },
   {
+    "name": "isAppNavigatorManifest",
+    "description": "Validate the complete serialized `AppManifest.navigator` slice.",
+    "isReadme": false,
+    "examples": [],
+    "kind": "function",
+    "modulePath": "src/appManifest/navigator.ts",
+    "sourceLocation": {
+      "filePath": "src/appManifest/navigator.ts",
+      "line": 14,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [
+      {
+        "label": "(value: unknown) => boolean",
+        "parameters": [
+          {
+            "name": "value",
+            "type": "unknown",
+            "required": true,
+            "description": null
+          }
+        ],
+        "returnType": "boolean",
+        "returnDescription": null
+      }
+    ],
+    "members": [],
+    "structuredRows": []
+  },
+  {
     "name": "isMediaAssetReference",
     "description": null,
     "isReadme": false,
@@ -8031,7 +8063,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 40,
+      "line": 42,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -8049,7 +8081,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 107,
+      "line": 109,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -8067,7 +8099,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 41,
+      "line": 43,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8085,7 +8117,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 64,
+      "line": 66,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8103,7 +8135,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 160,
+      "line": 162,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8136,7 +8168,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 108,
+      "line": 110,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8839,7 +8871,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 110,
+      "line": 112,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -8857,7 +8889,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 152,
+      "line": 154,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8897,7 +8929,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 116,
+      "line": 118,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -8948,7 +8980,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 6,
+      "line": 8,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -8966,7 +8998,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 3,
+      "line": 5,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -9338,7 +9370,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 240,
+      "line": 242,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9656,7 +9688,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 218,
+      "line": 220,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9838,7 +9870,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 245,
+      "line": 247,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9871,7 +9903,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 250,
+      "line": 252,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -9929,7 +9961,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 24,
+      "line": 26,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10138,7 +10170,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 148,
+      "line": 150,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10182,7 +10214,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 4,
+      "line": 6,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10757,7 +10789,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 118,
+      "line": 120,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -10797,7 +10829,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 226,
+      "line": 228,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -11984,7 +12016,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 182,
+      "line": 184,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -12183,7 +12215,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 201,
+      "line": 203,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -12244,7 +12276,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 26,
+      "line": 28,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -12262,7 +12294,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 29,
+      "line": 31,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],
@@ -12280,7 +12312,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 43,
+      "line": 45,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -12327,7 +12359,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 27,
+      "line": 29,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -12345,7 +12377,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 68,
+      "line": 70,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -12363,7 +12395,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 186,
+      "line": 188,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -12381,7 +12413,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 38,
+      "line": 40,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -12399,7 +12431,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 50,
+      "line": 52,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -13841,7 +13873,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 174,
+      "line": 176,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -13859,7 +13891,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 195,
+      "line": 197,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],
@@ -13877,7 +13909,7 @@
     "modulePath": "src/navigator.ts",
     "sourceLocation": {
       "filePath": "src/navigator.ts",
-      "line": 199,
+      "line": 201,
       "column": 1
     },
     "exportPaths": ["src/index.ts"],

--- a/paradox/exports.md
+++ b/paradox/exports.md
@@ -44,7 +44,7 @@ Source: `src/data/refs.ts:15:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:165:1`
+Source: `src/navigator.ts:167:1`
 
 ### Members
 
@@ -358,7 +358,7 @@ Source: `src/appManifest.ts:16:1`
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:262:1`
+Source: `src/navigator.ts:264:1`
 
 ## AppSettings
 
@@ -1365,7 +1365,7 @@ Source: `src/navigator/extensions.ts:3:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:212:1`
+Source: `src/navigator.ts:214:1`
 
 ### Members
 
@@ -2177,19 +2177,19 @@ Source: `src/types.ts:168:1`
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:84:14`
+Source: `src/navigator.ts:86:14`
 
 ## DRAWER_TYPES
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:87:14`
+Source: `src/navigator.ts:89:14`
 
 ## DrawerNavigatorNode
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:190:1`
+Source: `src/navigator.ts:192:1`
 
 ### Members
 
@@ -2204,7 +2204,7 @@ Source: `src/navigator.ts:190:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:90:1`
+Source: `src/navigator.ts:92:1`
 
 ### Members
 
@@ -2219,13 +2219,13 @@ Source: `src/navigator.ts:90:1`
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:85:1`
+Source: `src/navigator.ts:87:1`
 
 ## DrawerType
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:88:1`
+Source: `src/navigator.ts:90:1`
 
 ## EndpointId
 
@@ -2332,13 +2332,13 @@ Source: `src/secrets.ts:183:1`
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:97:14`
+Source: `src/navigator.ts:99:14`
 
 ## FixedHeadlessTabsPresentation
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:98:1`
+Source: `src/navigator.ts:100:1`
 
 ## FORBIDDEN_INLINE_SECRET_FIELDS
 
@@ -2375,31 +2375,31 @@ Source: `src/data/apis.ts:35:1`
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:100:14`
+Source: `src/navigator.ts:102:14`
 
 ## HeadlessTabsConfig
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:142:1`
+Source: `src/navigator.ts:144:1`
 
 ## HeadlessTabsPresentation
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:105:1`
+Source: `src/navigator.ts:107:1`
 
 ## HeadlessTabsPresentationConfig
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:124:1`
+Source: `src/navigator.ts:126:1`
 
 ## HeadlessTabsWebConfig
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:146:1`
+Source: `src/navigator.ts:148:1`
 
 ## IconSpec
 
@@ -2505,6 +2505,20 @@ Source: `src/appManifest.ts:51:1`
   - value: `unknown`
   - returns: `boolean`
 
+## isAppNavigatorManifest
+
+Kind: `function`
+Module: `src/appManifest/navigator.ts`
+Source: `src/appManifest/navigator.ts:14:1`
+
+Validate the complete serialized `AppManifest.navigator` slice.
+
+### Signatures
+
+- `(value: unknown) => boolean`
+  - value: `unknown`
+  - returns: `boolean`
+
 ## isMediaAssetReference
 
 Kind: `function`
@@ -2521,31 +2535,31 @@ Source: `src/media.ts:58:1`
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:40:14`
+Source: `src/navigator.ts:42:14`
 
 ## JAVASCRIPT_TABS_PRESENTATIONS
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:107:14`
+Source: `src/navigator.ts:109:14`
 
 ## JavaScriptStackPresentation
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:41:1`
+Source: `src/navigator.ts:43:1`
 
 ## JavaScriptStackScreenOptions
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:64:1`
+Source: `src/navigator.ts:66:1`
 
 ## JavaScriptTabsConfig
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:160:1`
+Source: `src/navigator.ts:162:1`
 
 ### Members
 
@@ -2558,7 +2572,7 @@ Source: `src/navigator.ts:160:1`
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:108:1`
+Source: `src/navigator.ts:110:1`
 
 ## KnownAuthOAuthProviderId
 
@@ -2786,13 +2800,13 @@ Source: `src/types.ts:230:1`
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:110:14`
+Source: `src/navigator.ts:112:14`
 
 ## NativeTabsConfig
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:152:1`
+Source: `src/navigator.ts:154:1`
 
 ### Members
 
@@ -2806,7 +2820,7 @@ Source: `src/navigator.ts:152:1`
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:116:1`
+Source: `src/navigator.ts:118:1`
 
 ## NavigateAction
 
@@ -2825,13 +2839,13 @@ Source: `src/types.ts:36:1`
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:6:14`
+Source: `src/navigator.ts:8:14`
 
 ## NAVIGATOR_TYPES
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:3:14`
+Source: `src/navigator.ts:5:14`
 
 ## NavigatorAdapterId
 
@@ -2946,7 +2960,7 @@ Source: `src/navigator/catalog.ts:76:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:240:1`
+Source: `src/navigator.ts:242:1`
 
 ### Members
 
@@ -3052,7 +3066,7 @@ Source: `src/navigator/catalog.ts:32:1`
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:218:1`
+Source: `src/navigator.ts:220:1`
 
 ## NavigatorNodePlan
 
@@ -3096,7 +3110,7 @@ Source: `src/navigator/planning.ts:117:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:245:1`
+Source: `src/navigator.ts:247:1`
 
 ### Members
 
@@ -3109,7 +3123,7 @@ Source: `src/navigator.ts:245:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:250:1`
+Source: `src/navigator.ts:252:1`
 
 ### Members
 
@@ -3129,7 +3143,7 @@ Source: `src/navigator/catalog.ts:34:1`
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:24:1`
+Source: `src/navigator.ts:26:1`
 
 ## NavigatorPresetDescriptor
 
@@ -3194,7 +3208,7 @@ Source: `src/navigator/generation.ts:43:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:148:1`
+Source: `src/navigator.ts:150:1`
 
 ### Members
 
@@ -3212,7 +3226,7 @@ Source: `src/navigator/planning.ts:142:1`
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:4:1`
+Source: `src/navigator.ts:6:1`
 
 ## NavigatorValidationContext
 
@@ -3410,7 +3424,7 @@ Source: `src/navigator/planning.ts:19:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:118:1`
+Source: `src/navigator.ts:120:1`
 
 ### Members
 
@@ -3424,7 +3438,7 @@ Source: `src/navigator.ts:118:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:226:1`
+Source: `src/navigator.ts:228:1`
 
 ### Members
 
@@ -3819,7 +3833,7 @@ Source: `src/auth.ts:214:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:182:1`
+Source: `src/navigator.ts:184:1`
 
 ### Members
 
@@ -3884,7 +3898,7 @@ Source: `src/types.ts:283:1`
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:201:1`
+Source: `src/navigator.ts:203:1`
 
 ### Members
 
@@ -3901,19 +3915,19 @@ Source: `src/navigator.ts:201:1`
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:26:14`
+Source: `src/navigator.ts:28:14`
 
 ## STACK_PRESENTATIONS
 
 Kind: `value`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:29:14`
+Source: `src/navigator.ts:31:14`
 
 ## StackHeaderOptions
 
 Kind: `type`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:43:1`
+Source: `src/navigator.ts:45:1`
 
 ### Members
 
@@ -3928,31 +3942,31 @@ Source: `src/navigator.ts:43:1`
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:27:1`
+Source: `src/navigator.ts:29:1`
 
 ## StackImplementationConfig
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:68:1`
+Source: `src/navigator.ts:70:1`
 
 ## StackNavigatorNode
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:186:1`
+Source: `src/navigator.ts:188:1`
 
 ## StackPresentation
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:38:1`
+Source: `src/navigator.ts:40:1`
 
 ## StackScreenOptions
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:50:1`
+Source: `src/navigator.ts:52:1`
 
 ## StartOAuthAuthorizationInput
 
@@ -4426,19 +4440,19 @@ Source: `src/types.ts:236:1`
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:174:1`
+Source: `src/navigator.ts:176:1`
 
 ## TabsNavigatorConfig
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:195:1`
+Source: `src/navigator.ts:197:1`
 
 ## TabsNavigatorNode
 
 Kind: `unknown`
 Module: `src/navigator.ts`
-Source: `src/navigator.ts:199:1`
+Source: `src/navigator.ts:201:1`
 
 ## TabsNavigatorPlan
 

--- a/paradox/index.html
+++ b/paradox/index.html
@@ -252,7 +252,7 @@
             <li>
               <button class="nav-button" type="button" data-target="src/appManifest/navigator.ts">
                 src/appManifest/navigator.ts
-                <small>10 functions</small>
+                <small>12 functions</small>
               </button>
             </li>
             <li>
@@ -262,7 +262,7 @@
                 data-target="src/appManifest/navigatorOptions.ts"
               >
                 src/appManifest/navigatorOptions.ts
-                <small>19 functions</small>
+                <small>20 functions</small>
               </button>
             </li>
             <li>
@@ -303,7 +303,7 @@
           <section class="panel">
             <h2>Package overview</h2>
             <div class="summary">
-              <div><strong>473</strong><span class="muted">public exports</span></div>
+              <div><strong>474</strong><span class="muted">public exports</span></div>
               <div><strong>0</strong><span class="muted">components</span></div>
               <div><strong>45</strong><span class="muted">modules</span></div>
               <div><strong>1</strong><span class="muted">entrypoints</span></div>
@@ -788,7 +788,7 @@
             </article>
             <article
               class="item"
-              data-search="src/index.ts Action ActionType AdapterId AdapterKind AdapterRef AdaptiveTabsConfig AlertAction AnkhCapabilityId AnkhCommandCategory AnkhCommandDescriptor AnkhCommandProviderManifest ANKHORAGE_CAPABILITY_NAMES ANKHORAGE_PERMISSION_NAMES AnkhorageCapabilityName AnkhoragePermissionName AnkhPackageMetadata AnkhProviderReference ApiBaseDefinition ApiDefinition ApiDefinitionList ApiId ApiOrigin ApiProtocol APP_CATEGORIES APP_DEPLOY_ENVIRONMENT_IDS APP_DEPLOY_TARGET_IDS AppCategory AppDeployAndroidTargetConfig AppDeployEnvironmentId AppDeployIosTargetConfig AppDeployManifest AppDeployProviderSelection AppDeployTargetId AppDeployTargets AppDeployWebTargetConfig AppManifest AppManifestParseResult AppNavigatorManifest AppSettings AUTH_IDENTIFIER_KINDS AUTH_OAUTH_CANCELLATION_REASONS AUTH_OAUTH_ERROR_CODES AUTH_OAUTH_ERROR_STAGES AUTH_OAUTH_PROVIDER_IDS AUTH_OAUTH_SETUP_CALLBACK_ROLES AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS AUTH_OAUTH_TRANSPORT_ERROR_CODES AUTH_OAUTH_TRANSPORT_IDS AUTH_PROFILE_CREATE_STRATEGIES AUTH_PROFILE_FIELDS AUTH_PROFILE_PRIMARY_KEY_STRATEGIES AUTH_PROFILE_UPDATE_STRATEGIES AUTH_PROVIDERS AUTH_SCOPES AUTH_SIGN_IN_IDENTIFIERS AUTH_SIGN_UP_FIELDS AUTH_SIGN_UP_POLICIES AuthAdapter AuthAdapterCapabilities AuthAdapterError AuthFlowConfig AuthIdentifier AuthIdentifierKind AuthOAuthAdapter AuthOAuthAuthorizationRequest AuthOAuthAuthorizationResponse AuthOAuthCancellationReason AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthConfig AuthOAuthError AuthOAuthErrorCode AuthOAuthErrorStage AuthOAuthProviderConfig AuthOAuthProviderId AuthOAuthSetupCallbackRequirement AuthOAuthSetupCallbackRole AuthOAuthSetupCapabilities AuthOAuthSetupFieldPersistence AuthOAuthSetupFieldRequirement AuthOAuthSetupFieldSensitivity AuthOAuthSetupPlan AuthOAuthSetupRequirement AuthOAuthStartResult AuthOAuthTransportCancellationReason AuthOAuthTransportError AuthOAuthTransportErrorCode AuthOAuthTransportId AuthProfileCreateStrategy AuthProfileField AuthProfilePrimaryKeyStrategy AuthProfileSpec AuthProfileUpdateStrategy AuthProvider AuthProviderConfig AuthResult AuthScope AuthSession AuthSignInConfig AuthSignInIdentifier AuthSignInSpec AuthSignUpConfig AuthSignUpField AuthSignUpPolicy AuthSignUpSpec AuthSpec AuthUser AUTHZ_ENGINES AUTHZ_KINDS AuthzEngine AuthzKind AuthzSpec BindingCondition BindingConditionOperator BindingDataPath BindingFallback BindingInputMap BindingInputValue BindingLifecycleBehavior BindingLifecycleState BindingOperationRef BindingValue BindingValueExpression BindingValueSource BindingValueTransform ButtonPressEventDto CollectionItemPressEventDto CollectionItemPressPayload CompleteOAuthAuthorizationInput ComponentDataBinding ComponentDataBindingRegistry ComponentEventDto ComponentEventDtoKind ComponentEventPayloadValue ComponentInstanceId ComponentRequirements ComponentTypeId ConsoleAction CreateNavigatorPlanOptions CredentialId CredentialKind CredentialRef CustomNavigatorConfigIssue CustomNavigatorNode CustomNavigatorRegistration CustomNavigatorRegistry DATABASE_PROVIDERS DATABASE_TIERS DatabaseAdapterRef DatabaseDataSourceConfig DatabaseProvider DatabaseSpec DatabaseTier DataContractValue DataDiagnosticCode DataDiagnosticSeverity DataEndpointConfig DataEndpointKind DataEndpointRegistry DataOperationConfig DataOperationIntent DataOperationMethod DataOperationPagination DataOperationParameter DataOperationParameterLocation DataOperationProtocol DataOperationRegistry DataOperationRequest DataOperationResponse DataPath DataSchema DataSchemaPrimitiveType DataSchemaProperty DataSchemaRef DataSchemaRegistry DataSchemaSlot DataSourceConfig DataSourceDiagnostic DataSourceDiagnosticResult DataSourceId DataSourceKind DataSourceRegistry DbAdapter DbAdapterCapabilities DbAdapterError DbAdminAdapter DbAdminAdapterCapabilities DbAdminResult DbChangeEvent DbChangeKind DbChangeListener DbCollectionDefinition DbCollectionReference DbCollectionSubscriptionInput DbDeleteInput DbFieldDefinition DbFieldType DbFilter DbFilterOperator DbFindByIdInput DbInsertInput DbPage DbRealtimeAdapter DbRecord DbRecordSubscriptionInput DbResult DbSelectInput DbSort DbSortDirection DbSubscription DbSuccess DbTableInput DbUpdateInput DEFAULT_AUTH_FLOW DEPLOYMENT_TARGETS DeploymentSpec DeploymentTarget DRAWER_POSITIONS DRAWER_TYPES DrawerNavigatorNode DrawerNavigatorOptions DrawerPosition DrawerType EndpointId EventBinding EventBindingTarget ExpoRouterNavigatorModule ExternalGraphQlApiDefinition ExternalRestApiDefinition FilterAction findForbiddenInlineSecretFields FIXED_HEADLESS_TABS_PRESENTATIONS FixedHeadlessTabsPresentation FORBIDDEN_INLINE_SECRET_FIELDS FormSubmitEventDto FormSubmitValues GraphQlIntrospectionConfig HEADLESS_TABS_PRESENTATIONS HeadlessTabsConfig HeadlessTabsPresentation HeadlessTabsPresentationConfig HeadlessTabsWebConfig IconSpec ImageAssetSource ImageMetadata InfraManifest InfraSecretStoreSpec InternalRestApiDefinition isAppDeployManifest isAppManifest isMediaAssetReference JAVASCRIPT_STACK_PRESENTATIONS JAVASCRIPT_TABS_PRESENTATIONS JavaScriptStackPresentation JavaScriptStackScreenOptions JavaScriptTabsConfig JavaScriptTabsPresentation KnownAuthOAuthProviderId KnownAuthOAuthTransportId KnownAuthProfileField KnownAuthProvider KnownAuthSignUpField KnownComponentEventDto KnownDatabaseProvider KnownDeploymentTarget KnownSecretStoreProvider KnownStateProvider ManifestValue MEDIA_ASSET_KINDS MediaAsset MediaAssetKind MediaAssetMetadata MediaAssetReference MediaAssetRegistry MediaAssetSource MediaBundledSource MediaManifest MediaStorageAdapter MediaStorageSource MediaUrlSource NamedIconSpec NATIVE_TABS_MINIMIZE_BEHAVIORS NativeTabsConfig NativeTabsMinimizeBehavior NavigateAction NAVIGATOR_PRESETS NAVIGATOR_TYPES NavigatorAdapterId NavigatorAdapterPlan NavigatorApiStability NavigatorCapabilityDescriptor NavigatorCapabilityId NavigatorCapabilityRequirement NavigatorCapabilityTarget NavigatorCapabilityVerification NavigatorCatalog NavigatorDefaults NavigatorDependencyRequirement NavigatorDiagnostic NavigatorGeneratedFile NavigatorGenerationBindings NavigatorGenerationOptions NavigatorGenerationResult NavigatorImplementation NavigatorNode NavigatorNodePlan NavigatorPlan NavigatorPlatformConfig NavigatorPlatforms NavigatorPresentation NavigatorPreset NavigatorPresetDescriptor NavigatorResponsiveSize NavigatorRoutePlan NavigatorRuntimePlatform NavigatorScreenModule NavigatorScreenReference NavigatorSupportStatus NavigatorType NavigatorValidationContext NavigatorVerificationKind NavigatorVerificationStatus NetworkingSpec normalizeSecretRef normalizeSecretScope OpenApiDocumentRef OperationId OperationScreenDataLoaderDefinition parseAppManifest PasswordResetInput PropBinding RepositoryManifest resolveAuthFlow ResolvedHeadlessTabsPresentation ResolvedTabsImplementation ResolvedTabsPresentation ResponsiveTabsPresentation RouteDefinition RuntimeCallback RuntimeCallbackArgs RuntimeCallbackMap RuntimeNodePropsResolver RuntimeResolveNodePropsArgs SchemaId ScreenCapabilityRequirement ScreenDataLoaderDefinition ScreenPermissionRequirement ScreenRequirements ScreenSpec SearchAction SECRET_STORE_ERROR_CODES SECRET_STORE_PROVIDERS SecretCreateInput SecretGetMetadataInput SecretListInput SecretMetadata SecretPayload SecretRef SecretRemoveInput SecretReplaceInput SecretResolveInput SecretScope SecretStoreAdapter SecretStoreError SecretStoreErrorCode SecretStoreOkResult SecretStoreProvider SecretStoreResult SetLanguageAction SignInInput SignOutInput SignUpInput SlotNavigatorNode SplashScreenAssetSpec SplashScreenModeSpec SplashScreenResizeMode SplashScreenSpec SplitViewNavigatorNode STACK_IMPLEMENTATIONS STACK_PRESENTATIONS StackHeaderOptions StackImplementation StackImplementationConfig StackNavigatorNode StackPresentation StackScreenOptions StartOAuthAuthorizationInput STATE_PERSISTENCE_MODES STATE_PROVIDERS StateAdapter StateAdapterCapabilities StateAdapterError StateListener StatePath StatePersistenceMode StatePrimitive StateProvider StateResult StateSnapshot StateSpec StateSubscription StateSuccess StateValue STORAGE_PROVIDERS StorageAdapter StorageAdapterError StorageAssetReference StorageImageAssetSource StorageListAdapter StorageListInput StorageListResult StorageObjectMetadata StorageOkResult StorageProvider StoragePublicUrlInput StoragePublicUrlResult StorageRemoveInput StorageResolveAdapter StorageResolvedAccess StorageResolvedAsset StorageResolveInput StorageResolveResult StorageResult StorageSpec StorageUploadInput StorageUploadResult SvgIconSpec TabsImplementationConfig TabsNavigatorConfig TabsNavigatorNode TabsNavigatorPlan ThemeConfig ThemeGlobalTokenOverrides ThemeModeConfig ThemeNumericTokenOverrides ThemeRecipeFieldOverrides ThemeRecipeOverrides ThemeRecipeOverrideValue ThemeStringTokenOverrides ThemeTypographyHeadingOverrides ThemeTypographyTokenOverrides ToggleDarkModeAction UiBindableEventMeta UiBindableEventPayloadMeta UiBindablePropMeta UiBindableValueFieldMeta UiBindableValueMeta UiBindableValueType UiComponentBindingMeta UiComponentBlueprint UiComponentBlueprintIcon UiComponentCategory UiComponentEventMeta UiComponentEventPayloadFieldMeta UiComponentEventPayloadFieldType UiComponentEventPayloadKind UiComponentI18nFieldMeta UiComponentI18nMeta UiComponentMeta UiComponentMetaRegistry UiComponentPackageManifest UiComponentPropArrayItemSchema UiComponentPropSchema UiComponentPropType UiComponentPropValue UiComponentSlotMeta UiNode UiNodeRepeatSpec UrlImageAssetSource validateSecretPayload VerifyOtpInput"
+              data-search="src/index.ts Action ActionType AdapterId AdapterKind AdapterRef AdaptiveTabsConfig AlertAction AnkhCapabilityId AnkhCommandCategory AnkhCommandDescriptor AnkhCommandProviderManifest ANKHORAGE_CAPABILITY_NAMES ANKHORAGE_PERMISSION_NAMES AnkhorageCapabilityName AnkhoragePermissionName AnkhPackageMetadata AnkhProviderReference ApiBaseDefinition ApiDefinition ApiDefinitionList ApiId ApiOrigin ApiProtocol APP_CATEGORIES APP_DEPLOY_ENVIRONMENT_IDS APP_DEPLOY_TARGET_IDS AppCategory AppDeployAndroidTargetConfig AppDeployEnvironmentId AppDeployIosTargetConfig AppDeployManifest AppDeployProviderSelection AppDeployTargetId AppDeployTargets AppDeployWebTargetConfig AppManifest AppManifestParseResult AppNavigatorManifest AppSettings AUTH_IDENTIFIER_KINDS AUTH_OAUTH_CANCELLATION_REASONS AUTH_OAUTH_ERROR_CODES AUTH_OAUTH_ERROR_STAGES AUTH_OAUTH_PROVIDER_IDS AUTH_OAUTH_SETUP_CALLBACK_ROLES AUTH_OAUTH_SETUP_FIELD_PERSISTENCE_KINDS AUTH_OAUTH_SETUP_FIELD_SENSITIVITIES AUTH_OAUTH_TRANSPORT_CANCELLATION_REASONS AUTH_OAUTH_TRANSPORT_ERROR_CODES AUTH_OAUTH_TRANSPORT_IDS AUTH_PROFILE_CREATE_STRATEGIES AUTH_PROFILE_FIELDS AUTH_PROFILE_PRIMARY_KEY_STRATEGIES AUTH_PROFILE_UPDATE_STRATEGIES AUTH_PROVIDERS AUTH_SCOPES AUTH_SIGN_IN_IDENTIFIERS AUTH_SIGN_UP_FIELDS AUTH_SIGN_UP_POLICIES AuthAdapter AuthAdapterCapabilities AuthAdapterError AuthFlowConfig AuthIdentifier AuthIdentifierKind AuthOAuthAdapter AuthOAuthAuthorizationRequest AuthOAuthAuthorizationResponse AuthOAuthCancellationReason AuthOAuthCapabilities AuthOAuthCompletionResult AuthOAuthConfig AuthOAuthError AuthOAuthErrorCode AuthOAuthErrorStage AuthOAuthProviderConfig AuthOAuthProviderId AuthOAuthSetupCallbackRequirement AuthOAuthSetupCallbackRole AuthOAuthSetupCapabilities AuthOAuthSetupFieldPersistence AuthOAuthSetupFieldRequirement AuthOAuthSetupFieldSensitivity AuthOAuthSetupPlan AuthOAuthSetupRequirement AuthOAuthStartResult AuthOAuthTransportCancellationReason AuthOAuthTransportError AuthOAuthTransportErrorCode AuthOAuthTransportId AuthProfileCreateStrategy AuthProfileField AuthProfilePrimaryKeyStrategy AuthProfileSpec AuthProfileUpdateStrategy AuthProvider AuthProviderConfig AuthResult AuthScope AuthSession AuthSignInConfig AuthSignInIdentifier AuthSignInSpec AuthSignUpConfig AuthSignUpField AuthSignUpPolicy AuthSignUpSpec AuthSpec AuthUser AUTHZ_ENGINES AUTHZ_KINDS AuthzEngine AuthzKind AuthzSpec BindingCondition BindingConditionOperator BindingDataPath BindingFallback BindingInputMap BindingInputValue BindingLifecycleBehavior BindingLifecycleState BindingOperationRef BindingValue BindingValueExpression BindingValueSource BindingValueTransform ButtonPressEventDto CollectionItemPressEventDto CollectionItemPressPayload CompleteOAuthAuthorizationInput ComponentDataBinding ComponentDataBindingRegistry ComponentEventDto ComponentEventDtoKind ComponentEventPayloadValue ComponentInstanceId ComponentRequirements ComponentTypeId ConsoleAction CreateNavigatorPlanOptions CredentialId CredentialKind CredentialRef CustomNavigatorConfigIssue CustomNavigatorNode CustomNavigatorRegistration CustomNavigatorRegistry DATABASE_PROVIDERS DATABASE_TIERS DatabaseAdapterRef DatabaseDataSourceConfig DatabaseProvider DatabaseSpec DatabaseTier DataContractValue DataDiagnosticCode DataDiagnosticSeverity DataEndpointConfig DataEndpointKind DataEndpointRegistry DataOperationConfig DataOperationIntent DataOperationMethod DataOperationPagination DataOperationParameter DataOperationParameterLocation DataOperationProtocol DataOperationRegistry DataOperationRequest DataOperationResponse DataPath DataSchema DataSchemaPrimitiveType DataSchemaProperty DataSchemaRef DataSchemaRegistry DataSchemaSlot DataSourceConfig DataSourceDiagnostic DataSourceDiagnosticResult DataSourceId DataSourceKind DataSourceRegistry DbAdapter DbAdapterCapabilities DbAdapterError DbAdminAdapter DbAdminAdapterCapabilities DbAdminResult DbChangeEvent DbChangeKind DbChangeListener DbCollectionDefinition DbCollectionReference DbCollectionSubscriptionInput DbDeleteInput DbFieldDefinition DbFieldType DbFilter DbFilterOperator DbFindByIdInput DbInsertInput DbPage DbRealtimeAdapter DbRecord DbRecordSubscriptionInput DbResult DbSelectInput DbSort DbSortDirection DbSubscription DbSuccess DbTableInput DbUpdateInput DEFAULT_AUTH_FLOW DEPLOYMENT_TARGETS DeploymentSpec DeploymentTarget DRAWER_POSITIONS DRAWER_TYPES DrawerNavigatorNode DrawerNavigatorOptions DrawerPosition DrawerType EndpointId EventBinding EventBindingTarget ExpoRouterNavigatorModule ExternalGraphQlApiDefinition ExternalRestApiDefinition FilterAction findForbiddenInlineSecretFields FIXED_HEADLESS_TABS_PRESENTATIONS FixedHeadlessTabsPresentation FORBIDDEN_INLINE_SECRET_FIELDS FormSubmitEventDto FormSubmitValues GraphQlIntrospectionConfig HEADLESS_TABS_PRESENTATIONS HeadlessTabsConfig HeadlessTabsPresentation HeadlessTabsPresentationConfig HeadlessTabsWebConfig IconSpec ImageAssetSource ImageMetadata InfraManifest InfraSecretStoreSpec InternalRestApiDefinition isAppDeployManifest isAppManifest isAppNavigatorManifest isMediaAssetReference JAVASCRIPT_STACK_PRESENTATIONS JAVASCRIPT_TABS_PRESENTATIONS JavaScriptStackPresentation JavaScriptStackScreenOptions JavaScriptTabsConfig JavaScriptTabsPresentation KnownAuthOAuthProviderId KnownAuthOAuthTransportId KnownAuthProfileField KnownAuthProvider KnownAuthSignUpField KnownComponentEventDto KnownDatabaseProvider KnownDeploymentTarget KnownSecretStoreProvider KnownStateProvider ManifestValue MEDIA_ASSET_KINDS MediaAsset MediaAssetKind MediaAssetMetadata MediaAssetReference MediaAssetRegistry MediaAssetSource MediaBundledSource MediaManifest MediaStorageAdapter MediaStorageSource MediaUrlSource NamedIconSpec NATIVE_TABS_MINIMIZE_BEHAVIORS NativeTabsConfig NativeTabsMinimizeBehavior NavigateAction NAVIGATOR_PRESETS NAVIGATOR_TYPES NavigatorAdapterId NavigatorAdapterPlan NavigatorApiStability NavigatorCapabilityDescriptor NavigatorCapabilityId NavigatorCapabilityRequirement NavigatorCapabilityTarget NavigatorCapabilityVerification NavigatorCatalog NavigatorDefaults NavigatorDependencyRequirement NavigatorDiagnostic NavigatorGeneratedFile NavigatorGenerationBindings NavigatorGenerationOptions NavigatorGenerationResult NavigatorImplementation NavigatorNode NavigatorNodePlan NavigatorPlan NavigatorPlatformConfig NavigatorPlatforms NavigatorPresentation NavigatorPreset NavigatorPresetDescriptor NavigatorResponsiveSize NavigatorRoutePlan NavigatorRuntimePlatform NavigatorScreenModule NavigatorScreenReference NavigatorSupportStatus NavigatorType NavigatorValidationContext NavigatorVerificationKind NavigatorVerificationStatus NetworkingSpec normalizeSecretRef normalizeSecretScope OpenApiDocumentRef OperationId OperationScreenDataLoaderDefinition parseAppManifest PasswordResetInput PropBinding RepositoryManifest resolveAuthFlow ResolvedHeadlessTabsPresentation ResolvedTabsImplementation ResolvedTabsPresentation ResponsiveTabsPresentation RouteDefinition RuntimeCallback RuntimeCallbackArgs RuntimeCallbackMap RuntimeNodePropsResolver RuntimeResolveNodePropsArgs SchemaId ScreenCapabilityRequirement ScreenDataLoaderDefinition ScreenPermissionRequirement ScreenRequirements ScreenSpec SearchAction SECRET_STORE_ERROR_CODES SECRET_STORE_PROVIDERS SecretCreateInput SecretGetMetadataInput SecretListInput SecretMetadata SecretPayload SecretRef SecretRemoveInput SecretReplaceInput SecretResolveInput SecretScope SecretStoreAdapter SecretStoreError SecretStoreErrorCode SecretStoreOkResult SecretStoreProvider SecretStoreResult SetLanguageAction SignInInput SignOutInput SignUpInput SlotNavigatorNode SplashScreenAssetSpec SplashScreenModeSpec SplashScreenResizeMode SplashScreenSpec SplitViewNavigatorNode STACK_IMPLEMENTATIONS STACK_PRESENTATIONS StackHeaderOptions StackImplementation StackImplementationConfig StackNavigatorNode StackPresentation StackScreenOptions StartOAuthAuthorizationInput STATE_PERSISTENCE_MODES STATE_PROVIDERS StateAdapter StateAdapterCapabilities StateAdapterError StateListener StatePath StatePersistenceMode StatePrimitive StateProvider StateResult StateSnapshot StateSpec StateSubscription StateSuccess StateValue STORAGE_PROVIDERS StorageAdapter StorageAdapterError StorageAssetReference StorageImageAssetSource StorageListAdapter StorageListInput StorageListResult StorageObjectMetadata StorageOkResult StorageProvider StoragePublicUrlInput StoragePublicUrlResult StorageRemoveInput StorageResolveAdapter StorageResolvedAccess StorageResolvedAsset StorageResolveInput StorageResolveResult StorageResult StorageSpec StorageUploadInput StorageUploadResult SvgIconSpec TabsImplementationConfig TabsNavigatorConfig TabsNavigatorNode TabsNavigatorPlan ThemeConfig ThemeGlobalTokenOverrides ThemeModeConfig ThemeNumericTokenOverrides ThemeRecipeFieldOverrides ThemeRecipeOverrides ThemeRecipeOverrideValue ThemeStringTokenOverrides ThemeTypographyHeadingOverrides ThemeTypographyTokenOverrides ToggleDarkModeAction UiBindableEventMeta UiBindableEventPayloadMeta UiBindablePropMeta UiBindableValueFieldMeta UiBindableValueMeta UiBindableValueType UiComponentBindingMeta UiComponentBlueprint UiComponentBlueprintIcon UiComponentCategory UiComponentEventMeta UiComponentEventPayloadFieldMeta UiComponentEventPayloadFieldType UiComponentEventPayloadKind UiComponentI18nFieldMeta UiComponentI18nMeta UiComponentMeta UiComponentMetaRegistry UiComponentPackageManifest UiComponentPropArrayItemSchema UiComponentPropSchema UiComponentPropType UiComponentPropValue UiComponentSlotMeta UiNode UiNodeRepeatSpec UrlImageAssetSource validateSecretPayload VerifyOtpInput"
             >
               <h3>src/index.ts</h3>
               <p class="muted">Configured entrypoint</p>
@@ -918,8 +918,8 @@
                 <code>ImageAssetSource</code>, <code>ImageMetadata</code>,
                 <code>InfraManifest</code>, <code>InfraSecretStoreSpec</code>,
                 <code>InternalRestApiDefinition</code>, <code>isAppDeployManifest</code>,
-                <code>isAppManifest</code>, <code>isMediaAssetReference</code>,
-                <code>JAVASCRIPT_STACK_PRESENTATIONS</code>,
+                <code>isAppManifest</code>, <code>isAppNavigatorManifest</code>,
+                <code>isMediaAssetReference</code>, <code>JAVASCRIPT_STACK_PRESENTATIONS</code>,
                 <code>JAVASCRIPT_TABS_PRESENTATIONS</code>,
                 <code>JavaScriptStackPresentation</code>, <code>JavaScriptStackScreenOptions</code>,
                 <code>JavaScriptTabsConfig</code>, <code>JavaScriptTabsPresentation</code>,
@@ -1050,7 +1050,7 @@
             </article>
             <article
               class="item"
-              data-search="src/navigator.ts src/types.ts AdaptiveTabsConfig AppNavigatorManifest CreateNavigatorPlanOptions CustomNavigatorConfigIssue CustomNavigatorNode CustomNavigatorRegistration CustomNavigatorRegistry DRAWER_POSITIONS DRAWER_TYPES DrawerNavigatorNode DrawerNavigatorOptions DrawerPosition DrawerType ExpoRouterNavigatorModule FIXED_HEADLESS_TABS_PRESENTATIONS FixedHeadlessTabsPresentation HEADLESS_TABS_PRESENTATIONS HeadlessTabsConfig HeadlessTabsPresentation HeadlessTabsPresentationConfig HeadlessTabsWebConfig JAVASCRIPT_STACK_PRESENTATIONS JAVASCRIPT_TABS_PRESENTATIONS JavaScriptStackPresentation JavaScriptStackScreenOptions JavaScriptTabsConfig JavaScriptTabsPresentation NATIVE_TABS_MINIMIZE_BEHAVIORS NativeTabsConfig NativeTabsMinimizeBehavior NAVIGATOR_PRESETS NAVIGATOR_TYPES NavigatorAdapterId NavigatorAdapterPlan NavigatorApiStability NavigatorCapabilityDescriptor NavigatorCapabilityId NavigatorCapabilityRequirement NavigatorCapabilityTarget NavigatorCapabilityVerification NavigatorCatalog NavigatorDefaults NavigatorDependencyRequirement NavigatorDiagnostic NavigatorGeneratedFile NavigatorGenerationBindings NavigatorGenerationOptions NavigatorGenerationResult NavigatorImplementation NavigatorNode NavigatorNodePlan NavigatorPlan NavigatorPlatformConfig NavigatorPlatforms NavigatorPresentation NavigatorPreset NavigatorPresetDescriptor NavigatorResponsiveSize NavigatorRoutePlan NavigatorRuntimePlatform NavigatorScreenModule NavigatorScreenReference NavigatorSupportStatus NavigatorType NavigatorValidationContext NavigatorVerificationKind NavigatorVerificationStatus ResolvedHeadlessTabsPresentation ResolvedTabsImplementation ResolvedTabsPresentation ResponsiveTabsPresentation RouteDefinition SlotNavigatorNode SplitViewNavigatorNode STACK_IMPLEMENTATIONS STACK_PRESENTATIONS StackHeaderOptions StackImplementation StackImplementationConfig StackNavigatorNode StackPresentation StackScreenOptions TabsImplementationConfig TabsNavigatorConfig TabsNavigatorNode TabsNavigatorPlan"
+              data-search="src/navigator.ts src/types.ts AdaptiveTabsConfig AppNavigatorManifest CreateNavigatorPlanOptions CustomNavigatorConfigIssue CustomNavigatorNode CustomNavigatorRegistration CustomNavigatorRegistry DRAWER_POSITIONS DRAWER_TYPES DrawerNavigatorNode DrawerNavigatorOptions DrawerPosition DrawerType ExpoRouterNavigatorModule FIXED_HEADLESS_TABS_PRESENTATIONS FixedHeadlessTabsPresentation HEADLESS_TABS_PRESENTATIONS HeadlessTabsConfig HeadlessTabsPresentation HeadlessTabsPresentationConfig HeadlessTabsWebConfig isAppNavigatorManifest JAVASCRIPT_STACK_PRESENTATIONS JAVASCRIPT_TABS_PRESENTATIONS JavaScriptStackPresentation JavaScriptStackScreenOptions JavaScriptTabsConfig JavaScriptTabsPresentation NATIVE_TABS_MINIMIZE_BEHAVIORS NativeTabsConfig NativeTabsMinimizeBehavior NAVIGATOR_PRESETS NAVIGATOR_TYPES NavigatorAdapterId NavigatorAdapterPlan NavigatorApiStability NavigatorCapabilityDescriptor NavigatorCapabilityId NavigatorCapabilityRequirement NavigatorCapabilityTarget NavigatorCapabilityVerification NavigatorCatalog NavigatorDefaults NavigatorDependencyRequirement NavigatorDiagnostic NavigatorGeneratedFile NavigatorGenerationBindings NavigatorGenerationOptions NavigatorGenerationResult NavigatorImplementation NavigatorNode NavigatorNodePlan NavigatorPlan NavigatorPlatformConfig NavigatorPlatforms NavigatorPresentation NavigatorPreset NavigatorPresetDescriptor NavigatorResponsiveSize NavigatorRoutePlan NavigatorRuntimePlatform NavigatorScreenModule NavigatorScreenReference NavigatorSupportStatus NavigatorType NavigatorValidationContext NavigatorVerificationKind NavigatorVerificationStatus ResolvedHeadlessTabsPresentation ResolvedTabsImplementation ResolvedTabsPresentation ResponsiveTabsPresentation RouteDefinition SlotNavigatorNode SplitViewNavigatorNode STACK_IMPLEMENTATIONS STACK_PRESENTATIONS StackHeaderOptions StackImplementation StackImplementationConfig StackNavigatorNode StackPresentation StackScreenOptions TabsImplementationConfig TabsNavigatorConfig TabsNavigatorNode TabsNavigatorPlan"
             >
               <h3>src/navigator.ts</h3>
               <p class="muted">Referenced module</p>
@@ -1068,7 +1068,8 @@
                 <code>FixedHeadlessTabsPresentation</code>,
                 <code>HEADLESS_TABS_PRESENTATIONS</code>, <code>HeadlessTabsConfig</code>,
                 <code>HeadlessTabsPresentation</code>, <code>HeadlessTabsPresentationConfig</code>,
-                <code>HeadlessTabsWebConfig</code>, <code>JAVASCRIPT_STACK_PRESENTATIONS</code>,
+                <code>HeadlessTabsWebConfig</code>, <code>isAppNavigatorManifest</code>,
+                <code>JAVASCRIPT_STACK_PRESENTATIONS</code>,
                 <code>JAVASCRIPT_TABS_PRESENTATIONS</code>,
                 <code>JavaScriptStackPresentation</code>, <code>JavaScriptStackScreenOptions</code>,
                 <code>JavaScriptTabsConfig</code>, <code>JavaScriptTabsPresentation</code>,
@@ -1475,6 +1476,43 @@
                 <h4>isAppDeployManifest</h4>
                 <p class="muted">function • <code>src/appManifest/deploy.ts:19:1</code></p>
 
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+                <div>
+                  <h5>Signature</h5>
+                  <pre>(value: unknown) =&gt; boolean</pre>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Parameter</th>
+                        <th>Type</th>
+                        <th>Required</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td><code>value</code></td>
+                        <td><code>unknown</code></td>
+                        <td>yes</td>
+                        <td></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <p><strong>Returns:</strong> <code>boolean</code></p>
+                </div>
+              </article>
+            </section>
+            <section>
+              <h3>src/appManifest/navigator.ts</h3>
+              <article
+                class="item"
+                id="symbol-isappnavigatormanifest"
+                data-search="isAppNavigatorManifest function src/appManifest/navigator.ts Validate the complete serialized `AppManifest.navigator` slice. (value: unknown) =&gt; boolean"
+              >
+                <h4>isAppNavigatorManifest</h4>
+                <p class="muted">function • <code>src/appManifest/navigator.ts:14:1</code></p>
+                <p>Validate the complete serialized `AppManifest.navigator` slice.</p>
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
                 <div>
@@ -8570,7 +8608,7 @@
                 data-search="AdaptiveTabsConfig type src/navigator.ts  HeadlessTabsPresentationConfig NativeTabsConfig"
               >
                 <h4>AdaptiveTabsConfig</h4>
-                <p class="muted">type • <code>src/navigator.ts:165:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:167:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -8622,7 +8660,7 @@
                 data-search="AppNavigatorManifest unknown src/navigator.ts "
               >
                 <h4>AppNavigatorManifest</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:262:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:264:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8633,7 +8671,7 @@
                 data-search="CustomNavigatorNode type src/navigator.ts  ManifestValue RouteDefinition"
               >
                 <h4>CustomNavigatorNode</h4>
-                <p class="muted">type • <code>src/navigator.ts:212:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:214:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -8701,7 +8739,7 @@
                 data-search="DRAWER_POSITIONS value src/navigator.ts "
               >
                 <h4>DRAWER_POSITIONS</h4>
-                <p class="muted">value • <code>src/navigator.ts:84:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:86:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8712,7 +8750,7 @@
                 data-search="DRAWER_TYPES value src/navigator.ts "
               >
                 <h4>DRAWER_TYPES</h4>
-                <p class="muted">value • <code>src/navigator.ts:87:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:89:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8723,7 +8761,7 @@
                 data-search="DrawerNavigatorNode type src/navigator.ts  DrawerNavigatorOptions RouteDefinition"
               >
                 <h4>DrawerNavigatorNode</h4>
-                <p class="muted">type • <code>src/navigator.ts:190:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:192:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -8782,7 +8820,7 @@
                 data-search="DrawerNavigatorOptions type src/navigator.ts "
               >
                 <h4>DrawerNavigatorOptions</h4>
-                <p class="muted">type • <code>src/navigator.ts:90:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:92:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8840,7 +8878,7 @@
                 data-search="DrawerPosition unknown src/navigator.ts "
               >
                 <h4>DrawerPosition</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:85:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:87:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8851,7 +8889,7 @@
                 data-search="DrawerType unknown src/navigator.ts "
               >
                 <h4>DrawerType</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:88:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:90:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8862,7 +8900,7 @@
                 data-search="FIXED_HEADLESS_TABS_PRESENTATIONS value src/navigator.ts "
               >
                 <h4>FIXED_HEADLESS_TABS_PRESENTATIONS</h4>
-                <p class="muted">value • <code>src/navigator.ts:97:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:99:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8873,7 +8911,7 @@
                 data-search="FixedHeadlessTabsPresentation unknown src/navigator.ts "
               >
                 <h4>FixedHeadlessTabsPresentation</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:98:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:100:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8884,7 +8922,7 @@
                 data-search="HEADLESS_TABS_PRESENTATIONS value src/navigator.ts "
               >
                 <h4>HEADLESS_TABS_PRESENTATIONS</h4>
-                <p class="muted">value • <code>src/navigator.ts:100:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:102:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8895,7 +8933,7 @@
                 data-search="HeadlessTabsConfig unknown src/navigator.ts "
               >
                 <h4>HeadlessTabsConfig</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:142:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:144:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8906,7 +8944,7 @@
                 data-search="HeadlessTabsPresentation unknown src/navigator.ts "
               >
                 <h4>HeadlessTabsPresentation</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:105:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:107:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8917,7 +8955,7 @@
                 data-search="HeadlessTabsPresentationConfig unknown src/navigator.ts "
               >
                 <h4>HeadlessTabsPresentationConfig</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:124:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:126:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8928,7 +8966,7 @@
                 data-search="HeadlessTabsWebConfig unknown src/navigator.ts "
               >
                 <h4>HeadlessTabsWebConfig</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:146:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:148:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8939,7 +8977,7 @@
                 data-search="JAVASCRIPT_STACK_PRESENTATIONS value src/navigator.ts "
               >
                 <h4>JAVASCRIPT_STACK_PRESENTATIONS</h4>
-                <p class="muted">value • <code>src/navigator.ts:40:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:42:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8950,7 +8988,7 @@
                 data-search="JAVASCRIPT_TABS_PRESENTATIONS value src/navigator.ts "
               >
                 <h4>JAVASCRIPT_TABS_PRESENTATIONS</h4>
-                <p class="muted">value • <code>src/navigator.ts:107:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:109:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8961,7 +8999,7 @@
                 data-search="JavaScriptStackPresentation unknown src/navigator.ts "
               >
                 <h4>JavaScriptStackPresentation</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:41:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:43:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8972,7 +9010,7 @@
                 data-search="JavaScriptStackScreenOptions unknown src/navigator.ts "
               >
                 <h4>JavaScriptStackScreenOptions</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:64:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:66:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -8983,7 +9021,7 @@
                 data-search="JavaScriptTabsConfig type src/navigator.ts "
               >
                 <h4>JavaScriptTabsConfig</h4>
-                <p class="muted">type • <code>src/navigator.ts:160:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:162:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9022,7 +9060,7 @@
                 data-search="JavaScriptTabsPresentation unknown src/navigator.ts "
               >
                 <h4>JavaScriptTabsPresentation</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:108:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:110:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9033,7 +9071,7 @@
                 data-search="NATIVE_TABS_MINIMIZE_BEHAVIORS value src/navigator.ts "
               >
                 <h4>NATIVE_TABS_MINIMIZE_BEHAVIORS</h4>
-                <p class="muted">value • <code>src/navigator.ts:110:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:112:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9044,7 +9082,7 @@
                 data-search="NativeTabsConfig type src/navigator.ts  NavigatorScreenReference"
               >
                 <h4>NativeTabsConfig</h4>
-                <p class="muted">type • <code>src/navigator.ts:152:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:154:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -9100,7 +9138,7 @@
                 data-search="NativeTabsMinimizeBehavior unknown src/navigator.ts "
               >
                 <h4>NativeTabsMinimizeBehavior</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:116:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:118:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9111,7 +9149,7 @@
                 data-search="NAVIGATOR_PRESETS value src/navigator.ts "
               >
                 <h4>NAVIGATOR_PRESETS</h4>
-                <p class="muted">value • <code>src/navigator.ts:6:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:8:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9122,7 +9160,7 @@
                 data-search="NAVIGATOR_TYPES value src/navigator.ts "
               >
                 <h4>NAVIGATOR_TYPES</h4>
-                <p class="muted">value • <code>src/navigator.ts:3:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:5:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9133,7 +9171,7 @@
                 data-search="NavigatorDefaults type src/navigator.ts  StackImplementationConfig TabsImplementationConfig"
               >
                 <h4>NavigatorDefaults</h4>
-                <p class="muted">type • <code>src/navigator.ts:240:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:242:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -9178,7 +9216,7 @@
                 data-search="NavigatorNode unknown src/navigator.ts "
               >
                 <h4>NavigatorNode</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:218:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:220:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9189,7 +9227,7 @@
                 data-search="NavigatorPlatformConfig type src/navigator.ts  StackImplementationConfig TabsImplementationConfig"
               >
                 <h4>NavigatorPlatformConfig</h4>
-                <p class="muted">type • <code>src/navigator.ts:245:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:247:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -9234,7 +9272,7 @@
                 data-search="NavigatorPlatforms type src/navigator.ts  NavigatorPlatformConfig"
               >
                 <h4>NavigatorPlatforms</h4>
-                <p class="muted">type • <code>src/navigator.ts:250:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:252:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -9285,7 +9323,7 @@
                 data-search="NavigatorPreset unknown src/navigator.ts "
               >
                 <h4>NavigatorPreset</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:24:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:26:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9296,7 +9334,7 @@
                 data-search="NavigatorScreenReference type src/navigator.ts "
               >
                 <h4>NavigatorScreenReference</h4>
-                <p class="muted">type • <code>src/navigator.ts:148:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:150:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9328,7 +9366,7 @@
                 data-search="NavigatorType unknown src/navigator.ts "
               >
                 <h4>NavigatorType</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:4:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:6:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9339,7 +9377,7 @@
                 data-search="ResponsiveTabsPresentation type src/navigator.ts "
               >
                 <h4>ResponsiveTabsPresentation</h4>
-                <p class="muted">type • <code>src/navigator.ts:118:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:120:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9400,7 +9438,7 @@
                 data-search="RouteDefinition type src/navigator.ts  IconSpec NavigatorNode StackScreenOptions"
               >
                 <h4>RouteDefinition</h4>
-                <p class="muted">type • <code>src/navigator.ts:226:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:228:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -9495,7 +9533,7 @@
                 data-search="SlotNavigatorNode type src/navigator.ts  RouteDefinition"
               >
                 <h4>SlotNavigatorNode</h4>
-                <p class="muted">type • <code>src/navigator.ts:182:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:184:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -9546,7 +9584,7 @@
                 data-search="SplitViewNavigatorNode type src/navigator.ts  NavigatorScreenReference RouteDefinition"
               >
                 <h4>SplitViewNavigatorNode</h4>
-                <p class="muted">type • <code>src/navigator.ts:201:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:203:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div>
@@ -9629,7 +9667,7 @@
                 data-search="STACK_IMPLEMENTATIONS value src/navigator.ts "
               >
                 <h4>STACK_IMPLEMENTATIONS</h4>
-                <p class="muted">value • <code>src/navigator.ts:26:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:28:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9640,7 +9678,7 @@
                 data-search="STACK_PRESENTATIONS value src/navigator.ts "
               >
                 <h4>STACK_PRESENTATIONS</h4>
-                <p class="muted">value • <code>src/navigator.ts:29:14</code></p>
+                <p class="muted">value • <code>src/navigator.ts:31:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9651,7 +9689,7 @@
                 data-search="StackHeaderOptions type src/navigator.ts "
               >
                 <h4>StackHeaderOptions</h4>
-                <p class="muted">type • <code>src/navigator.ts:43:1</code></p>
+                <p class="muted">type • <code>src/navigator.ts:45:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9704,7 +9742,7 @@
                 data-search="StackImplementation unknown src/navigator.ts "
               >
                 <h4>StackImplementation</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:27:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:29:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9715,7 +9753,7 @@
                 data-search="StackImplementationConfig unknown src/navigator.ts "
               >
                 <h4>StackImplementationConfig</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:68:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:70:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9726,7 +9764,7 @@
                 data-search="StackNavigatorNode unknown src/navigator.ts "
               >
                 <h4>StackNavigatorNode</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:186:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:188:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9737,7 +9775,7 @@
                 data-search="StackPresentation unknown src/navigator.ts "
               >
                 <h4>StackPresentation</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:38:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:40:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9748,7 +9786,7 @@
                 data-search="StackScreenOptions unknown src/navigator.ts "
               >
                 <h4>StackScreenOptions</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:50:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:52:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9759,7 +9797,7 @@
                 data-search="TabsImplementationConfig unknown src/navigator.ts "
               >
                 <h4>TabsImplementationConfig</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:174:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:176:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9770,7 +9808,7 @@
                 data-search="TabsNavigatorConfig unknown src/navigator.ts "
               >
                 <h4>TabsNavigatorConfig</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:195:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:197:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -9781,7 +9819,7 @@
                 data-search="TabsNavigatorNode unknown src/navigator.ts "
               >
                 <h4>TabsNavigatorNode</h4>
-                <p class="muted">unknown • <code>src/navigator.ts:199:1</code></p>
+                <p class="muted">unknown • <code>src/navigator.ts:201:1</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -19266,8 +19304,11 @@ graph LR
                 export_isAppDeployManifest[&quot;isAppDeployManifest&quot;]
                 module_src_appManifest_deploy_ts --&gt; export_isAppDeployManifest
                 export_isAppManifest[&quot;isAppManifest&quot;] module_src_appManifest_ts --&gt;
-                export_isAppManifest export_isMediaAssetReference[&quot;isMediaAssetReference&quot;]
-                module_src_media_ts --&gt; export_isMediaAssetReference
+                export_isAppManifest
+                export_isAppNavigatorManifest[&quot;isAppNavigatorManifest&quot;]
+                module_src_appManifest_navigator_ts --&gt; export_isAppNavigatorManifest
+                export_isMediaAssetReference[&quot;isMediaAssetReference&quot;] module_src_media_ts
+                --&gt; export_isMediaAssetReference
                 export_JAVASCRIPT_STACK_PRESENTATIONS[&quot;JAVASCRIPT_STACK_PRESENTATIONS&quot;]
                 module_src_navigator_ts --&gt; export_JAVASCRIPT_STACK_PRESENTATIONS
                 export_JAVASCRIPT_TABS_PRESENTATIONS[&quot;JAVASCRIPT_TABS_PRESENTATIONS&quot;]
@@ -20562,6 +20603,8 @@ graph LR
   module_src_appManifest_deploy_ts --&gt; export_isAppDeployManifest
   export_isAppManifest[&quot;isAppManifest&quot;]
   module_src_appManifest_ts --&gt; export_isAppManifest
+  export_isAppNavigatorManifest[&quot;isAppNavigatorManifest&quot;]
+  module_src_appManifest_navigator_ts --&gt; export_isAppNavigatorManifest
   export_isMediaAssetReference[&quot;isMediaAssetReference&quot;]
   module_src_media_ts --&gt; export_isMediaAssetReference
   export_JAVASCRIPT_STACK_PRESENTATIONS[&quot;JAVASCRIPT_STACK_PRESENTATIONS&quot;]
@@ -21743,7 +21786,7 @@ graph LR
               data-search="isAppNavigatorManifest src/appManifest/navigator.ts Validate the complete serialized `AppManifest.navigator` slice."
             >
               <h3>isAppNavigatorManifest</h3>
-              <p class="muted"><code>src/appManifest/navigator.ts:17:1</code></p>
+              <p class="muted"><code>src/appManifest/navigator.ts:14:1</code></p>
               <p>Validate the complete serialized `AppManifest.navigator` slice.</p>
             </article>
             <article
@@ -21751,9 +21794,31 @@ graph LR
               data-search="isNavigatorNode src/appManifest/navigator.ts Validate one nested navigator node independently from app-level authoring metadata."
             >
               <h3>isNavigatorNode</h3>
-              <p class="muted"><code>src/appManifest/navigator.ts:30:1</code></p>
+              <p class="muted"><code>src/appManifest/navigator.ts:27:1</code></p>
               <p>
                 Validate one nested navigator node independently from app-level authoring metadata.
+              </p>
+            </article>
+            <article
+              class="item"
+              data-search="hasNavigatorPreset src/appManifest/navigator.ts Check a serialized preset against the public contract without eager cyclic initialization."
+            >
+              <h3>hasNavigatorPreset</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:61:1</code></p>
+              <p>
+                Check a serialized preset against the public contract without eager cyclic
+                initialization.
+              </p>
+            </article>
+            <article
+              class="item"
+              data-search="hasNavigatorType src/appManifest/navigator.ts Check a serialized topology against the public contract without eager cyclic initialization."
+            >
+              <h3>hasNavigatorType</h3>
+              <p class="muted"><code>src/appManifest/navigator.ts:66:1</code></p>
+              <p>
+                Check a serialized topology against the public contract without eager cyclic
+                initialization.
               </p>
             </article>
             <article
@@ -21761,7 +21826,7 @@ graph LR
               data-search="isRouteDefinition src/appManifest/navigator.ts Validate one route and preserve its portable metadata and nested navigator."
             >
               <h3>isRouteDefinition</h3>
-              <p class="muted"><code>src/appManifest/navigator.ts:64:1</code></p>
+              <p class="muted"><code>src/appManifest/navigator.ts:71:1</code></p>
               <p>Validate one route and preserve its portable metadata and nested navigator.</p>
             </article>
             <article
@@ -21769,7 +21834,7 @@ graph LR
               data-search="isSplitViewNavigatorNode src/appManifest/navigator.ts Validate Split View screen references without duplicating the routed secondary tree."
             >
               <h3>isSplitViewNavigatorNode</h3>
-              <p class="muted"><code>src/appManifest/navigator.ts:80:1</code></p>
+              <p class="muted"><code>src/appManifest/navigator.ts:87:1</code></p>
               <p>
                 Validate Split View screen references without duplicating the routed secondary tree.
               </p>
@@ -21779,7 +21844,7 @@ graph LR
               data-search="isCustomNavigatorNode src/appManifest/navigator.ts Validate a registered custom navigator with JSON-safe configuration only."
             >
               <h3>isCustomNavigatorNode</h3>
-              <p class="muted"><code>src/appManifest/navigator.ts:98:1</code></p>
+              <p class="muted"><code>src/appManifest/navigator.ts:105:1</code></p>
               <p>Validate a registered custom navigator with JSON-safe configuration only.</p>
             </article>
             <article
@@ -21787,7 +21852,7 @@ graph LR
               data-search="isNavigatorJsonRecord src/appManifest/navigator.ts Validate an acyclic, finite JSON object used by a custom navigator adapter."
             >
               <h3>isNavigatorJsonRecord</h3>
-              <p class="muted"><code>src/appManifest/navigator.ts:108:1</code></p>
+              <p class="muted"><code>src/appManifest/navigator.ts:115:1</code></p>
               <p>Validate an acyclic, finite JSON object used by a custom navigator adapter.</p>
             </article>
             <article
@@ -21795,7 +21860,7 @@ graph LR
               data-search="isNavigatorJsonValue src/appManifest/navigator.ts Recursively validate the portable manifest value domain and reject cycles."
             >
               <h3>isNavigatorJsonValue</h3>
-              <p class="muted"><code>src/appManifest/navigator.ts:113:1</code></p>
+              <p class="muted"><code>src/appManifest/navigator.ts:120:1</code></p>
               <p>Recursively validate the portable manifest value domain and reject cycles.</p>
             </article>
             <article
@@ -21803,7 +21868,7 @@ graph LR
               data-search="isNavigatorDefaults src/appManifest/navigator.ts Validate package-owned navigator defaults without requiring a navigator node type."
             >
               <h3>isNavigatorDefaults</h3>
-              <p class="muted"><code>src/appManifest/navigator.ts:138:1</code></p>
+              <p class="muted"><code>src/appManifest/navigator.ts:145:1</code></p>
               <p>
                 Validate package-owned navigator defaults without requiring a navigator node type.
               </p>
@@ -21813,7 +21878,7 @@ graph LR
               data-search="isNavigatorPlatforms src/appManifest/navigator.ts Validate per-platform navigator implementation overrides."
             >
               <h3>isNavigatorPlatforms</h3>
-              <p class="muted"><code>src/appManifest/navigator.ts:150:1</code></p>
+              <p class="muted"><code>src/appManifest/navigator.ts:157:1</code></p>
               <p>Validate per-platform navigator implementation overrides.</p>
             </article>
             <article
@@ -21821,7 +21886,7 @@ graph LR
               data-search="isNavigatorPlatformConfig src/appManifest/navigator.ts Validate one platform-specific navigator override slice."
             >
               <h3>isNavigatorPlatformConfig</h3>
-              <p class="muted"><code>src/appManifest/navigator.ts:161:1</code></p>
+              <p class="muted"><code>src/appManifest/navigator.ts:168:1</code></p>
               <p>Validate one platform-specific navigator override slice.</p>
             </article>
           </section>
@@ -21839,7 +21904,7 @@ graph LR
               data-search="isStackImplementationConfig src/appManifest/navigatorOptions.ts Validate stable native, JavaScript, or alpha Experimental Stack desired state."
             >
               <h3>isStackImplementationConfig</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:23:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:14:1</code></p>
               <p>Validate stable native, JavaScript, or alpha Experimental Stack desired state.</p>
             </article>
             <article
@@ -21847,7 +21912,7 @@ graph LR
               data-search="isStackScreenOptions src/appManifest/navigatorOptions.ts Validate the serializable native-stack screen option subset."
             >
               <h3>isStackScreenOptions</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:50:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:41:1</code></p>
               <p>Validate the serializable native-stack screen option subset.</p>
             </article>
             <article
@@ -21855,7 +21920,7 @@ graph LR
               data-search="isDrawerNavigatorOptions src/appManifest/navigatorOptions.ts Validate the finite serializable Drawer option subset."
             >
               <h3>isDrawerNavigatorOptions</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:79:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:71:1</code></p>
               <p>Validate the finite serializable Drawer option subset.</p>
             </article>
             <article
@@ -21863,7 +21928,7 @@ graph LR
               data-search="isTabsImplementationConfig src/appManifest/navigatorOptions.ts Validate tabs implementation desired state, with omitted implementation meaning adaptive."
             >
               <h3>isTabsImplementationConfig</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:94:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:86:1</code></p>
               <p>
                 Validate tabs implementation desired state, with omitted implementation meaning
                 adaptive.
@@ -21874,7 +21939,7 @@ graph LR
               data-search="isNavigatorScreenReference src/appManifest/navigatorOptions.ts Validate a reference into the app-owned screen registry."
             >
               <h3>isNavigatorScreenReference</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:108:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:100:1</code></p>
               <p>Validate a reference into the app-owned screen registry.</p>
             </article>
             <article
@@ -21882,7 +21947,7 @@ graph LR
               data-search="hasOnlyKeys src/appManifest/navigatorOptions.ts Check that a finite configuration object contains no unsupported keys."
             >
               <h3>hasOnlyKeys</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:113:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:105:1</code></p>
               <p>Check that a finite configuration object contains no unsupported keys.</p>
             </article>
             <article
@@ -21890,7 +21955,7 @@ graph LR
               data-search="isJavaScriptStackScreenOptions src/appManifest/navigatorOptions.ts Validate JavaScript Stack options without accepting native-only presentations."
             >
               <h3>isJavaScriptStackScreenOptions</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:122:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:114:1</code></p>
               <p>Validate JavaScript Stack options without accepting native-only presentations.</p>
             </article>
             <article
@@ -21898,7 +21963,7 @@ graph LR
               data-search="isStackHeaderOptions src/appManifest/navigatorOptions.ts Validate the portable header subset supported by Experimental Stack."
             >
               <h3>isStackHeaderOptions</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:140:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:132:1</code></p>
               <p>Validate the portable header subset supported by Experimental Stack.</p>
             </article>
             <article
@@ -21906,7 +21971,7 @@ graph LR
               data-search="isStackHeaderOptionsShape src/appManifest/navigatorOptions.ts Validate shared stack header field values after branch-specific key filtering."
             >
               <h3>isStackHeaderOptionsShape</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:149:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:141:1</code></p>
               <p>Validate shared stack header field values after branch-specific key filtering.</p>
             </article>
             <article
@@ -21914,7 +21979,7 @@ graph LR
               data-search="isSheetAllowedDetents src/appManifest/navigatorOptions.ts Validate sorted, finite native sheet detents or the fit-to-content sentinel."
             >
               <h3>isSheetAllowedDetents</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:159:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:151:1</code></p>
               <p>Validate sorted, finite native sheet detents or the fit-to-content sentinel.</p>
             </article>
             <article
@@ -21922,7 +21987,7 @@ graph LR
               data-search="isAdaptiveTabsConfig src/appManifest/navigatorOptions.ts Validate an adaptive tabs branch and reject implementation-specific conflicts."
             >
               <h3>isAdaptiveTabsConfig</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:173:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:165:1</code></p>
               <p>Validate an adaptive tabs branch and reject implementation-specific conflicts.</p>
             </article>
             <article
@@ -21930,7 +21995,7 @@ graph LR
               data-search="isFullNativeTabsConfig src/appManifest/navigatorOptions.ts Validate the top-level native tabs implementation."
             >
               <h3>isFullNativeTabsConfig</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:189:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:181:1</code></p>
               <p>Validate the top-level native tabs implementation.</p>
             </article>
             <article
@@ -21938,7 +22003,7 @@ graph LR
               data-search="isJavaScriptTabsConfig src/appManifest/navigatorOptions.ts Validate the top-level JavaScript tabs implementation."
             >
               <h3>isJavaScriptTabsConfig</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:203:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:195:1</code></p>
               <p>Validate the top-level JavaScript tabs implementation.</p>
             </article>
             <article
@@ -21946,7 +22011,7 @@ graph LR
               data-search="isNativeTabsConfig src/appManifest/navigatorOptions.ts Validate the native branch used by adaptive tabs."
             >
               <h3>isNativeTabsConfig</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:221:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:213:1</code></p>
               <p>Validate the native branch used by adaptive tabs.</p>
             </article>
             <article
@@ -21954,7 +22019,7 @@ graph LR
               data-search="isNativeTabsFields src/appManifest/navigatorOptions.ts Validate fields supported by the native tabs branch."
             >
               <h3>isNativeTabsFields</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:231:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:223:1</code></p>
               <p>Validate fields supported by the native tabs branch.</p>
             </article>
             <article
@@ -21962,7 +22027,7 @@ graph LR
               data-search="isHeadlessTabsWebConfig src/appManifest/navigatorOptions.ts Validate the implementation-free headless-tabs Web branch inside adaptive tabs."
             >
               <h3>isHeadlessTabsWebConfig</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:241:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:233:1</code></p>
               <p>Validate the implementation-free headless-tabs Web branch inside adaptive tabs.</p>
             </article>
             <article
@@ -21970,7 +22035,7 @@ graph LR
               data-search="isHeadlessTabsPresentationConfig src/appManifest/navigatorOptions.ts Validate headless-tab presentation and its conditional serializable configuration."
             >
               <h3>isHeadlessTabsPresentationConfig</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:250:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:242:1</code></p>
               <p>
                 Validate headless-tab presentation and its conditional serializable configuration.
               </p>
@@ -21980,15 +22045,25 @@ graph LR
               data-search="isResponsiveTabsPresentation src/appManifest/navigatorOptions.ts Validate semantic compact/medium/expanded headless-tab presentation mapping."
             >
               <h3>isResponsiveTabsPresentation</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:275:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:267:1</code></p>
               <p>Validate semantic compact/medium/expanded headless-tab presentation mapping.</p>
+            </article>
+            <article
+              class="item"
+              data-search="contains src/appManifest/navigatorOptions.ts Check a string against a public finite contract without eager cyclic initialization."
+            >
+              <h3>contains</h3>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:282:1</code></p>
+              <p>
+                Check a string against a public finite contract without eager cyclic initialization.
+              </p>
             </article>
             <article
               class="item"
               data-search="hasNoDefinedKeys src/appManifest/navigatorOptions.ts Check that mutually exclusive branch fields are absent."
             >
               <h3>hasNoDefinedKeys</h3>
-              <p class="muted"><code>src/appManifest/navigatorOptions.ts:290:1</code></p>
+              <p class="muted"><code>src/appManifest/navigatorOptions.ts:287:1</code></p>
               <p>Check that mutually exclusive branch fields are absent.</p>
             </article>
           </section>

--- a/paradox/paradox.json
+++ b/paradox/paradox.json
@@ -14,7 +14,7 @@
     {
       "id": "npm",
       "label": "npm",
-      "value": "v11.1.0",
+      "value": "v12.0.0",
       "color": "cb3837"
     },
     {
@@ -807,6 +807,7 @@
         "InternalRestApiDefinition",
         "isAppDeployManifest",
         "isAppManifest",
+        "isAppNavigatorManifest",
         "isMediaAssetReference",
         "JAVASCRIPT_STACK_PRESENTATIONS",
         "JAVASCRIPT_TABS_PRESENTATIONS",
@@ -1075,6 +1076,7 @@
         "HeadlessTabsPresentation",
         "HeadlessTabsPresentationConfig",
         "HeadlessTabsWebConfig",
+        "isAppNavigatorManifest",
         "JAVASCRIPT_STACK_PRESENTATIONS",
         "JAVASCRIPT_TABS_PRESENTATIONS",
         "JavaScriptStackPresentation",
@@ -1617,7 +1619,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 165,
+        "line": 167,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -2629,7 +2631,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 262,
+        "line": 264,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -5725,7 +5727,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 212,
+        "line": 214,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8391,7 +8393,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 84,
+        "line": 86,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -8409,7 +8411,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 87,
+        "line": 89,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -8427,7 +8429,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 190,
+        "line": 192,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8474,7 +8476,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 90,
+        "line": 92,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8521,7 +8523,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 85,
+        "line": 87,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8539,7 +8541,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 88,
+        "line": 90,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -8920,7 +8922,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 97,
+        "line": 99,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -8938,7 +8940,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 98,
+        "line": 100,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9043,7 +9045,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 100,
+        "line": 102,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -9061,7 +9063,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 142,
+        "line": 144,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9079,7 +9081,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 105,
+        "line": 107,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9097,7 +9099,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 124,
+        "line": 126,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9115,7 +9117,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 146,
+        "line": 148,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9478,6 +9480,38 @@
       "structuredRows": []
     },
     {
+      "name": "isAppNavigatorManifest",
+      "description": "Validate the complete serialized `AppManifest.navigator` slice.",
+      "isReadme": false,
+      "examples": [],
+      "kind": "function",
+      "modulePath": "src/appManifest/navigator.ts",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 14,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [
+        {
+          "label": "(value: unknown) => boolean",
+          "parameters": [
+            {
+              "name": "value",
+              "type": "unknown",
+              "required": true,
+              "description": null
+            }
+          ],
+          "returnType": "boolean",
+          "returnDescription": null
+        }
+      ],
+      "members": [],
+      "structuredRows": []
+    },
+    {
       "name": "isMediaAssetReference",
       "description": null,
       "isReadme": false,
@@ -9518,7 +9552,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 40,
+        "line": 42,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -9536,7 +9570,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 107,
+        "line": 109,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -9554,7 +9588,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 41,
+        "line": 43,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9572,7 +9606,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 64,
+        "line": 66,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9590,7 +9624,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 160,
+        "line": 162,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -9623,7 +9657,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 108,
+        "line": 110,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10326,7 +10360,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 110,
+        "line": 112,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -10344,7 +10378,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 152,
+        "line": 154,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10384,7 +10418,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 116,
+        "line": 118,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -10435,7 +10469,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 6,
+        "line": 8,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -10453,7 +10487,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 3,
+        "line": 5,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -10825,7 +10859,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 240,
+        "line": 242,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11143,7 +11177,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 218,
+        "line": 220,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11325,7 +11359,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 245,
+        "line": 247,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11358,7 +11392,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 250,
+        "line": 252,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11416,7 +11450,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 24,
+        "line": 26,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11625,7 +11659,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 148,
+        "line": 150,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -11669,7 +11703,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 4,
+        "line": 6,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -12244,7 +12278,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 118,
+        "line": 120,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -12284,7 +12318,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 226,
+        "line": 228,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13471,7 +13505,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 182,
+        "line": 184,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13670,7 +13704,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 201,
+        "line": 203,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13731,7 +13765,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 26,
+        "line": 28,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -13749,7 +13783,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 29,
+        "line": 31,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -13767,7 +13801,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 43,
+        "line": 45,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13814,7 +13848,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 27,
+        "line": 29,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13832,7 +13866,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 68,
+        "line": 70,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13850,7 +13884,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 186,
+        "line": 188,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13868,7 +13902,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 38,
+        "line": 40,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -13886,7 +13920,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 50,
+        "line": 52,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -15328,7 +15362,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 174,
+        "line": 176,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -15346,7 +15380,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 195,
+        "line": 197,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -15364,7 +15398,7 @@
       "modulePath": "src/navigator.ts",
       "sourceLocation": {
         "filePath": "src/navigator.ts",
-        "line": 199,
+        "line": 201,
         "column": 1
       },
       "exportPaths": ["src/index.ts"],
@@ -17762,7 +17796,7 @@
       "description": "Validate the complete serialized `AppManifest.navigator` slice.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigator.ts",
-        "line": 17,
+        "line": 14,
         "column": 1
       }
     },
@@ -17771,7 +17805,25 @@
       "description": "Validate one nested navigator node independently from app-level authoring metadata.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigator.ts",
-        "line": 30,
+        "line": 27,
+        "column": 1
+      }
+    },
+    {
+      "name": "hasNavigatorPreset",
+      "description": "Check a serialized preset against the public contract without eager cyclic initialization.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 61,
+        "column": 1
+      }
+    },
+    {
+      "name": "hasNavigatorType",
+      "description": "Check a serialized topology against the public contract without eager cyclic initialization.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigator.ts",
+        "line": 66,
         "column": 1
       }
     },
@@ -17780,7 +17832,7 @@
       "description": "Validate one route and preserve its portable metadata and nested navigator.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigator.ts",
-        "line": 64,
+        "line": 71,
         "column": 1
       }
     },
@@ -17789,7 +17841,7 @@
       "description": "Validate Split View screen references without duplicating the routed secondary tree.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigator.ts",
-        "line": 80,
+        "line": 87,
         "column": 1
       }
     },
@@ -17798,7 +17850,7 @@
       "description": "Validate a registered custom navigator with JSON-safe configuration only.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigator.ts",
-        "line": 98,
+        "line": 105,
         "column": 1
       }
     },
@@ -17807,7 +17859,7 @@
       "description": "Validate an acyclic, finite JSON object used by a custom navigator adapter.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigator.ts",
-        "line": 108,
+        "line": 115,
         "column": 1
       }
     },
@@ -17816,7 +17868,7 @@
       "description": "Recursively validate the portable manifest value domain and reject cycles.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigator.ts",
-        "line": 113,
+        "line": 120,
         "column": 1
       }
     },
@@ -17825,7 +17877,7 @@
       "description": "Validate package-owned navigator defaults without requiring a navigator node type.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigator.ts",
-        "line": 138,
+        "line": 145,
         "column": 1
       }
     },
@@ -17834,7 +17886,7 @@
       "description": "Validate per-platform navigator implementation overrides.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigator.ts",
-        "line": 150,
+        "line": 157,
         "column": 1
       }
     },
@@ -17843,7 +17895,7 @@
       "description": "Validate one platform-specific navigator override slice.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigator.ts",
-        "line": 161,
+        "line": 168,
         "column": 1
       }
     },
@@ -17852,7 +17904,7 @@
       "description": "Validate stable native, JavaScript, or alpha Experimental Stack desired state.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 23,
+        "line": 14,
         "column": 1
       }
     },
@@ -17861,7 +17913,7 @@
       "description": "Validate the serializable native-stack screen option subset.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 50,
+        "line": 41,
         "column": 1
       }
     },
@@ -17870,7 +17922,7 @@
       "description": "Validate the finite serializable Drawer option subset.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 79,
+        "line": 71,
         "column": 1
       }
     },
@@ -17879,7 +17931,7 @@
       "description": "Validate tabs implementation desired state, with omitted implementation meaning adaptive.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 94,
+        "line": 86,
         "column": 1
       }
     },
@@ -17888,7 +17940,7 @@
       "description": "Validate a reference into the app-owned screen registry.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 108,
+        "line": 100,
         "column": 1
       }
     },
@@ -17897,7 +17949,7 @@
       "description": "Check that a finite configuration object contains no unsupported keys.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 113,
+        "line": 105,
         "column": 1
       }
     },
@@ -17906,7 +17958,7 @@
       "description": "Validate JavaScript Stack options without accepting native-only presentations.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 122,
+        "line": 114,
         "column": 1
       }
     },
@@ -17915,7 +17967,7 @@
       "description": "Validate the portable header subset supported by Experimental Stack.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 140,
+        "line": 132,
         "column": 1
       }
     },
@@ -17924,7 +17976,7 @@
       "description": "Validate shared stack header field values after branch-specific key filtering.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 149,
+        "line": 141,
         "column": 1
       }
     },
@@ -17933,7 +17985,7 @@
       "description": "Validate sorted, finite native sheet detents or the fit-to-content sentinel.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 159,
+        "line": 151,
         "column": 1
       }
     },
@@ -17942,7 +17994,7 @@
       "description": "Validate an adaptive tabs branch and reject implementation-specific conflicts.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 173,
+        "line": 165,
         "column": 1
       }
     },
@@ -17951,7 +18003,7 @@
       "description": "Validate the top-level native tabs implementation.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 189,
+        "line": 181,
         "column": 1
       }
     },
@@ -17960,7 +18012,7 @@
       "description": "Validate the top-level JavaScript tabs implementation.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 203,
+        "line": 195,
         "column": 1
       }
     },
@@ -17969,7 +18021,7 @@
       "description": "Validate the native branch used by adaptive tabs.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 221,
+        "line": 213,
         "column": 1
       }
     },
@@ -17978,7 +18030,7 @@
       "description": "Validate fields supported by the native tabs branch.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 231,
+        "line": 223,
         "column": 1
       }
     },
@@ -17987,7 +18039,7 @@
       "description": "Validate the implementation-free headless-tabs Web branch inside adaptive tabs.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 241,
+        "line": 233,
         "column": 1
       }
     },
@@ -17996,7 +18048,7 @@
       "description": "Validate headless-tab presentation and its conditional serializable configuration.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 250,
+        "line": 242,
         "column": 1
       }
     },
@@ -18005,7 +18057,16 @@
       "description": "Validate semantic compact/medium/expanded headless-tab presentation mapping.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 275,
+        "line": 267,
+        "column": 1
+      }
+    },
+    {
+      "name": "contains",
+      "description": "Check a string against a public finite contract without eager cyclic initialization.",
+      "sourceLocation": {
+        "filePath": "src/appManifest/navigatorOptions.ts",
+        "line": 282,
         "column": 1
       }
     },
@@ -18014,7 +18075,7 @@
       "description": "Check that mutually exclusive branch fields are absent.",
       "sourceLocation": {
         "filePath": "src/appManifest/navigatorOptions.ts",
-        "line": 290,
+        "line": 287,
         "column": 1
       }
     },
@@ -18262,6 +18323,14 @@
     },
     {
       "kind": "export",
+      "name": "isAppNavigatorManifest",
+      "sourcePath": "src/appManifest/navigator.ts",
+      "symbolName": "isAppNavigatorManifest",
+      "description": "Validate the complete serialized `AppManifest.navigator` slice.",
+      "isReadme": false
+    },
+    {
+      "kind": "export",
       "name": "isMediaAssetReference",
       "sourcePath": "src/media.ts",
       "symbolName": "isMediaAssetReference",
@@ -18474,6 +18543,11 @@
       {
         "fromPath": "src/navigator.ts",
         "toPath": "src/types.ts",
+        "sourcePath": "src/navigator.ts"
+      },
+      {
+        "fromPath": "src/navigator.ts",
+        "toPath": "src/appManifest/navigator.ts",
         "sourcePath": "src/navigator.ts"
       },
       {
@@ -20254,6 +20328,12 @@
       },
       {
         "fromSymbol": "isAppNavigatorManifest",
+        "toSymbol": "hasNavigatorPreset",
+        "callExpression": "hasNavigatorPreset",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isAppNavigatorManifest",
         "toSymbol": "isNavigatorDefaults",
         "callExpression": "isNavigatorDefaults",
         "sourcePath": "src/appManifest/navigator.ts"
@@ -20268,6 +20348,12 @@
         "fromSymbol": "isNavigatorNode",
         "toSymbol": "isRecord",
         "callExpression": "isRecord",
+        "sourcePath": "src/appManifest/navigator.ts"
+      },
+      {
+        "fromSymbol": "isNavigatorNode",
+        "toSymbol": "hasNavigatorType",
+        "callExpression": "hasNavigatorType",
         "sourcePath": "src/appManifest/navigator.ts"
       },
       {
@@ -20500,6 +20586,12 @@
       },
       {
         "fromSymbol": "isStackScreenOptions",
+        "toSymbol": "contains",
+        "callExpression": "contains",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isStackScreenOptions",
         "toSymbol": "isSheetAllowedDetents",
         "callExpression": "isSheetAllowedDetents",
         "sourcePath": "src/appManifest/navigatorOptions.ts"
@@ -20520,6 +20612,12 @@
         "fromSymbol": "isDrawerNavigatorOptions",
         "toSymbol": "hasOnlyKeys",
         "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isDrawerNavigatorOptions",
+        "toSymbol": "contains",
+        "callExpression": "contains",
         "sourcePath": "src/appManifest/navigatorOptions.ts"
       },
       {
@@ -20589,6 +20687,12 @@
         "sourcePath": "src/appManifest/navigatorOptions.ts"
       },
       {
+        "fromSymbol": "isJavaScriptStackScreenOptions",
+        "toSymbol": "contains",
+        "callExpression": "contains",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
         "fromSymbol": "isStackHeaderOptions",
         "toSymbol": "isRecord",
         "callExpression": "isRecord",
@@ -20655,6 +20759,12 @@
         "sourcePath": "src/appManifest/navigatorOptions.ts"
       },
       {
+        "fromSymbol": "isJavaScriptTabsConfig",
+        "toSymbol": "contains",
+        "callExpression": "contains",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
         "fromSymbol": "isNativeTabsConfig",
         "toSymbol": "isRecord",
         "callExpression": "isRecord",
@@ -20670,6 +20780,12 @@
         "fromSymbol": "isNativeTabsConfig",
         "toSymbol": "isNativeTabsFields",
         "callExpression": "isNativeTabsFields",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isNativeTabsFields",
+        "toSymbol": "contains",
+        "callExpression": "contains",
         "sourcePath": "src/appManifest/navigatorOptions.ts"
       },
       {
@@ -20698,6 +20814,12 @@
       },
       {
         "fromSymbol": "isHeadlessTabsPresentationConfig",
+        "toSymbol": "contains",
+        "callExpression": "contains",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isHeadlessTabsPresentationConfig",
         "toSymbol": "isResponsiveTabsPresentation",
         "callExpression": "isResponsiveTabsPresentation",
         "sourcePath": "src/appManifest/navigatorOptions.ts"
@@ -20718,6 +20840,12 @@
         "fromSymbol": "isResponsiveTabsPresentation",
         "toSymbol": "hasOnlyKeys",
         "callExpression": "hasOnlyKeys",
+        "sourcePath": "src/appManifest/navigatorOptions.ts"
+      },
+      {
+        "fromSymbol": "isResponsiveTabsPresentation",
+        "toSymbol": "contains",
+        "callExpression": "contains",
         "sourcePath": "src/appManifest/navigatorOptions.ts"
       },
       {

--- a/src/appManifest/navigator.ts
+++ b/src/appManifest/navigator.ts
@@ -1,4 +1,4 @@
-import { NAVIGATOR_PRESETS, NAVIGATOR_TYPES } from '../navigator';
+import { type AppNavigatorManifest, NAVIGATOR_PRESETS, NAVIGATOR_TYPES } from '../navigator';
 import { isIconSpec } from './icon';
 import {
   hasOnlyKeys,
@@ -10,16 +10,13 @@ import {
 } from './navigatorOptions';
 import { isOptionalBoolean, isOptionalString, isRecord, isStringArray } from './shared';
 
-const NAVIGATOR_PRESET_SET = new Set<string>(NAVIGATOR_PRESETS);
-const NAVIGATOR_TYPE_SET = new Set<string>(NAVIGATOR_TYPES);
-
 /*** Validate the complete serialized `AppManifest.navigator` slice. */
-export function isAppNavigatorManifest(value: unknown): boolean {
+export function isAppNavigatorManifest(value: unknown): value is AppNavigatorManifest {
   return (
     isRecord(value) &&
     isNavigatorNode(value) &&
     (value.preset === undefined ||
-      (typeof value.preset === 'string' && NAVIGATOR_PRESET_SET.has(value.preset))) &&
+      (typeof value.preset === 'string' && hasNavigatorPreset(value.preset))) &&
     value.flows === undefined &&
     (value.defaults === undefined || isNavigatorDefaults(value.defaults)) &&
     (value.platforms === undefined || isNavigatorPlatforms(value.platforms))
@@ -31,7 +28,7 @@ function isNavigatorNode(value: unknown): boolean {
   if (
     !isRecord(value) ||
     typeof value.type !== 'string' ||
-    !NAVIGATOR_TYPE_SET.has(value.type) ||
+    !hasNavigatorType(value.type) ||
     !isOptionalString(value.initialRouteName) ||
     !Array.isArray(value.routes) ||
     !value.routes.every(isRouteDefinition)
@@ -58,6 +55,16 @@ function isNavigatorNode(value: unknown): boolean {
     default:
       return false;
   }
+}
+
+/*** Check a serialized preset against the public contract without eager cyclic initialization. */
+function hasNavigatorPreset(value: string): boolean {
+  return (NAVIGATOR_PRESETS as readonly string[]).includes(value);
+}
+
+/*** Check a serialized topology against the public contract without eager cyclic initialization. */
+function hasNavigatorType(value: string): boolean {
+  return (NAVIGATOR_TYPES as readonly string[]).includes(value);
 }
 
 /*** Validate one route and preserve its portable metadata and nested navigator. */

--- a/src/appManifest/navigatorOptions.ts
+++ b/src/appManifest/navigatorOptions.ts
@@ -10,15 +10,6 @@ import {
 } from '../navigator';
 import { isOptionalBoolean, isOptionalString, isRecord } from './shared';
 
-const HEADLESS_TABS_PRESENTATION_SET = new Set<string>(HEADLESS_TABS_PRESENTATIONS);
-const DRAWER_POSITION_SET = new Set<string>(DRAWER_POSITIONS);
-const DRAWER_TYPE_SET = new Set<string>(DRAWER_TYPES);
-const FIXED_HEADLESS_TABS_PRESENTATION_SET = new Set<string>(FIXED_HEADLESS_TABS_PRESENTATIONS);
-const JAVASCRIPT_STACK_PRESENTATION_SET = new Set<string>(JAVASCRIPT_STACK_PRESENTATIONS);
-const JAVASCRIPT_TABS_PRESENTATION_SET = new Set<string>(JAVASCRIPT_TABS_PRESENTATIONS);
-const NATIVE_TABS_MINIMIZE_BEHAVIOR_SET = new Set<string>(NATIVE_TABS_MINIMIZE_BEHAVIORS);
-const STACK_PRESENTATION_SET = new Set<string>(STACK_PRESENTATIONS);
-
 /*** Validate stable native, JavaScript, or alpha Experimental Stack desired state. */
 export function isStackImplementationConfig(value: Record<string, unknown>): boolean {
   if (
@@ -61,7 +52,8 @@ export function isStackScreenOptions(value: unknown): boolean {
     ]) ||
     !isStackHeaderOptionsShape(value) ||
     (value.presentation !== undefined &&
-      (typeof value.presentation !== 'string' || !STACK_PRESENTATION_SET.has(value.presentation)))
+      (typeof value.presentation !== 'string' ||
+        !contains(STACK_PRESENTATIONS, value.presentation)))
   ) {
     return false;
   }
@@ -82,9 +74,9 @@ export function isDrawerNavigatorOptions(value: unknown): boolean {
     hasOnlyKeys(value, ['drawerPosition', 'drawerType', 'swipeEnabled', 'headerShown']) &&
     (value.drawerPosition === undefined ||
       (typeof value.drawerPosition === 'string' &&
-        DRAWER_POSITION_SET.has(value.drawerPosition))) &&
+        contains(DRAWER_POSITIONS, value.drawerPosition))) &&
     (value.drawerType === undefined ||
-      (typeof value.drawerType === 'string' && DRAWER_TYPE_SET.has(value.drawerType))) &&
+      (typeof value.drawerType === 'string' && contains(DRAWER_TYPES, value.drawerType))) &&
     isOptionalBoolean(value.swipeEnabled) &&
     isOptionalBoolean(value.headerShown)
   );
@@ -132,7 +124,7 @@ function isJavaScriptStackScreenOptions(value: unknown): boolean {
     isStackHeaderOptionsShape(value) &&
     (value.presentation === undefined ||
       (typeof value.presentation === 'string' &&
-        JAVASCRIPT_STACK_PRESENTATION_SET.has(value.presentation)))
+        contains(JAVASCRIPT_STACK_PRESENTATIONS, value.presentation)))
   );
 }
 
@@ -213,7 +205,7 @@ function isJavaScriptTabsConfig(value: Record<string, unknown>): boolean {
     ]) &&
     (value.presentation === undefined ||
       (typeof value.presentation === 'string' &&
-        JAVASCRIPT_TABS_PRESENTATION_SET.has(value.presentation)))
+        contains(JAVASCRIPT_TABS_PRESENTATIONS, value.presentation)))
   );
 }
 
@@ -232,7 +224,7 @@ function isNativeTabsFields(value: Record<string, unknown>): boolean {
   return (
     (value.minimizeBehavior === undefined ||
       (typeof value.minimizeBehavior === 'string' &&
-        NATIVE_TABS_MINIMIZE_BEHAVIOR_SET.has(value.minimizeBehavior))) &&
+        contains(NATIVE_TABS_MINIMIZE_BEHAVIORS, value.minimizeBehavior))) &&
     (value.bottomAccessory === undefined || isNavigatorScreenReference(value.bottomAccessory))
   );
 }
@@ -250,7 +242,7 @@ function isHeadlessTabsWebConfig(value: unknown): boolean {
 function isHeadlessTabsPresentationConfig(value: Record<string, unknown>): boolean {
   if (
     typeof value.presentation !== 'string' ||
-    !HEADLESS_TABS_PRESENTATION_SET.has(value.presentation)
+    !contains(HEADLESS_TABS_PRESENTATIONS, value.presentation)
   ) {
     return false;
   }
@@ -258,7 +250,7 @@ function isHeadlessTabsPresentationConfig(value: Record<string, unknown>): boole
     return false;
   }
   if (!isOptionalString(value.customPresentationId)) return false;
-  if (FIXED_HEADLESS_TABS_PRESENTATION_SET.has(value.presentation)) {
+  if (contains(FIXED_HEADLESS_TABS_PRESENTATIONS, value.presentation)) {
     return value.responsive === undefined && value.customPresentationId === undefined;
   }
   if (value.presentation === 'responsive') {
@@ -277,13 +269,18 @@ function isResponsiveTabsPresentation(value: unknown): boolean {
     isRecord(value) &&
     hasOnlyKeys(value, ['compact', 'medium', 'expanded']) &&
     typeof value.compact === 'string' &&
-    FIXED_HEADLESS_TABS_PRESENTATION_SET.has(value.compact) &&
+    contains(FIXED_HEADLESS_TABS_PRESENTATIONS, value.compact) &&
     (value.medium === undefined ||
       (typeof value.medium === 'string' &&
-        FIXED_HEADLESS_TABS_PRESENTATION_SET.has(value.medium))) &&
+        contains(FIXED_HEADLESS_TABS_PRESENTATIONS, value.medium))) &&
     typeof value.expanded === 'string' &&
-    FIXED_HEADLESS_TABS_PRESENTATION_SET.has(value.expanded)
+    contains(FIXED_HEADLESS_TABS_PRESENTATIONS, value.expanded)
   );
+}
+
+/*** Check a string against a public finite contract without eager cyclic initialization. */
+function contains(values: readonly string[], value: string): boolean {
+  return values.includes(value);
 }
 
 /*** Check that mutually exclusive branch fields are absent. */

--- a/src/navigator.test.ts
+++ b/src/navigator.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from 'bun:test';
 
-import { isAppNavigatorManifest } from './appManifest/screens';
 import {
   type AppNavigatorManifest,
+  isAppNavigatorManifest,
   NAVIGATOR_PRESETS,
   NAVIGATOR_TYPES,
   type NavigatorNode,
   type StackImplementationConfig,
   type TabsNavigatorConfig,
 } from './navigator';
+
+function parseNavigator(value: unknown): AppNavigatorManifest {
+  if (!isAppNavigatorManifest(value)) throw new Error('Expected a navigator manifest.');
+  return value;
+}
 
 function createAdaptiveTabs(): AppNavigatorManifest {
   return {
@@ -80,6 +85,12 @@ const VALID_NAVIGATOR_NODES = [
     routes: [],
   },
 ] as const satisfies readonly NavigatorNode[];
+
+it('narrows unknown input through the public navigator boundary', () => {
+  const manifest = parseNavigator({ type: 'drawer', routes: [] });
+
+  expect(manifest.type).toBe('drawer');
+});
 
 describe('app navigator manifest topology', () => {
   it('keeps canonical topology presets finite and authorable', () => {

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -1,5 +1,7 @@
 import type { IconSpec, ManifestValue } from './types';
 
+export { isAppNavigatorManifest } from './appManifest/navigator';
+
 export const NAVIGATOR_TYPES = ['slot', 'stack', 'tabs', 'drawer', 'split-view', 'custom'] as const;
 export type NavigatorType = (typeof NAVIGATOR_TYPES)[number];
 


### PR DESCRIPTION
## Summary

- export the standalone `isAppNavigatorManifest` type guard from `@ankhorage/contracts/navigator`
- narrow successful unknown input to the canonical `AppNavigatorManifest` type
- make finite navigator-value checks lazy so the new public runtime export remains ESM-cycle safe
- regenerate public API documentation and add a patch changeset

## Architecture

Contracts remains the sole owner of structural navigator parsing. Navigator can consume only the focused navigator subpath and does not need the complete `AppManifest` or a duplicated validator.

## Verification

- `bun test src` — 134 passed
- focused navigator tests — 20 passed
- `bun run typecheck`
- `bun run build`
- `bun run lint`
- `bun run knip:check`
- `bun run docs`
- `bun run changeset:status`
- `bun run format:check`

Closes #198.
Unblocks [ankhorage/navigator#79](https://github.com/ankhorage/navigator/issues/79).