### PR TITLE
fix: use media references for splash screen assets

### DIFF
--- a/.changeset/fair-splashes-reference-media.md
+++ b/.changeset/fair-splashes-reference-media.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/contracts': major
+---
+
+Replace raw splash-screen image paths with stable media asset references so generated hosts can resolve the current bundled asset location.

--- a/src/appManifest.test.ts
+++ b/src/appManifest.test.ts
@@ -22,7 +22,7 @@ function createManifest(): Record<string, unknown> {
     activeThemeId: 'default',
     activeThemeMode: 'light',
     splashScreen: {
-      image: './assets/splash.png',
+      image: { mediaId: 'hero' },
       resizeMode: 'contain',
       backgroundColor: '#ffffff',
       dark: { backgroundColor: '#000000' },
@@ -150,6 +150,14 @@ describe('AppManifest runtime parsing', () => {
 
     expect(isAppManifest(manifest)).toBe(true);
     expect(parseAppManifest(manifest)).toEqual({ ok: true, manifest });
+  });
+
+  it('rejects raw splash screen image paths', () => {
+    const manifest = createManifest();
+    const splashScreen = manifest.splashScreen as Record<string, unknown>;
+    splashScreen.image = './assets/splash.png';
+
+    expect(isAppManifest(manifest)).toBe(false);
   });
 
   it('accepts an optional GitHub repository configuration', () => {

--- a/src/appManifest/screens.ts
+++ b/src/appManifest/screens.ts
@@ -1,5 +1,6 @@
 import { COLOR_HARMONIES } from '@ankhorage/color-theory';
 
+import { isMediaAssetReference } from '../media';
 import { APP_CATEGORIES } from '../types';
 import { isBindingValueSource, isScreenDataLoaderDefinition } from './bindings';
 import { isOptionalNumber, isOptionalString, isRecord } from './shared';
@@ -103,7 +104,7 @@ function isScreenSpec(value: unknown): boolean {
 function isSplashScreenModeSpec(value: unknown): boolean {
   return (
     isRecord(value) &&
-    isOptionalString(value.image) &&
+    (value.image === undefined || isMediaAssetReference(value.image)) &&
     isOptionalNumber(value.imageWidth) &&
     (value.resizeMode === undefined ||
       (typeof value.resizeMode === 'string' &&

--- a/src/contracts.test.ts
+++ b/src/contracts.test.ts
@@ -199,12 +199,12 @@ describe('contracts', () => {
   it('accepts serializable splash screen branding on app manifests', () => {
     const splashScreen: SplashScreenSpec = {
       backgroundColor: '#ffffff',
-      image: './assets/splash/icon.png',
+      image: { mediaId: 'splash-logo' },
       imageWidth: 160,
       resizeMode: 'contain',
       dark: {
         backgroundColor: '#000000',
-        image: './assets/splash/icon-dark.png',
+        image: { mediaId: 'splash-logo-dark' },
         imageWidth: 160,
         resizeMode: 'contain',
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -271,7 +271,7 @@ export interface ScreenSpec {
 export type SplashScreenResizeMode = 'contain' | 'cover' | 'native';
 
 export interface SplashScreenAssetSpec {
-  readonly image?: string;
+  readonly image?: MediaAssetReference;
   readonly imageWidth?: number;
   readonly resizeMode?: SplashScreenResizeMode;
 }


### PR DESCRIPTION
## Summary

- replace raw `SplashScreenSpec.image` filesystem strings with canonical `MediaAssetReference` values
- validate splash artwork through the existing media-reference contract
- reject legacy raw splash image paths at the `AppManifest` runtime boundary
- update contract serialization coverage for light and dark splash artwork
- add a major changeset because this intentionally removes the raw-path contract

## Architecture

The portable app manifest no longer owns a generated filesystem path for splash artwork. It references `AppManifest.media.assets` by `mediaId`; the generated host can then resolve the asset's current source/path at the Expo projection boundary.

This keeps one source of truth and avoids compatibility aliases or parallel raw-path/reference forms.

## Release impact

This is a breaking Contracts change and must be released before downstream Templates and Studio consumers migrate. No unreleased package version is introduced here.

## Validation

The change updates the existing compile-time serialization test and runtime AppManifest parser fixture, and adds explicit coverage that a raw `image: './assets/...'` value is rejected.

Work was performed through the GitHub connector, so repository-local Bun validation was not executed from this chat. GitHub CI is the authoritative validation for this PR; generated Paradox documentation was intentionally not hand-edited.

## Tracking

Part of ankhorage/studio#492. The umbrella issue remains open until the downstream Templates and Studio PRs are merged and native splash generation is accepted.