### PR TITLE
chore: use package metadata for Paradox docs

### DIFF
--- a/.changeset/use-package-metadata-for-docs.md
+++ b/.changeset/use-package-metadata-for-docs.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/contracts": patch
+---
+
+Use package metadata as the default Paradox documentation title and description.

--- a/.changeset/use-package-metadata-for-docs.md
+++ b/.changeset/use-package-metadata-for-docs.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/contracts": patch
+'@ankhorage/contracts': patch
 ---
 
 Use package metadata as the default Paradox documentation title and description.

--- a/paradox.config.ts
+++ b/paradox.config.ts
@@ -3,10 +3,6 @@ import { defineParadoxConfig } from '@ankhorage/paradox';
 export default defineParadoxConfig({
   mode: 'write',
 
-  docs: {
-    title: 'CONTRACTS',
-  },
-
   package: {
     root: '.',
     entrypoints: ['src/index.ts'],


### PR DESCRIPTION
## Summary
- remove redundant `docs.title` from the Paradox config
- rely on Paradox defaults backed by `package.json` `name` and `description`
- keep all unrelated Paradox configuration unchanged

## Architecture
No public API or package-boundary change. This removes duplicated package metadata from documentation configuration.

## Validation
- reviewed the branch diff against `main`
- added the required patch changeset and triggered fresh CI
- local Bun validation is unavailable through the GitHub connector

## Changeset
Patch changeset for `@ankhorage/contracts`.

## Documentation
Generated README/Paradox artifacts were not hand-edited. The docs workflow is responsible for detecting whether regeneration is required.

## Linked issue
None; direct cross-repository maintenance request.